### PR TITLE
Fixed bug in compute_clustering convenience function

### DIFF
--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -267,7 +267,16 @@ class ModelFactory(object):
         else:
             summary_func = np.median
 
-        snapshot = HaloCatalog(preload_halo_table = True, **kwargs)
+
+        halocat_kwargs = {}
+        if 'simname' in kwargs:
+            halocat_kwargs['simname'] = kwargs['simname']
+        if 'desired_redshift' in kwargs:
+            halocat_kwargs['redshift'] = kwargs['desired_redshift']
+        if 'halo_finder' in kwargs:
+            halocat_kwargs['halo_finder'] = kwargs['halo_finder']
+
+        snapshot = HaloCatalog(preload_halo_table = True, **halocat_kwargs)
 
         if 'rbins' in kwargs:
             rbins = kwargs['rbins']
@@ -434,7 +443,15 @@ class ModelFactory(object):
         else:
             summary_func = np.median
 
-        snapshot = HaloCatalog(preload_halo_table = True, **kwargs)
+        halocat_kwargs = {}
+        if 'simname' in kwargs:
+            halocat_kwargs['simname'] = kwargs['simname']
+        if 'desired_redshift' in kwargs:
+            halocat_kwargs['redshift'] = kwargs['desired_redshift']
+        if 'halo_finder' in kwargs:
+            halocat_kwargs['halo_finder'] = kwargs['halo_finder']
+
+        snapshot = HaloCatalog(preload_halo_table = True, **halocat_kwargs)
 
         if 'rbins' in kwargs:
             rbins = kwargs['rbins']


### PR DESCRIPTION
The problem was that HaloCatalog does not accept **kwargs, but **kwargs was being passed on from the compute_galaxy_clustering and compute_galaxy_matter_cross_clustering methods to HaloCatalog. As introduced in 78816235053ffcb5bb1ffb0130def27b890faa50 , HaloCatalog does not accept **kwargs to protect against the bug pointed out in #132 . So the solution was simply to create a new function keyword argument dictionary within the namespace of compute_galaxy_clustering and compute_galaxy_matter_cross_clustering.