### PR TITLE
Hearin15 model no longer raises needless warning. 

### DIFF
--- a/halotools/empirical_models/preloaded_hod_blueprints.py
+++ b/halotools/empirical_models/preloaded_hod_blueprints.py
@@ -213,6 +213,10 @@ def Hearin15_blueprint(central_assembias_strength = 1,
             assembias_strength = satellite_assembias_strength, 
             assembias_abcissa = satellite_assembias_strength_abcissa, 
             **kwargs)
+        # There is no need for a redundant new_haloprop_func_dict 
+        # if this is already possessed by the central model
+        if hasattr(cen_ab_component, 'new_haloprop_func_dict'):
+            del sat_ab_component.new_haloprop_func_dict
 
     sat_model_dict = {}
     sat_model_dict['occupation'] = sat_ab_component


### PR DESCRIPTION
Deleted new_haloprop_func_dict from satellite model during creation of Hearin15 blueprint for cases where the central model already has the dict. Resolves #135