### PR TITLE
Mockobs wrappers

### DIFF
--- a/docs/mock_observations/mock_observables_api.rst
+++ b/docs/mock_observations/mock_observables_api.rst
@@ -1,0 +1,7 @@
+.. _mock_observations_api:
+
+*****************************************************
+Reference/API for `halotools.mock_observables`
+*****************************************************
+
+.. automodapi:: halotools.mock_observables

--- a/docs/mock_observations/overview.rst
+++ b/docs/mock_observations/overview.rst
@@ -5,5 +5,10 @@
 Overview of Mock Observations
 ****************************************
 
+Using ``mock_observables``
+============================================
 
-Coming soon!
+.. toctree::
+   :maxdepth: 1
+
+   mock_observables_api.rst

--- a/halotools/empirical_models/mock_factories.py
+++ b/halotools/empirical_models/mock_factories.py
@@ -251,8 +251,15 @@ class MockFactory(object):
         >>> r, quiescent_clustering, q_sf_cross_clustering, star_forming_clustering = mock.compute_galaxy_clustering(quiescent = True, include_crosscorr = True) # doctest: +SKIP
 
         Finally, suppose we wish to ask a very targeted question about how some physical effect 
-        impacts the clustering of galaxies in a specific halo mass range. For this we can use the 
-        more flexible mask option to select our population:
+        impacts the clustering of galaxies in a specific halo mass range. 
+        For example, suppose we wish to study the two-point function of satellite galaxies 
+        residing in cluster-mass halos. For this we can use the more flexible mask_function 
+        option to select our population:
+
+        >>> def my_masking_function(table): # doctest: +SKIP
+        >>>     result = (table['halo_mvir'] > 1e14) & (table['gal_type'] == 'satellites') # doctest: +SKIP
+        >>>     return result # doctest: +SKIP
+        >>> r, cluster_sat_clustering = mock.compute_galaxy_clustering(mask_function = my_masking_function) # doctest: +SKIP
 
         Notes 
         -----
@@ -361,8 +368,16 @@ class MockFactory(object):
         >>> r, quiescent_matter_clustering, star_forming_matter_clustering = mock.compute_galaxy_matter_cross_clustering(quiescent = True, include_complement = True) # doctest: +SKIP
 
         Finally, suppose we wish to ask a very targeted question about how some physical effect 
-        impacts the clustering of galaxies in a specific halo mass range. For this we can use the 
-        more flexible mask_function option to select our population:
+        impacts the clustering of galaxies in a specific halo mass range. 
+        For example, suppose we wish to study the galaxy-matter cross-correlation function of satellite galaxies 
+        residing in cluster-mass halos. For this we can use the more flexible mask_function 
+        option to select our population:
+
+        >>> def my_masking_function(table): # doctest: +SKIP
+        >>>     result = (table['halo_mvir'] > 1e14) & (table['gal_type'] == 'satellites') # doctest: +SKIP
+        >>>     return result # doctest: +SKIP
+        >>> r, cluster_sat_clustering = mock.compute_galaxy_matter_cross_clustering(mask_function = my_masking_function) # doctest: +SKIP
+
 
         Notes 
         -----

--- a/halotools/empirical_models/mock_factories.py
+++ b/halotools/empirical_models/mock_factories.py
@@ -207,9 +207,9 @@ class MockFactory(object):
             and the the auto-correlation of the complementary subsample, in that order. 
             See examples below. 
 
-        mask : array, optional 
-            Numpy array serving as a mask to select a specific sub-population. Equivalent to 
-            the ``variable_galaxy_mask`` option, but more flexible since an input ``mask`` 
+        mask_function : array, optional 
+            Function object returning a masking array when operating on the galaxy_table. 
+            More flexible than the simpler ``variable_galaxy_mask`` option because ``mask_function``
             allows for the possibility of multiple simultaneous cuts. See examples below. 
 
         rbins : array, optional 
