### PR TITLE
Added h5py to rtd-pip-requirements

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -4,3 +4,4 @@ Cython
 astropy-helpers
 astropy
 scipy
+h5py


### PR DESCRIPTION
Hopefully this will fix the current RTD docs build problem. 