### PR TITLE
Mock convenience bug fixes

### DIFF
--- a/halotools/empirical_models/mock_factories.py
+++ b/halotools/empirical_models/mock_factories.py
@@ -451,7 +451,7 @@ class MockFactory(object):
     def satellite_fraction(self):
         """ Fraction of mock galaxies that are satellites. 
         """
-        satmask = self.galaxy_table['gal_type'] == 'satellites'
+        satmask = self.galaxy_table['gal_type'] != 'centrals'
         return len(self.galaxy_table[satmask]) / float(len(self.galaxy_table))
 
 class HodMockFactory(MockFactory):

--- a/halotools/empirical_models/model_factories.py
+++ b/halotools/empirical_models/model_factories.py
@@ -139,7 +139,7 @@ class ModelFactory(object):
 
         self.mock.populate()
 
-    def compute_galaxy_clustering(self, num_iterations=5, summary_statistic = 'median', **kwargs):
+    def compute_average_galaxy_clustering(self, num_iterations=5, summary_statistic = 'median', **kwargs):
         """
         Method repeatedly populates a simulation with a mock galaxy catalog, computes the clustering 
         signal of each Monte Carlo realization, and returns a summary statistic of the clustering 
@@ -216,35 +216,35 @@ class ModelFactory(object):
 
         Examples 
         ---------
-        The simplest use-case of the `compute_galaxy_clustering` function 
+        The simplest use-case of the `compute_average_galaxy_clustering` function 
         is just to call the function with no arguments. This will generate a sequence 
         of Monte Carlo realizations of your model into the default snapshot, 
         calculate the two-point correlation function of all galaxies in your mock, 
         and return the median clustering strength in each radial bin: 
 
         >>> model = Leauthaud11() # doctest: +SKIP 
-        >>> r, clustering = model.compute_galaxy_clustering() # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_clustering() # doctest: +SKIP 
 
         To control how which simulation is used, you use the same syntax you use to load 
         a `~halotools.sim_manager.HaloCatalog` into memory from your cache directory: 
 
-        >>> r, clustering = model.compute_galaxy_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
 
         You can control the number of mock catalogs that are generated via: 
 
-        >>> r, clustering = model.compute_galaxy_clustering(num_iterations = 10) # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_clustering(num_iterations = 10) # doctest: +SKIP 
 
         You may wish to focus on the clustering signal for a specific subpopulation. To do this, 
         you have two options. First, you can use the ``variable_galaxy_mask`` mechanism: 
 
-        >>> r, clustering = model.compute_galaxy_clustering(gal_type = 'centrals') # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_clustering(gal_type = 'centrals') # doctest: +SKIP 
 
         With the ``variable_galaxy_mask`` mechanism, you are free to use any column of your galaxy_table 
         as a keyword argument. If you couple this function call with the ``include_crosscorr`` 
         keyword argument, the function will also return all auto- and cross-correlations of the subset 
         and its complement:
 
-        >>> r, cen_cen, cen_sat, sat_sat = model.compute_galaxy_clustering(gal_type = 'centrals', include_crosscorr = True) # doctest: +SKIP 
+        >>> r, cen_cen, cen_sat, sat_sat = model.compute_average_galaxy_clustering(gal_type = 'centrals', include_crosscorr = True) # doctest: +SKIP 
 
         Your second option is to use the ``mask_function`` option. 
         For example, suppose we wish to study the clustering of satellite galaxies 
@@ -253,11 +253,11 @@ class ModelFactory(object):
         >>> def my_masking_function(table): # doctest: +SKIP
         >>>     result = (table['halo_mvir'] > 1e14) & (table['gal_type'] == 'satellites') # doctest: +SKIP
         >>>     return result # doctest: +SKIP
-        >>> r, cluster_sat_clustering = model.compute_galaxy_clustering(mask_function = my_masking_function) # doctest: +SKIP 
+        >>> r, cluster_sat_clustering = model.compute_average_galaxy_clustering(mask_function = my_masking_function) # doctest: +SKIP 
 
         Notes 
         -----
-        The `compute_galaxy_clustering` method bound to mock instances is just a convenience wrapper 
+        The `compute_average_galaxy_clustering` method bound to mock instances is just a convenience wrapper 
         around the `~halotools.mock_observables.clustering.tpcf` function. If you wish for greater 
         control over how your galaxy clustering signal is estimated, 
         see the `~halotools.mock_observables.clustering.tpcf` documentation. 
@@ -313,7 +313,7 @@ class ModelFactory(object):
             xi = summary_func(xi_coll, axis=0)
             return rbin_centers, xi
 
-    def compute_galaxy_matter_cross_clustering(self, num_iterations=5, 
+    def compute_average_galaxy_matter_cross_clustering(self, num_iterations=5, 
         summary_statistic = 'median', **kwargs):
         """
         Method repeatedly populates a simulation with a mock galaxy catalog, 