@@ -253,9 +253,6 @@ class MockFactory(object):
         Finally, suppose we wish to ask a very targeted question about how some physical effect 
         impacts the clustering of galaxies in a specific halo mass range. For this we can use the 
         more flexible mask option to select our population:
-
-        >>> cluster_satellite_mask = (mock.galaxy_table['halo_mvir'] > 1e14) & (mock.galaxy_table['galaxy_type'] == 'satellite') # doctest: +SKIP
-        >>> r, cluster_sat_clustering = mock.compute_galaxy_clustering(mask = cluster_satellite_mask) # doctest: +SKIP
 
         Notes 
         -----
@@ -322,9 +319,9 @@ class MockFactory(object):
             method will also return the cross-correlation between the dark matter particles 
             and the complementary subsample. See examples below. 
 
-        mask : array, optional 
-            Numpy array serving as a mask to select a specific sub-population. Equivalent to 
-            the ``variable_galaxy_mask`` option, but more flexible since an input ``mask`` 
+        mask_function : array, optional 
+            Function object returning a masking array when operating on the galaxy_table. 
+            More flexible than the simpler ``variable_galaxy_mask`` option because ``mask_function``
             allows for the possibility of multiple simultaneous cuts. See examples below. 
 
         rbins : array, optional 
@@ -365,10 +362,7 @@ class MockFactory(object):
 
         Finally, suppose we wish to ask a very targeted question about how some physical effect 
         impacts the clustering of galaxies in a specific halo mass range. For this we can use the 
-        more flexible mask option to select our population:
-
-        >>> cluster_satellite_mask = (mock.galaxy_table['halo_mvir'] > 1e14) & (mock.galaxy_table['galaxy_type'] == 'satellite') # doctest: +SKIP
-        >>> r, cluster_sat_clustering = mock.compute_galaxy_matter_cross_clustering(mask = cluster_satellite_mask) # doctest: +SKIP
+        more flexible mask_function option to select our population:
 
         Notes 
         -----

