### PR TITLE
fixed bug in satellite position assignment

### DIFF
--- a/halotools/empirical_models/mock_factories.py
+++ b/halotools/empirical_models/mock_factories.py
@@ -577,6 +577,10 @@ class HodMockFactory(MockFactory):
                 self.galaxy_table[halocatkey][gal_type_slice] = np.repeat(
                     self.halo_table[halocatkey], self._occupation[gal_type], axis=0)
 
+        self.galaxy_table['x'] = self.galaxy_table['halo_x']
+        self.galaxy_table['y'] = self.galaxy_table['halo_y']
+        self.galaxy_table['z'] = self.galaxy_table['halo_z']
+
         for method in self._remaining_methods_to_call:
             func = getattr(self.model, method)
             gal_type_slice = self._gal_type_indices[func.gal_type]


### PR DESCRIPTION
PR resolves #164 

The source of the problem was really simple. When the monte carlo position assignment method `mc_pos` in the monte_carlo_phase_space module accepts a halo_table argument, this method assumes that the 'x', 'y', and 'z' keys have already been set to the halo-centric positions 'halo_x', 'halo_y', and 'halo_z'. However, the mock factory overhaul was not implementing this, and the 'x', 'y', and 'z'  columns were all just zero when this function was called within the populate_mock method. 