@@ -372,7 +372,7 @@ class ModelFactory(object):
 
         Examples 
         ---------
-        The simplest use-case of the `compute_galaxy_matter_cross_clustering` function 
+        The simplest use-case of the `compute_average_galaxy_matter_cross_clustering` function 
         is just to call the function with no arguments. This will generate a sequence 
         of Monte Carlo realizations of your model into the default snapshot, 
         calculate the cross-correlation function between dark matter 
@@ -380,27 +380,27 @@ class ModelFactory(object):
         clustering strength in each radial bin: 
 
         >>> model = Leauthaud11() # doctest: +SKIP 
-        >>> r, clustering = model.compute_galaxy_matter_cross_clustering() # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_matter_cross_clustering() # doctest: +SKIP 
 
         To control how which simulation is used, you use the same syntax you use to load 
         a `~halotools.sim_manager.HaloCatalog` into memory from your cache directory: 
 
-        >>> r, clustering = model.compute_galaxy_matter_cross_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_matter_cross_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
 
         You can control the number of mock catalogs that are generated via: 
 
-        >>> r, clustering = model.compute_galaxy_matter_cross_clustering(num_iterations = 10) # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_matter_cross_clustering(num_iterations = 10) # doctest: +SKIP 
 
         You may wish to focus on the clustering signal for a specific subpopulation. To do this, 
         you have two options. First, you can use the ``variable_galaxy_mask`` mechanism: 
 
-        >>> r, clustering = model.compute_galaxy_matter_cross_clustering(gal_type = 'centrals') # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_matter_cross_clustering(gal_type = 'centrals') # doctest: +SKIP 
 
         With the ``variable_galaxy_mask`` mechanism, you are free to use any column of your galaxy_table 
         as a keyword argument. If you couple this function call with the ``include_complement`` 
         keyword argument, the function will also return the correlation function of the complementary subset. 
 
-        >>> r, cen_clustering, sat_clustering = model.compute_galaxy_matter_cross_clustering(gal_type = 'centrals', include_complement = True) # doctest: +SKIP 
+        >>> r, cen_clustering, sat_clustering = model.compute_average_galaxy_matter_cross_clustering(gal_type = 'centrals', include_complement = True) # doctest: +SKIP 
 
         Your second option is to use the ``mask_function`` option. 
         For example, suppose we wish to study the galaxy-matter cross-correlation function of satellite galaxies 
@@ -409,7 +409,7 @@ class ModelFactory(object):
         >>> def my_masking_function(table): # doctest: +SKIP
         >>>     result = (table['halo_mvir'] > 1e14) & (table['gal_type'] == 'satellites') # doctest: +SKIP
         >>>     return result # doctest: +SKIP
-        >>> r, cluster_sat_clustering = model.compute_galaxy_matter_cross_clustering(mask_function = my_masking_function) # doctest: +SKIP 
+        >>> r, cluster_sat_clustering = model.compute_average_galaxy_matter_cross_clustering(mask_function = my_masking_function) # doctest: +SKIP 
 
         Returns 
         --------
@@ -432,7 +432,7 @@ class ModelFactory(object):
 
         Notes 
         -----
-        The `compute_galaxy_matter_cross_clustering` method bound to 
+        The `compute_average_galaxy_matter_cross_clustering` method bound to 
         mock instances is just a convenience wrapper 
         around the `~halotools.mock_observables.clustering.tpcf` function. If you wish for greater 
         control over how your galaxy clustering signal is estimated, 


### PR DESCRIPTION
* Fixed satellite_fraction method to properly deal with multiple, independently-defined satellite populations. 
* Renamed model.compute_galaxy_clustering method to model.compute_average_galaxy_clustering, resolving #168 . 