--- a/halotools/empirical_models/mock_helpers.py
+++ b/halotools/empirical_models/mock_helpers.py
@@ -6,41 +6,69 @@ used to provide convenience wrappers for mock objects
 """
 
 import numpy as np 
+from ..halotools_exceptions import HalotoolsError
 
 def three_dim_pos_bundle(table, key1, key2, key3, 
-	return_complement=False, **kwargs):
-	""" 
-	Method returns 3d positions of particles in 
-	the standard form of the inputs used by many of the 
-	functions in the `~halotools.mock_observables`. 
+    return_complement=False, **kwargs):
+    """ 
+    Method returns 3d positions of particles in 
+    the standard form of the inputs used by many of the 
+    functions in the `~halotools.mock_observables`. 
 
-	Parameters 
-	----------
-	table : data table 
-		`~astropy.table.Table` object 
+    Parameters 
+    ----------
+    table : data table 
+        `~astropy.table.Table` object 
 
-	key1, key2, key3: strings 
-		Keys used to access the relevant columns of the data table. 
+    key1, key2, key3: strings 
+        Keys used to access the relevant columns of the data table. 
 
-	mask : array, optional 
-		array used to apply a mask over the input ``table``. Default is None. 
+    mask : array, optional 
+        array used to apply a mask over the input ``table``. Default is None. 
 
-	return_complement : bool, optional 
-		If set to True, method will also return the table subset given by the inverse mask. 
-		Default is False. 
+    return_complement : bool, optional 
+        If set to True, method will also return the table subset given by the inverse mask. 
+        Default is False. 
 
-	"""
-	if 'mask' in kwargs.keys():
-		mask = kwargs['mask']
-		x, y, z = table[key1][mask], table[key2][mask], table[key3][mask]
-		if return_complement is True:
-			x2, y2, z2 = table[key1][np.invert(mask)], table[key2][np.invert(mask)], table[key3][np.invert(mask)]
-			return np.vstack((x, y, z)).T, np.vstack((x2, y2, z2)).T
-		else:
-			return np.vstack((x, y, z)).T 
-	else:
-		x, y, z = table[key1], table[key2], table[key3]
-		return np.vstack((x, y, z)).T
+    """
+    if 'mask' in kwargs.keys():
+        mask = kwargs['mask']
+        x, y, z = table[key1][mask], table[key2][mask], table[key3][mask]
+        if return_complement is True:
+            x2, y2, z2 = table[key1][np.invert(mask)], table[key2][np.invert(mask)], table[key3][np.invert(mask)]
+            return np.vstack((x, y, z)).T, np.vstack((x2, y2, z2)).T
+        else:
+            return np.vstack((x, y, z)).T 
+    else:
+        x, y, z = table[key1], table[key2], table[key3]
+        return np.vstack((x, y, z)).T
+
+
+def infer_mask_from_kwargs(table, **kwargs):
+    """
+    """
+    if 'mask' in kwargs:
+        mask = kwargs['mask']
+    else:
+        galaxy_table_keyset = set(galaxy_table.keys())
+        kwargs_set = set(kwargs.keys())
+        masking_keys = list(galaxy_table.intersection(kwargs_set))
+        if len(masking_keys) == 0:
+            mask = np.ones(len(galaxy_table), dtype=bool)
+        elif len(masking_keys) == 1:
+            key = masking_keys[0]
+            mask = galaxy_table[key] == kwargs[key]
+        else:
+            # We were passed too many keywords - raise an exception
+            msg = ("Only a single mask at a time is permitted by calls to "
+                "compute_galaxy_clustering. \nChoose only one of the following keyword arguments:\n")
+            arglist = ''
+            for arg in masking_keys:
+                arglist = arglist + arg + ', '
+            arglist = arglist[:-2]
+            msg = msg + arglist
+            raise HalotoolsError(msg)
+    return mask
 
 
 

--- a/halotools/empirical_models/mock_helpers.py
+++ b/halotools/empirical_models/mock_helpers.py
@@ -7,6 +7,7 @@ used to provide convenience wrappers for mock objects
 
 import numpy as np 
 from ..halotools_exceptions import HalotoolsError
+from warnings import warn
 
 def three_dim_pos_bundle(table, key1, key2, key3, 
     return_complement=False, **kwargs):
@@ -44,15 +45,16 @@ def three_dim_pos_bundle(table, key1, key2, key3,
         return np.vstack((x, y, z)).T
 
 
-def infer_mask_from_kwargs(table, **kwargs):
+def infer_mask_from_kwargs(galaxy_table, **kwargs):
     """
     """
-    if 'mask' in kwargs:
-        mask = kwargs['mask']
+    if 'mask_function' in kwargs:
+        func = kwargs['mask_function']
+        mask = func(galaxy_table)
     else:
         galaxy_table_keyset = set(galaxy_table.keys())
         kwargs_set = set(kwargs.keys())
-        masking_keys = list(galaxy_table.intersection(kwargs_set))
+        masking_keys = list(galaxy_table_keyset.intersection(kwargs_set))
         if len(masking_keys) == 0:
             mask = np.ones(len(galaxy_table), dtype=bool)
         elif len(masking_keys) == 1:

--- a/halotools/empirical_models/model_defaults.py
+++ b/halotools/empirical_models/model_defaults.py
@@ -105,6 +105,8 @@ halo_boundary = 'halo_rvir'
 default_rbins = np.logspace(-1, 1.35, 10)
 default_nptcls = 1e5
 
+default_b_perp = 0.2
+default_b_para = 0.75
 
 
 

--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -183,7 +183,7 @@ class ModelFactory(object):
         else:
             rbins = model_defaults.default_rbins
 
-        if 'include_crosscorr' in kwargs:
+        if 'include_crosscorr' in kwargs.keys():
             include_crosscorr = kwargs['include_crosscorr']
         else:
             include_crosscorr = False
@@ -191,7 +191,7 @@ class ModelFactory(object):
         if include_crosscorr is True:
 
             xi_coll = np.zeros(
-                len(rbins)*num_iterations*3).reshape(3, num_iterations, len(rbins))
+                (len(rbins)-1)*num_iterations*3).reshape(3, num_iterations, len(rbins)-1)
 
             for i in range(num_iterations):
                 self.populate_mock(snapshot = snapshot)
@@ -205,7 +205,7 @@ class ModelFactory(object):
         else:
 
             xi_coll = np.zeros(
-                len(rbins)*num_iterations).reshape(num_iterations, len(rbins))
+                (len(rbins)-1)*num_iterations).reshape(num_iterations, len(rbins)-1)
 
             for i in range(num_iterations):
                 self.populate_mock(snapshot = snapshot)

--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -183,7 +183,12 @@ class ModelFactory(object):
         else:
             rbins = model_defaults.default_rbins
 
-        if ('include_crosscorr' in kwargs) & (kwargs['include_crosscorr'] == True):
+        if 'include_crosscorr' in kwargs:
+            include_crosscorr = kwargs['include_crosscorr']
+        else:
+            include_crosscorr = False
+
+        if include_crosscorr is True:
 
             xi_coll = np.zeros(
                 len(rbins)*num_iterations*3).reshape(3, num_iterations, len(rbins))

--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -136,11 +136,6 @@ class ModelFactory(object):
             and the the auto-correlation of the complementary subsample, in that order. 
             See examples below. 
 
-        mask : array, optional 
-            Numpy array serving as a mask to select a specific sub-population. Equivalent to 
-            the ``variable_galaxy_mask`` option, but more flexible since an input ``mask`` 
-            allows for the possibility of multiple simultaneous cuts. See examples below. 
-
         rbins : array, optional 
             Bins in which the correlation function will be calculated. 
             Default is set in `~halotools.empirical_models.model_defaults` module. 

--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -164,6 +164,47 @@ class ModelFactory(object):
             and the the auto-correlation of the complementary subsample, in that order. 
             See the example below. 
 
+        Examples 
+        ---------
+        The simplest use-case of the `compute_galaxy_clustering` function 
+        is just to call the function with no arguments. This will generate a sequence 
+        of Monte Carlo realizations of your model into the default snapshot, 
+        calculate the two-point correlation function of all galaxies in your mock, 
+        and return the median clustering strength in each radial bin: 
+
+        >>> model = Leauthaud11() # doctest: +SKIP 
+        >>> r, clustering = model.compute_galaxy_clustering() # doctest: +SKIP 
+
+        To control how which simulation is used, you use the same syntax you use to load 
+        a `~halotools.sim_manager.HaloCatalog` into memory from your cache directory: 
+
+        >>> r, clustering = model.compute_galaxy_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
+
+        You can control the number of mock catalogs that are generated via: 
+
+        >>> r, clustering = model.compute_galaxy_clustering(num_iterations = 10) # doctest: +SKIP 
+
+        You may wish to focus on the clustering signal for a specific subpopulation. To do this, 
+        you have two options. First, you can use the ``variable_galaxy_mask`` mechanism: 
+
+        >>> r, clustering = model.compute_galaxy_clustering(gal_type = 'centrals') # doctest: +SKIP 
+
+        With the ``variable_galaxy_mask`` mechanism, you are free to use any column of your galaxy_table 
+        as a keyword argument. If you couple this function call with the ``include_crosscorr`` 
+        keyword argument, the function will also return all auto- and cross-correlations of the subset 
+        and its complement:
+
+        >>> r, cen_cen, cen_sat, sat_sat = model.compute_galaxy_clustering(gal_type = 'centrals', include_crosscorr = True) # doctest: +SKIP 
+
+        Your second option is to use the ``mask_function`` option. 
+        For example, suppose we wish to study the clustering of satellite galaxies 
+        residing in cluster-mass halos:
+
+        >>> def my_masking_function(table): # doctest: +SKIP
+        >>>     result = (table['halo_mvir'] > 1e14) & (table['gal_type'] == 'satellites') # doctest: +SKIP
+        >>>     return result # doctest: +SKIP
+        >>> r, cluster_sat_clustering = model.compute_galaxy_clustering(mask_function = my_masking_function) # doctest: +SKIP 
+
         Notes 
         -----
         The `compute_galaxy_clustering` method bound to mock instances is just a convenience wrapper 
@@ -270,6 +311,47 @@ class ModelFactory(object):
             Bins in which the correlation function will be calculated. 
             Default is set in `~halotools.empirical_models.model_defaults` module. 
 
+        Examples 
+        ---------
+        The simplest use-case of the `compute_galaxy_matter_cross_clustering` function 
+        is just to call the function with no arguments. This will generate a sequence 
+        of Monte Carlo realizations of your model into the default snapshot, 
+        calculate the cross-correlation function between dark matter 
+        and all galaxies in your mock, and return the median 
+        clustering strength in each radial bin: 
+
+        >>> model = Leauthaud11() # doctest: +SKIP 
+        >>> r, clustering = model.compute_galaxy_matter_cross_clustering() # doctest: +SKIP 
+
+        To control how which simulation is used, you use the same syntax you use to load 
+        a `~halotools.sim_manager.HaloCatalog` into memory from your cache directory: 
+
+        >>> r, clustering = model.compute_galaxy_matter_cross_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
+
+        You can control the number of mock catalogs that are generated via: 
+
+        >>> r, clustering = model.compute_galaxy_matter_cross_clustering(num_iterations = 10) # doctest: +SKIP 
+
+        You may wish to focus on the clustering signal for a specific subpopulation. To do this, 
+        you have two options. First, you can use the ``variable_galaxy_mask`` mechanism: 
+
+        >>> r, clustering = model.compute_galaxy_matter_cross_clustering(gal_type = 'centrals') # doctest: +SKIP 
+
+        With the ``variable_galaxy_mask`` mechanism, you are free to use any column of your galaxy_table 
+        as a keyword argument. If you couple this function call with the ``include_complement`` 
+        keyword argument, the function will also return the correlation function of the complementary subset. 
+
+        >>> r, cen_clustering, sat_clustering = model.compute_galaxy_matter_cross_clustering(gal_type = 'centrals', include_complement = True) # doctest: +SKIP 
+
+        Your second option is to use the ``mask_function`` option. 
+        For example, suppose we wish to study the galaxy-matter cross-correlation function of satellite galaxies 
+        residing in cluster-mass halos:
+
+        >>> def my_masking_function(table): # doctest: +SKIP
+        >>>     result = (table['halo_mvir'] > 1e14) & (table['gal_type'] == 'satellites') # doctest: +SKIP
+        >>>     return result # doctest: +SKIP
+        >>> r, cluster_sat_clustering = model.compute_galaxy_matter_cross_clustering(mask_function = my_masking_function) # doctest: +SKIP 
+
         Returns 
         --------
         rbin_centers : array 
@@ -322,7 +404,7 @@ class ModelFactory(object):
             for i in range(num_iterations):
                 self.populate_mock(snapshot = snapshot)
                 rbin_centers, xi_coll[0, i, :], xi_coll[1, i, :] = (
-                    self.mock.compute_galaxy_clustering(**kwargs)
+                    self.mock.compute_galaxy_matter_cross_clustering(**kwargs)
                     )
             xi_11 = summary_func(xi_coll[0, :], axis=0)
             xi_22 = summary_func(xi_coll[1, :], axis=0)
@@ -334,7 +416,7 @@ class ModelFactory(object):
 
             for i in range(num_iterations):
                 self.populate_mock(snapshot = snapshot)
-                rbin_centers, xi_coll[i, :] = self.mock.compute_galaxy_clustering(**kwargs)
+                rbin_centers, xi_coll[i, :] = self.mock.compute_galaxy_matter_cross_clustering(**kwargs)
             xi = summary_func(xi_coll, axis=0)
             return rbin_centers, xi
 

--- a/halotools/mock_observables/clustering.py
+++ b/halotools/mock_observables/clustering.py
@@ -156,9 +156,13 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,\
                       do_RR, do_DR):
         """
         Count random pairs.  There are three high level branches: 
