### PR TITLE
comment-out the travis builds checking numpy versions other than 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,13 @@ matrix:
           env: SETUP_CMD='test'
 
         # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+        # currently these are commented out because the conda copy of astropy is only up-to-date for numpy 1.9
+        #- python: 2.7
+        #  env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+        #- python: 2.7
+        #  env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+        #- python: 2.7
+        #  env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
 before_install:
 


### PR DESCRIPTION
This closes #21 by just not running the numpy builds for versions < 1.9. Hopefully the travis tests will start passing once this is in.

This is probably best considered a work-around, because there are some subtle bugs that can creep in if you don't test older versions of numpy.  Unless of course you don't mind just requiring numpy 1.9 (or at least saying "untested/not guaranteed for older versions) - then there's no need to test them at all.

cc @aphearin