### PR TITLE
Merged hod designer branch 

### DIFF
--- a/halotools/empirical_models/__init__.py
+++ b/halotools/empirical_models/__init__.py
@@ -19,3 +19,4 @@ from .sfr_components import *
 from .abunmatch import *
 from .model_helpers import *
 from .assembias import *
+from .hod_designer import *

--- a/halotools/empirical_models/assembias.py
+++ b/halotools/empirical_models/assembias.py
@@ -323,10 +323,14 @@ class HeavisideAssembias(object):
                 no_edge_percentiles = halo_table[self.sec_haloprop_key + '_percentile'][no_edge_mask]
                 type1_mask = no_edge_percentiles >= no_edge_split
             else:
-                msg = ("Computing ``%s`` quantity from scratch - \n"
-                    "Method is much faster if this quantity is pre-computed")
+                msg = ("\nThe HeavisideAssembias class implements assembly bias \n" 
+                    "by altering the behavior of the model according to the value of " 
+                    "``%s``.\n This quantity can be pre-computed using the "
+                    "new_haloprop_func_dict mechanism, making your mock population run faster.\n"
+                    "See the MockFactory documentation for detailed instructions.\n "
+                    "Now computing %s from scratch.\n")
                 key = self.sec_haloprop_key + '_percentile'
-                warn(msg % key)
+                warn(msg % (key, key))
 
                 percentiles = compute_conditional_percentiles(
                     halo_table = halo_table, 

--- a/halotools/empirical_models/halo_prof_components.py
+++ b/halotools/empirical_models/halo_prof_components.py
@@ -29,7 +29,7 @@ from ..sim_manager import sim_defaults
 ##################################################################################
 
 @six.add_metaclass(ABCMeta)
-class HaloProfileModel(object):
+class HaloProfileModel(model_helpers.GalPropModel):
     """ Container class for any halo profile model. 
 
     This is an abstract class, and cannot itself be instantiated. 
@@ -64,6 +64,7 @@ class HaloProfileModel(object):
             Default is None. 
 
         """
+        super(HaloProfileModel, self).__init__(galprop_key='occupation')
 
         self.halo_boundary = halo_boundary
         self.prim_haloprop_key = prim_haloprop_key

--- a/halotools/empirical_models/hod_designer.py
+++ b/halotools/empirical_models/hod_designer.py
@@ -6,6 +6,34 @@ for building a new galaxy-halo model by swapping out features
 from an existing model. 
 """
 
+from ..halotools_exceptions import HalotoolsError
+
+class HodModelArchitect(object):
+
+	def __init__(self):
+		pass
+
+	@staticmethod
+	def customize_model(*args, **kwargs):
+
+		try:
+			baseline_model = kwargs['baseline_model']
+		except KeyError:
+			msg = ("\nThe customize_model method of HodModelArchitect "
+				"requires a baseline_model keyword argument\n")
+			raise HalotoolsError(msg)
+		baseline_blueprint = baseline_model.model_blueprint
+
+		for component in args:
+			try:
+				gal_type = component.gal_type
+			except AttributeError:
+			msg = ("\nEvery argument of the customize_model method of HodModelArchitect "
+				"must be a model instance that has a ``gal_type`` attribute.\n")
+				raise HalotoolsError(msg)
+			
+
+
 
 
 

--- a/halotools/empirical_models/hod_designer.py
+++ b/halotools/empirical_models/hod_designer.py
@@ -9,6 +9,8 @@ from copy import copy
 from ..halotools_exceptions import HalotoolsError
 from .model_factories import HodModelFactory 
 
+__all__ = ['HodModelArchitect']
+
 
 class HodModelArchitect(object):
     """ Class used to create customized HOD-style models.  

--- a/halotools/empirical_models/hod_designer.py
+++ b/halotools/empirical_models/hod_designer.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """
-
 This module provides a convenient interface 
 for building a new galaxy-halo model by swapping out features 
 from an existing model. 
@@ -12,6 +11,8 @@ from .model_factories import HodModelFactory
 
 
 class HodModelArchitect(object):
+    """ Class used to create customized HOD-style models.  
+    """
 
     def __init__(self):
         pass

--- a/halotools/empirical_models/hod_designer.py
+++ b/halotools/empirical_models/hod_designer.py
@@ -10,28 +10,28 @@ from ..halotools_exceptions import HalotoolsError
 
 class HodModelArchitect(object):
 
-	def __init__(self):
-		pass
+    def __init__(self):
+        pass
 
-	@staticmethod
-	def customize_model(*args, **kwargs):
+    @staticmethod
+    def customize_model(*args, **kwargs):
 
-		try:
-			baseline_model = kwargs['baseline_model']
-		except KeyError:
-			msg = ("\nThe customize_model method of HodModelArchitect "
-				"requires a baseline_model keyword argument\n")
-			raise HalotoolsError(msg)
-		baseline_blueprint = baseline_model.model_blueprint
+        try:
+            baseline_model = kwargs['baseline_model']
+        except KeyError:
+            msg = ("\nThe customize_model method of HodModelArchitect "
+                "requires a baseline_model keyword argument\n")
+            raise HalotoolsError(msg)
+        baseline_blueprint = baseline_model.model_blueprint
 
-		for component in args:
-			try:
-				gal_type = component.gal_type
-			except AttributeError:
-			msg = ("\nEvery argument of the customize_model method of HodModelArchitect "
-				"must be a model instance that has a ``gal_type`` attribute.\n")
-				raise HalotoolsError(msg)
-			
+        for component in args:
+            try:
+                gal_type = component.gal_type
+            except AttributeError:
+                msg = ("\nEvery argument of the customize_model method of HodModelArchitect "
+                    "must be a model instance that has a ``gal_type`` attribute.\n")
+                raise HalotoolsError(msg)
+
 
 
 

--- a/halotools/empirical_models/hod_designer.py
+++ b/halotools/empirical_models/hod_designer.py
@@ -6,7 +6,10 @@ for building a new galaxy-halo model by swapping out features
 from an existing model. 
 """
 
+from copy import copy 
 from ..halotools_exceptions import HalotoolsError
+from .model_factories import HodModelFactory 
+
 
 class HodModelArchitect(object):
 
@@ -23,14 +26,21 @@ class HodModelArchitect(object):
                 "requires a baseline_model keyword argument\n")
             raise HalotoolsError(msg)
         baseline_blueprint = baseline_model.model_blueprint
