### PR TITLE
galaxy_table now is deleted upon HodMockFactory call to allocate_memory

### DIFF
--- a/halotools/empirical_models/mock_factories.py
+++ b/halotools/empirical_models/mock_factories.py
@@ -360,6 +360,9 @@ class HodMockFactory(MockFactory):
         ``_occupation`` and ``_gal_type_indices``. 
 
         """
+
+        self.galaxy_table = Table() 
+
         self._occupation = {}
         self._total_abundance = {}
         self._gal_type_indices = {}


### PR DESCRIPTION
This is needed so that the populate() method can be called repeatedly within the same python session. 