+
             1. no PBCs w/ randoms.
+
             2. PBCs w/ randoms
+
             3. PBCs and analytical randoms
+
         There are also logical bits to do RR and DR pair counts, as not all estimators 
         need one or the other, and not doing these can save a lot of calculation.
         """
@@ -749,7 +753,7 @@ def redshift_space_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,\
                         period=None, do_auto=True, do_cross=True, estimator='Natural',\
                         N_threads=1, max_sample_size=int(1e6)):
     """ 
-    Calculate the redshift space correlation function, :math:`\\xi(r_p, \\pi)`.
+    Calculate the redshift space correlation function, :math:`\\xi(r_{p}, \\pi)`.
     
     The first two dimensions define the plane for perpendicular distances.  The third 
     dimension is used for parallel distances.  i.e. x,y positions are on the plane of the
@@ -800,17 +804,17 @@ def redshift_space_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,\
     Returns 
     -------
     correlation_function : array_like
-        ndarray containing correlation function :math:`\\xi(r_p, \\pi)` computed in each 
+        ndarray containing correlation function :math:`\\xi(r_{p}, \\pi)` computed in each 
         of the len(rp_bins)-1 X len(pi_bins)-1 bins defined by input `rp_bins` and 
         `pi_bins`.
 
-        :math:`1 + \\xi(r_p,\\pi) \equiv DD / RR`, is the 'Natural' estimator is used, 
+        :math:`1 + \\xi(r_{p},\\pi) = DD / RR`, is the 'Natural' estimator is used, 
         where `DD` is calculated by the pair counter, and `RR` is counted internally 
         analytic `randoms` if no randoms are passed as an argument.
 
         If sample2 is passed as input, three ndarrays of shape 
         (len(rp_bins)-1,len(pi_bins)-1) are returned: 