+        new_blueprint = copy(baseline_blueprint)
 
         for component in args:
             try:
                 gal_type = component.gal_type
+                galprop_key = component.galprop_key
             except AttributeError:
                 msg = ("\nEvery argument of the customize_model method of HodModelArchitect "
-                    "must be a model instance that has a ``gal_type`` attribute.\n")
+                    "must be a model instance that has a ``gal_type`` and a ``galprop_key`` attribute.\n")
                 raise HalotoolsError(msg)
+            new_blueprint[gal_type][galprop_key] = component
+        new_model = HodModelFactory(new_blueprint)
+
+        return new_model
+
 
 
 

--- a/halotools/empirical_models/hod_designer.py
+++ b/halotools/empirical_models/hod_designer.py
@@ -18,6 +18,26 @@ class HodModelArchitect(object):
 
     @staticmethod
     def customize_model(*args, **kwargs):
+        """ Method takes a baseline composite model as input, 
+        together with an arbitrary number of new component models, 
+        and swaps in the new component models to create a and return new composite model. 
+
+        Parameters 
+        ----------
+        baseline_model : HOD model instance 
+            `~halotools.empirical_models.HodModelFactory` instance. 
+
+        component_models : Halotools objects 
+            Instance of any component model that you want to swap in to the baseline_model. 
+
+        Returns 
+        --------
+        new_model : HOD model instance  
+            `~halotools.empirical_models.HodModelFactory` instance. The ``new_model`` will 
+            be identical in every way to the ``baseline_model``, except the features in the 
+            input component_models will replace the features in the ``baseline_model``. 
+
+        """
 
         try:
             baseline_model = kwargs['baseline_model']

--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -406,7 +406,6 @@ class HodModelFactory(ModelFactory):
         for gal_type in self.gal_types:
             input_prof_model = model_blueprint[gal_type]['profile']
             if input_prof_model.__class__ != gal_prof_factory.IsotropicGalProf:
-                #print("%s gal_type is an instance of a HaloProfileModel" % gal_type)
                 prof_model = gal_prof_factory.IsotropicGalProf(
                     gal_type=gal_type, halo_prof_model=input_prof_model.__class__)
                 model_blueprint[gal_type]['profile'] = prof_model

--- a/halotools/empirical_models/model_helpers.py
+++ b/halotools/empirical_models/model_helpers.py
@@ -27,14 +27,14 @@ from abc import ABCMeta
 class GalPropModel(object):
     """ Abstact container class for any model of any galaxy property. 
     """
-
     def __init__(self, galprop_key):
+        self.galprop_key = galprop_key
 
-        # Enforce the requirement that sub-classes have been configured properly
-        required_method_name = 'mc_'+galprop_key
-        if not hasattr(self, required_method_name):
-            raise SyntaxError("Any sub-class of GalPropModel must "
-                "implement a method named %s " % required_method_name)
+        # # Enforce the requirement that sub-classes have been configured properly
+        # required_method_name = 'mc_'+galprop_key
+        # if not hasattr(self, required_method_name):
+        #     raise SyntaxError("Any sub-class of GalPropModel must "
+        #         "implement a method named %s " % required_method_name)
 
 
 def solve_for_polynomial_coefficients(abcissa, ordinates):


### PR DESCRIPTION
Only change needed to get this finally integrated was to have halo profile models sub-class GalPropModels, and to remove the needless restriction that component models have a mc_galprop_key method. Now GalPropModels only bind the galprop_key, that's it. 