### PR TITLE
Removed h5py from module-wide imports and docs build

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -4,4 +4,3 @@ Cython
 astropy-helpers
 astropy
 scipy
-h5py

--- a/halotools/sim_manager/catalog_manager.py
+++ b/halotools/sim_manager/catalog_manager.py
@@ -22,7 +22,6 @@ except ImportError:
 import posixpath
 import urlparse
 
-import h5py
 import datetime 
 
 from ..utils.array_utils import find_idx_nearest_val
@@ -1070,6 +1069,7 @@ class CatalogManager(object):
         halo_table.write(output_fname, path='data', overwrite = overwrite, append = overwrite)
 
         ### Add metadata to the hdf5 file
+        import h5py
         f = h5py.File(output_fname)
 
         time_right_now = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -18,8 +18,6 @@ except ImportError:
 import posixpath
 import urlparse
 
-import h5py
-
 from . import sim_defaults, catalog_manager
 
 from ..utils.array_utils import find_idx_nearest_val
@@ -329,6 +327,7 @@ class HaloCatalog(object):
             "and the %s inferred from its filename.\n"
             "This indicates a bug during the generation of the hdf5 file storing the catalog.")
 
+        import h5py
         f = h5py.File(fname)
         if abs(float(f.attrs['redshift']) - closest_redshift) > 0.01:
             raise HalotoolsIOError(msg % ('redshift', 'redshift'))


### PR DESCRIPTION
For some reason, RTD was having problems building h5py, so I just hid h5py from the docs build as a workaround. 