-        :math:`\\xi_{11}(rp, \\pi)`, `\\xi_{12}(r_p,\\pi)`, `\\xi_{22}(r_p,\\pi)`
+        :math:`\\xi_{11}(rp, \\pi)`, `\\xi_{12}(r_{p},\\pi)`, `\\xi_{22}(r_{p},\\pi)`
         and the associated covariance matrices.
         The autocorrelation of sample1, the cross-correlation between sample1 and sample2,
         and the autocorrelation of sample2.  If do_auto or do_cross is set to False, the 
@@ -904,9 +908,13 @@ def redshift_space_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,\
                       PBCs, k, N_threads, do_RR, do_DR):
         """
         Count random pairs.  There are three high level branches: 
+
             1. no PBCs w/ randoms.
+
             2. PBCs w/ randoms
+            
             3. PBCs and analytical randoms
+
         There are also logical bits to do RR and DR pair counts, as not all estimators 
         need one or the other, and not doing these can save a lot of calculation.
         """
@@ -1091,7 +1099,7 @@ def wp(sample1, rp_bins, pi_bins, sample2=None, randoms=None, period=None,\
        do_auto=True, do_cross=True, estimator='Natural', N_threads=1,\
        max_sample_size=int(1e6)):
     """ 
-    Calculate the projected correlation function, :math:`\\w_p`.
+    Calculate the projected correlation function, :math:`w_{p}`.
     
     The first two dimensions define the plane for perpendicular distances.  The third 
     dimension is used for parallel distances.  i.e. x,y positions are on the plane of the
@@ -1141,15 +1149,15 @@ def wp(sample1, rp_bins, pi_bins, sample2=None, randoms=None, period=None,\
     Returns 
     -------
     correlation_function : array_like
-        array containing correlation function :math:`\\w_p` computed in each of the Nrbins 
+        array containing correlation function :math:`w_{p}` computed in each of the Nrbins 
         defined by input `rp_bins`.
 
-        :math:`1 + \\w_p(r) \equiv DD / RR`, 
+        :math:`1 + w_p(r) \equiv DD / RR`, 
         where `DD` is calculated by the pair counter, and `RR` is counted internally 
         using analytic `randoms` if no randoms are passed as an argument.
 
         If sample2 is passed as input, three arrays of length len(rbins)-1 are returned: 
-        :math:`\\w_{p11}(r)`, `\\w_{p12}(r)`, `\\w_{p22}(r)`
+        :math:`w_{p11}(r)`, `w_{p12}(r)`, `w_{p22}(r)`
         The autocorrelation of sample1, the cross-correlation between sample1 and sample2,
         and the autocorrelation of sample2.  If do_auto or do_cross is set to False, the 
         appropriate result is not returned.
@@ -1353,9 +1361,13 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,\
                       PBCs, k, N_threads, do_RR, do_DR):
         """
         Count random pairs.  There are three high level branches: 
