### PR TITLE
work around for igraph package naming issue.

### DIFF
--- a/halotools/mock_observables/groups.py
+++ b/halotools/mock_observables/groups.py
@@ -16,6 +16,10 @@ try: import igraph
 except ImportError:
     igraph_available=False
     print("igraph package not installed.  Some functions will not be available.")
+if igraph_available==True: #there is another package called igraph--need to distinguish.
+    if not hasattr(igraph,'Graph'):
+        igraph_available==False
+        print("igraph package is not installed.  Some functions will not be available.")
 ##########################################################################################
 
 __all__=['FoFgroups']


### PR DESCRIPTION
added a kind of ugly work-around to deal with the issue that there are two packages called igraph.  I am not sure how we want to deal with this in the long run.

@aphearin do you want to see if this solves your problem?