+
             1. no PBCs w/ randoms.
+
             2. PBCs w/ randoms
+
             3. PBCs and analytical randoms
+
         There are also logical bits to do RR and DR pair counts, as not all estimators 
         need one or the other, and not doing these can save a lot of calculation.
         """
@@ -1364,7 +1376,7 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,\
             Calculate the volume of a spherical sector, used for the analytical randoms.
             https://en.wikipedia.org/wiki/Spherical_sector
             
-            #note that the extra *2 is to get the reflection.
+            note that the extra *2 is to get the reflection.
             """
             theta = np.arcsin(mu)
             return (2.0*np.pi/3.0) * np.outer((s**3.0),(1.0-np.cos(theta)))*2

--- a/halotools/sim_manager/cache_config.py
+++ b/halotools/sim_manager/cache_config.py
@@ -23,7 +23,10 @@ def simname_is_supported(simname):
 
     Parameters 
     ----------
-    simname : string 
+    simname : string, optional keyword argument 
+        Nickname of the simulation. Currently supported simulations are 
+        Bolshoi  (simname = ``bolshoi``), Consuelo (simname = ``consuelo``), 
+        MultiDark (simname = ``multidark``), and Bolshoi-Planck (simname = ``bolplanck``). 
 
     Returns 
     -------

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -221,7 +221,8 @@ class HaloCatalog(object):
 
     def __init__(self, simname=sim_defaults.default_simname, 
         halo_finder=sim_defaults.default_halo_finder, 
-        desired_redshift = sim_defaults.default_redshift, dz_tol = 0.05, **kwargs):
+        desired_redshift = sim_defaults.default_redshift, dz_tol = 0.05, 
+        preload_halo_table = False, **kwargs):
         """
         Parameters 
         ----------
@@ -242,6 +243,10 @@ class HaloCatalog(object):
         dz_tol : float, optional
             Tolerance value determining how close the requested redshift must be to 
             some available snapshot before issuing a warning. Default value is 0.05. 
+
+        preload_halo_table : bool, optional 
+            If True, the `HaloCatalog` class will automatically retrieve the halo 
+            table from disk upon instantiation. Default is False. 
 
         Examples 
         ---------
@@ -300,6 +305,10 @@ class HaloCatalog(object):
             self.dtype_ascii, self.header_ascii = sim_defaults.return_dtype_and_header(
                 self.simname, self.halo_finder)
             self._check_catalog_self_consistency(fname, closest_redshift)
+
+        if preload_halo_table is True:
+            self._halo_table = Table.read(self.processed_halo_table_fname, path='data')
+
 
     @property 
     def halo_table(self):


### PR DESCRIPTION
Branch introduces several convenience functions for mock and model objects. There are now compute_galaxy_clustering and compute_galaxy_matter_cross_clustering methods bound to both mock and composite model objects. The latter generates a sequence of mocks, computes the signal in each one, and returns the median in each bin. Mock objects also now have a compute_groupids method. All of these functions are simple wrapper behaviors for the relevant mock_observables functions. This branch also introduces mock_observables documentation that builds, and a skeleton organization for documenting this sub-package. 