### PR TITLE
Rewrite of the pair-counting engine

### DIFF
--- a/halotools/mock_observables/double_tree_clustering.py
+++ b/halotools/mock_observables/double_tree_clustering.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+
+"""
+functions to calculate clustering statistics, e.g. two point correlation functions.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+####import modules########################################################################
+import sys
+import numpy as np
+from math import pi, gamma
+
+from .pair_counters.rect_cuboid_pairs import npairs
+##########################################################################################
+
+
+__all__=['tpcf']
+__author__ = ['Duncan Campbell']
+
+
+np.seterr(divide='ignore', invalid='ignore') #ignore divide by zero in e.g. DD/RR
+
+
+def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,\
+         do_auto=True, do_cross=True, estimator='Natural', N_threads=1,\
+         max_sample_size=int(1e6)):
+    """ 
+    Calculate the real space two-point correlation function, :math:`\\xi(r)`.
+    
+    Parameters 
+    ----------
+    sample1 : array_like
+        Npts x 3 numpy array containing 3-D positions of points.
+    
+    rbins : array_like
+        array of boundaries defining the real space radial bins in which pairs are 
+        counted.
+    
+    sample2 : array_like, optional
+        Npts x 3 array containing 3-D positions of points.
+    
+    randoms : array_like, optional
+        Npts x 3 array containing 3-D positions of points.  If no randoms are provided
+        analytic randoms are used (only valid for periodic boundary conditions).
+    
+    period : array_like, optional
+        length 3 array defining axis-aligned periodic boundary conditions. If only
+        one number, Lbox, is specified, period is assumed to be np.array([Lbox]*3).
+        If none, PBCs are set to infinity.
+    
+    do_auto : boolean, optional
+        do auto-correlation?
+    
+    do_cross : boolean, optional
+        do cross-correlation?
+    
+    estimator : string, optional
+        options: 'Natural', 'Davis-Peebles', 'Hewett' , 'Hamilton', 'Landy-Szalay'
+    
+    N_threads : int, optional
+        number of threads to use in calculation. Default is 1. A string 'max' may be used
+        to indicate that the pair counters should use all available cores on the machine.
+    
+    max_sample_size : int, optional
+        Defines maximum size of the sample that will be passed to the pair counter. 
+        
+        If sample size exeeds max_sample_size, the sample will be randomly down-sampled
+        such that the subsample is equal to max_sample_size. 
+    
+    Returns 
+    -------
+    correlation_function : numpy.array
+        len(`rbins`)-1 length array containing the correlation function :math:`\\xi(r)` 
+        computed in each of the bins defined by input `rbins`.
+        
+        :math:`1 + \\xi(r) \\equiv \\mathrm{DD} / \\mathrm{RR}`, if the 'Natural' 
+        `estimator` is used, where  :math:`\\mathrm{DD}` is calculated by the pair 
+        counter, and :math:`\\mathrm{RR}` is counted internally using 'analytic randoms' 
+        if no `randoms` are passed as an argument (see notes for an explanation).
+        
+        If `sample2` is passed as input, three arrays of length len(`rbins`)-1 are 
+        returned: :math:`\\xi_{11}(r)`, :math:`\\xi_{12}(r)`, :math:`\\xi_{22}(r)`,
+        the autocorrelation of sample1, the cross-correlation between `sample1` and 
+        `sample2`, and the autocorrelation of `sample2`.  If `do_auto` or `do_cross` is 
+        set to False, the appropriate result(s) is not returned.
+
+    Notes
+    -----
+    Pairs are counted using the pair_counters.rect_cuboid_pairs module.  This pair 
+    counter is optimized to work on points distributed in a rectangular cuboid volume, 
+    e.g. a simulation box.  This optimization restricts this function to work on 3-D 
+    point distributions.
+    
+    If the points are distributed in a 'periodic box', then `randoms` are not necessary, 
+    as the geometry is very simple, and the monte carlo integration that randoms are used 
+    for in complex geometries can be done analytically.
+    
+    If the `period` argument is passed, points may not have any component of their 
+    coordinates be negative.
+    """
+    
+    estimators = _list_estimators()
+    
+    #process input parameters
+    sample1 = np.asarray(sample1)
+    if sample2 is not None: 
+        sample2 = np.asarray(sample2)
+        if np.all(sample1==sample2):
+            do_cross==False
+            print("Warning: sample1 and sample2 are exactly the same, only the\
+                   auto-correlation will be returned.")
+    else: sample2 = sample1
+    if randoms is not None: randoms = np.asarray(randoms)
+    rbins = np.asarray(rbins)
+    
+    #Process period entry and check for consistency.
+    if period is None:
+            PBCs = False
+            period = np.array([np.inf]*np.shape(sample1)[-1])
+    else:
+        PBCs = True
+        period = np.asarray(period).astype("float64")
+        if np.shape(period) == ():
+            period = np.array([period]*np.shape(sample1)[-1])
+        elif np.shape(period)[0] != np.shape(sample1)[-1]:
+            raise ValueError("period should have shape (k,)")
+            return None
+    
+    #down sample if sample size exceeds max_sample_size.
+    if (len(sample1)>max_sample_size) & (np.all(sample1==sample2)):
+        inds = np.arange(0,len(sample1))
+        np.random.shuffle(inds)
+        inds = inds[0:max_sample_size]
+        sample1 = sample1[inds]
+        sample2 = sample2[inds]
+        print('downsampling sample1...')
+    if len(sample2)>max_sample_size:
+        inds = np.arange(0,len(sample2))
+        np.random.shuffle(inds)
+        inds = inds[0:max_sample_size]
+        sample2 = sample2[inds]
+        print('down sampling sample2...')
+    if len(sample1)>max_sample_size:
+        inds = np.arange(0,len(sample1))
+        np.random.shuffle(inds)
+        inds = inds[0:max_sample_size]
+        sample1 = sample1[inds]
+        print('down sampling sample1...')
+    
+    #check radial bins
+    if np.shape(rbins) == ():
+        rbins = np.array([rbins])
+    if rbins.ndim != 1:
+        raise ValueError('rbins must be a 1-D array')
+    if len(rbins)<2:
+        raise ValueError('rbins must be of lenght >=2.')
+    
+    #check dimensionality of data. currently, points must be 3D.
+    k = np.shape(sample1)[-1]
+    if k!=3:
+        raise ValueError('data must be 3-dimensional.')
+    
+    #check for input parameter consistency
+    if (period is not None) & (np.max(rbins)>np.min(period)/2.0):
+        raise ValueError('cannot calculate for seperations larger than Lbox/2.')
+    if (sample2 is not None) & (sample1.shape[-1]!=sample2.shape[-1]):
+        raise ValueError('sample1 and sample2 must have same dimension.')
+    if (randoms is None) & (min(period)==np.inf):
+        raise ValueError('if no PBCs are specified, randoms must be provided.')
+    if estimator not in estimators: 
+        raise ValueError('user must specify a supported estimator. Supported estimators \
+        are:{0}'.value(estimators))
+    if (PBCs==True) & (max(period)==np.inf):
+        raise ValueError('if a non-infinte PBC specified, all PBCs must be non-infinte.')
+    if (type(do_auto) is not bool) | (type(do_cross) is not bool):
+        raise ValueError('do_auto and do_cross keywords must be of type boolean.')
+
+    def random_counts(sample1, sample2, randoms, rbins, period, PBCs, k, N_threads,\
+                      do_RR, do_DR):
+        """
+        Count random pairs.  There are three high level branches: 
+
+            1. no PBCs w/ randoms.
+
+            2. PBCs w/ randoms
+
+            3. PBCs and analytical randoms
+
+        There are also logical bits to do RR and DR pair counts, as not all estimators 
+        need one or the other, and not doing these can save a lot of calculation.
+        
+        If no randoms are passes, calculate analytical randoms; otherwise, do it the old 
+        fashioned way.
+        """
+        def nball_volume(R,k):
+            """
+            Calculate the volume of a n-shpere.  This is used for the analytical randoms.
+            """
+            return (np.pi**(k/2.0)/gamma(k/2.0+1.0))*R**k
+        
+        #No PBCs, randoms must have been provided.
+        if PBCs==False:
+            RR = npairs(randoms, randoms, rbins, period=period, N_threads=N_threads)
+            RR = np.diff(RR)
+            D1R = npairs(sample1, randoms, rbins, period=period, N_threads=N_threads)
+            D1R = np.diff(D1R)
+            if np.all(sample1 == sample2): #calculating the cross-correlation
+                D2R = None
+            else:
+                D2R = npairs(sample2, randoms, rbins, period=period, N_threads=N_threads)
+                D2R = np.diff(D2R)
+            
+            return D1R, D2R, RR
+        #PBCs and randoms.
+        elif randoms is not None:
+            if do_RR==True:
+                RR = npairs(randoms, randoms, rbins, period=period, N_threads=N_threads)
+                RR = np.diff(RR)
+            else: RR=None
+            if do_DR==True:
+                D1R = npairs(sample1, randoms, rbins, period=period, N_threads=N_threads)
+                D1R = np.diff(D1R)
+            else: D1R=None
+            if np.all(sample1 == sample2): #calculating the cross-correlation
+                D2R = None
+            else:
+                if do_DR==True:
+                    D2R = npairs(sample2, randoms, rbins, period=period,\
+                                 N_threads=N_threads)
+                    D2R = np.diff(D2R)
+                else: D2R=None
+            
+            return D1R, D2R, RR
+        #PBCs and no randoms--calculate randoms analytically.
+        elif randoms is None:
+            #do volume calculations
+            dv = nball_volume(rbins,k) #volume of spheres
+            dv = np.diff(dv) #volume of shells
+            global_volume = period.prod() #sexy
+            
+            #calculate randoms for sample1
+            N1 = np.shape(sample1)[0]
+            rho1 = N1/global_volume
+            D1R = (N1)*(dv*rho1) #read note about pair counter
+            
+            #if not calculating cross-correlation, set RR exactly equal to D1R.
+            if np.all(sample1 == sample2):
+                D2R = None
+                RR = D1R #in the analytic case, for the auto-correlation, DR==RR.
+            else: #if there is a sample2, calculate randoms for it.
+                N2 = np.shape(sample2)[0]
+                rho2 = N2/global_volume
+                D2R = N2*(dv*rho2) #read note about pair counter
+                #calculate the random-random pairs.
+                #RR is only the RR for the cross-correlation when using analytical randoms
+                #for the non-cross case, DR==RR (in analytical world).
+                NR = N1*N2
+                rhor = NR/global_volume
+                RR = (dv*rhor)
+
+            return D1R, D2R, RR
+        else:
+            raise ValueError('Un-supported combination of PBCs and randoms provided.')
+    
+    def pair_counts(sample1, sample2, rbins, period, N_thread, do_auto, do_cross, do_DD):
+        """
+        Count data pairs.
+        """
+        if do_auto==True:
+            D1D1 = npairs(sample1, sample1, rbins, period=period, N_threads=N_threads)
+            D1D1 = np.diff(D1D1)
+        else:
+            D1D1=None
+            D2D2=None
+        
+        if np.all(sample1 == sample2):
+            D1D2 = D1D1
+            D2D2 = D1D1
+        else:
+            if do_cross==True:
+                D1D2 = npairs(sample1, sample2, rbins, period=period, N_threads=N_threads)
+                D1D2 = np.diff(D1D2)
+            else: D1D2=None
+            if do_auto==True:
+                D2D2 = npairs(sample2, sample2, rbins, period=period, N_threads=N_threads)
+                D2D2 = np.diff(D2D2)
+            else: D2D2=None
+
+        return D1D1, D1D2, D2D2
+    
+    #what needs to be done?
+    do_DD, do_DR, do_RR = _TP_estimator_requirements(estimator)
+    
+    #how many points are there? (for normalization purposes)
+    if randoms is not None:
+        N1 = len(sample1)
+        N2 = len(sample2)
+        NR = len(randoms)
+    else: #this is taken care of in the analytical randoms case.
+        N1 = 1.0
+        N2 = 1.0
+        NR = 1.0
+    
+    #count pairs
+    D1D1,D1D2,D2D2 = pair_counts(sample1, sample2, rbins, period,\
+                                 N_threads, do_auto, do_cross, do_DD)
+    D1R, D2R, RR = random_counts(sample1, sample2, randoms, rbins, period,\
+                                 PBCs, k, N_threads, do_RR, do_DR)
+    
+    #return results
+    if np.all(sample2==sample1):
+        xi_11 = _TP_estimator(D1D1,D1R,RR,N1,N1,NR,NR,estimator)
+        return xi_11
+    else:
+        if (do_auto==True) & (do_cross==True): 
+            xi_11 = _TP_estimator(D1D1,D1R,RR,N1,N1,NR,NR,estimator)
+            xi_12 = _TP_estimator(D1D2,D1R,RR,N1,N2,NR,NR,estimator)
+            xi_22 = _TP_estimator(D2D2,D2R,RR,N2,N2,NR,NR,estimator)
+            return xi_11, xi_12, xi_22
+        elif (do_cross==True):
+            xi_12 = _TP_estimator(D1D2,D1R,RR,N1,N2,NR,NR,estimator)
+            return xi_12
+        elif (do_auto==True):
+            xi_11 = _TP_estimator(D1D1,D1R,D1R,N1,N1,NR,NR,estimator)
+            xi_22 = _TP_estimator(D2D2,D2R,D2R,N2,N2,NR,NR,estimator)
+            return xi_11

--- a/halotools/mock_observables/pair_counters/double_tree.py
+++ b/halotools/mock_observables/pair_counters/double_tree.py
@@ -1,0 +1,462 @@
+# -*- coding: utf-8 -*-
+
+"""
+Data structures used for efficient, cache-aware 
+pairwise calculations on simulation boxes.
+"""
+
+import numpy as np
+from math import ceil, floor
+from ...custom_exceptions import *
+
+__all__=['FlatRectanguloidTree', 'FlatRectanguloidDoubleTree']
+__author__ = ['Andrew Hearin', 'Duncan Campbell']
+
+class FlatRectanguloidTree(object):
+    """ Flat, rectangular grid of the simulation box. 
+
+    The simulation box is divided into rectanguloid cells whose edges 
+    and faces are aligned with the x-, y- and z-axes of the box. 
+    Each 3d point in the simulation belongs to a unique cell. 
+
+    Any cell can be identified by either its tuple indices, (ix, iy, iz), 
+    or by the unique integer ID assigned it via the dictionary ordering 
+    of tuple indices:
+
+        * (0, 0, 0) <--> 0
+
+        * (0, 0, 1) <--> 1
+
+        * (0, 0, 2) <--> 2
+
+        * ... 
+
+        * (0, 1, 0) <--> num_zdivs
+
+        * (0, 1, 1) <--> num_zdivs + 1
+
+        * ...
+
+    And so forth. Each of the Npts thus has a unique triplet, 
+    or equivalently, unique integer specifying the subvolume containing the point. 
+    The unique integer is called the *cellID*. 
+    In order to access the *x* positions of the points lying in subvolume *i*, 
+    x[idx_sort][slice_array[i]]. 
+
+    In practice, because fancy indexing with `idx_sort` is not instantaneous, 
+    it is more efficient to use `idx_sort` once to sort the x, y, and z arrays 
+    in-place, and then access the sorted arrays with the relevant slice_array element. 
+
+    """
+
+    def __init__(self, x, y, z, 
+        approx_xcell_size, approx_ycell_size, approx_zcell_size, 
+        xperiod, yperiod, zperiod):
+        """
+        Parameters 
+        ----------
+        x, y, z : arrays
+            Length-Npts arrays containing the spatial position of the Npts points. 
+
+        Lbox : float
+            Length scale defining the periodic boundary conditions
+
+        cell_size : float 
+            The approximate cell size into which the box will be divided. 
+        """
+
+        self._check_sensible_constructor_inputs()
+
+        self.xperiod = xperiod 
+        self.yperiod = yperiod 
+        self.zperiod = zperiod 
+
+        self.num_xdivs = int(round(xperiod/float(approx_xcell_size)))
+        self.num_ydivs = int(round(yperiod/float(approx_ycell_size)))
+        self.num_zdivs = int(round(zperiod/float(approx_zcell_size)))
+
+        self.xcell_size = self.xperiod/float(self.num_xdivs)
+        self.ycell_size = self.yperiod/float(self.num_ydivs)
+        self.zcell_size = self.zperiod/float(self.num_zdivs)
+        
+        # Build the tree
+        idx_sorted, slice_array = self.compute_cell_structure(x, y, z)
+        self.x = np.ascontiguousarray(x[idx_sorted], dtype=np.float64)
+        self.y = np.ascontiguousarray(y[idx_sorted], dtype=np.float64)
+        self.z = np.ascontiguousarray(z[idx_sorted], dtype=np.float64)
+        self.slice_array = slice_array
+        self.idx_sorted = idx_sorted
+
+    def _check_sensible_constructor_inputs(self):
+        """
+        """
+        pass
+
+    def cell_idx_from_cell_tuple(self, ix, iy, iz):
+        """
+        """
+        return ix*(self.num_ydivs*self.num_zdivs) + iy*self.num_zdivs + iz
+
+    def cell_tuple_from_cell_idx(self, icell):
+        """
+        """
+        nxny = self.num_xdivs*self.num_ydivs
+        ix = icell / nxny
+        itemp1 = icell - ix*nxny
+        iy = itemp1 / self.num_ydivs
+        itemp2 = itemp1 - iy*self.num_ydivs
+        iz = itemp2 % self.num_zdivs
+        return ix, iy, iz
+
+    def compute_cell_structure(self, x, y, z):
+        """ 
+        Method divides the periodic box into regular, cubical subvolumes, and assigns a 
+        subvolume index to each point.  The returned arrays can be used to efficiently 
+        access only those points in a given subvolume. 
+
+        Parameters 
+        ----------
+        x, y, z : arrays
+            Length-Npts arrays containing the spatial position of the Npts points. 
+
+        Returns 
+        -------
+        idx_sorted : array
+            Array of indices that sort the points according to the dictionary 
+            order of the 3d subvolumes. 
+
+        slice_array : array 
+            array of slice objects used to access the elements of x, y, and z 
+            of points residing in a given subvolume. 
+
+        """
+
+        ix = np.floor(x/self.xcell_size).astype(int)
+        iy = np.floor(y/self.ycell_size).astype(int)
+        iz = np.floor(z/self.zcell_size).astype(int)
+        
+        #take care of points right on the boundary
+        ix = np.where(ix >= self.num_xdivs, self.num_xdivs-1, ix)
+        iy = np.where(iy >= self.num_ydivs, self.num_ydivs-1, iy)
+        iz = np.where(iz >= self.num_zdivs, self.num_zdivs-1, iz)
+
+        cell_idx_of_particles = self.cell_idx_from_cell_tuple(ix, iy, iz)
+        
+        num_total_cells = self.num_xdivs*self.num_ydivs*self.num_zdivs
+
+        idx_sorted = np.argsort(cell_idx_of_particles)
+        bin_indices = np.searchsorted(cell_idx_of_particles[idx_sorted], 
+            np.arange(num_total_cells))
+        bin_indices = np.append(bin_indices, None)
+        
+        slice_array = np.empty(num_total_cells, dtype=object)
+        for icell in xrange(num_total_cells):
+            slice_array[icell] = slice(bin_indices[icell], bin_indices[icell+1], 1)
+            
+        return idx_sorted, slice_array
+
+
+class FlatRectanguloidDoubleTree(object):
+    """
+    """
+
+    def __init__(self, x1, y1, z1, x2, y2, z2,  
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        search_xlength, search_ylength, search_zlength, 
+        xperiod, yperiod, zperiod, PBCs = True):
+        """
+        Parameters 
+        ----------
+        x, y, z : arrays
+            Length-Npts arrays containing the spatial position of the Npts points. 
+
+        Lbox : float
+            Length scale defining the periodic boundary conditions
+
+        cell_size : float 
+            The approximate cell size into which the box will be divided. 
+        """
+
+
+        self.xperiod = xperiod 
+        self.yperiod = yperiod 
+        self.zperiod = zperiod 
+        self.search_xlength = search_xlength 
+        self.search_ylength = search_ylength 
+        self.search_zlength = search_zlength 
+        self._PBCs = PBCs
+
+        self._check_sensible_constructor_inputs()
+
+        # Set the cell size of sample 1
+        modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize = (
+            self.set_tree1_cell_sizes(
+                approx_x1cell_size, approx_y1cell_size, approx_z1cell_size)
+            )
+
+        # Build the tree for sample 1
+        self.tree1 = FlatRectanguloidTree(x1, y1, z1, 
+            modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize, 
+            xperiod, yperiod, zperiod)
+
+        # Define a few convenient pointers
+        self.num_x1divs = self.tree1.num_xdivs 
+        self.num_y1divs = self.tree1.num_ydivs 
+        self.num_z1divs = self.tree1.num_zdivs 
+
+        self.x1cell_size = self.tree1.xcell_size
+        self.y1cell_size = self.tree1.ycell_size
+        self.z1cell_size = self.tree1.zcell_size
+
+        # Set the cell size of sample 2
+        modified_x2_cellsize, modified_y2_cellsize, modified_z2_cellsize = (
+            self.set_tree2_cell_sizes(
+                approx_x2cell_size, approx_y2cell_size, approx_z2cell_size)
+            )
+
+        # Build the tree for sample 2
+        self.tree2 = FlatRectanguloidTree(x2, y2, z2, 
+            modified_x2_cellsize, modified_y2_cellsize, modified_z2_cellsize, 
+            xperiod, yperiod, zperiod)
+
+        # Define a few convenient pointers
+        self.num_x2divs = self.tree2.num_xdivs 
+        self.num_y2divs = self.tree2.num_ydivs 
+        self.num_z2divs = self.tree2.num_zdivs 
+
+        self.x2cell_size = self.tree2.xcell_size
+        self.y2cell_size = self.tree2.ycell_size
+        self.z2cell_size = self.tree2.zcell_size
+
+        self.num_xcell2_per_xcell1 = self.num_x2divs/self.num_x1divs
+        self.num_ycell2_per_ycell1 = self.num_y2divs/self.num_y1divs
+        self.num_zcell2_per_zcell1 = self.num_z2divs/self.num_z1divs
+
+    def _check_sensible_constructor_inputs(self):
+        """
+        """
+        try:
+            assert self.search_xlength <= self.xperiod/3.
+            assert self.search_ylength <= self.yperiod/3.
+            assert self.search_zlength <= self.zperiod/3.
+        except AssertionError:
+            msg = ("\n The maximum length over which you search for pairs of points \n"
+                "cannot be larger than Lbox/3 in any dimension. \n"
+                "If you need to count pairs on these length scales, \n"
+                "you should use a larger simulation.\n")
+            raise HalotoolsError(msg)
+        
+
+
+    def set_tree1_cell_sizes(self, 
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
+        max_cells_per_dimension = 25):
+        """ Method sets the size of the cells of the first tree structure. 
+
+        In each dimension, the cell size is required to evenly divide the 
+        size of the box enclosing the points. In order for the bookkeeping 
+        of the `adjacent_cell_generator` method to be correct, 
+        there must be at least three cell-lengths per box-length. 
+        Furthermore, there should not be too many cells per dimension 
+        or performance suffers, so the ``max_cells_per_dimension`` argument 
+        limits how small the cell-lengths can be. 
+
+        Parameters 
+        -----------
+        approx_x1cell_size : float 
+            Rough estimate for cell-length in the x-dimension. The exact 
+            cell-length will be adjusted to meet the criteria described above. 
+
+        approx_y1cell_size : float 
+
+        approx_z1cell_size : float 
+
+        max_cells_per_dimension : int, optional 
+
+        Returns 
+        -------
+        modified_x1_cellsize : float 
+            Exact size of the cell-length in the x-dimension. 
+
+        modified_y1_cellsize : float 
+
+        modified_z1_cellsize : float 
+        """
+
+        x1mult = int(floor(self.xperiod/float(approx_x1cell_size)))
+        y1mult = int(floor(self.yperiod/float(approx_y1cell_size)))
+        z1mult = int(floor(self.zperiod/float(approx_z1cell_size)))
+
+        x1mult = min(max_cells_per_dimension, x1mult)
+        y1mult = min(max_cells_per_dimension, y1mult)
+        z1mult = min(max_cells_per_dimension, z1mult)
+
+        xsearch_mult = int(floor(self.xperiod/float(self.search_xlength)))
+        ysearch_mult = int(floor(self.yperiod/float(self.search_ylength)))
+        zsearch_mult = int(floor(self.zperiod/float(self.search_zlength)))
+
+        x1mult = min(x1mult, xsearch_mult)
+        y1mult = min(y1mult, ysearch_mult)
+        z1mult = min(z1mult, zsearch_mult)
+
+        x1mult = max(3, x1mult)
+        y1mult = max(3, y1mult)
+        z1mult = max(3, z1mult)
+
+        modified_x1_cellsize = self.xperiod/float(x1mult)
+        modified_y1_cellsize = self.yperiod/float(y1mult)
+        modified_z1_cellsize = self.zperiod/float(z1mult)
+
+        return modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize
+
+    def set_tree2_cell_sizes(self, 
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        max_cells_per_dimension = 25):
+        """ Method sets the size of the cells of the second tree structure. 
+
+        In each dimension, the cell size is required to evenly divide the 
+        cell-size of the corresponding dimension of the first tree structure. 
+        In order for the bookkeeping of the `adjacent_cell_generator` method 
+        to be correct, in each dimension the cell-lengths of tree 2 cannot 
+        be larger than the cell-length of tree 1. 
+        Furthermore, there should not be too many cells per dimension 
+        or performance suffers, so the ``max_cells_per_dimension`` argument 
+        limits how small the cell-lengths can be. 
+
+        Parameters 
+        -----------
+        approx_x2cell_size : float 
+            Rough estimate for cell-length in the x-dimension. The exact 
+            cell-length will be adjusted to meet the criteria described above. 
+
+        approx_y2cell_size : float 
+
+        approx_z2cell_size : float 
+
+        max_cells_per_dimension : int, optional 
+
+        Returns 
+        -------
+        modified_x2_cellsize : float 
+            Exact size of the cell-length in the x-dimension. 
+
+        modified_y2_cellsize : float 
+
+        modified_z2_cellsize : float 
+        """
+
+        x2mult = int(round(self.tree1.xcell_size/float(approx_x2cell_size)))
+        y2mult = int(round(self.tree1.ycell_size/float(approx_y2cell_size)))
+        z2mult = int(round(self.tree1.zcell_size/float(approx_z2cell_size)))
+
+        x2mult = max(1, x2mult)
+        y2mult = max(1, y2mult)
+        z2mult = max(1, z2mult)
+
+        x2mult = min(max_cells_per_dimension, x2mult)
+        y2mult = min(max_cells_per_dimension, y2mult)
+        z2mult = min(max_cells_per_dimension, z2mult)
+
+        modified_x2_cellsize = self.tree1.xcell_size/x2mult
+        modified_y2_cellsize = self.tree1.ycell_size/y2mult
+        modified_z2_cellsize = self.tree1.zcell_size/z2mult
+
+        return modified_x2_cellsize, modified_y2_cellsize, modified_z2_cellsize
+
+
+    def leftmost_cell_tuple_idx2(self, tuple_idx1, num_cell2_per_cell1):
+        return tuple_idx1*num_cell2_per_cell1
+
+    def rightmost_cell_tuple_idx2(self, tuple_idx1, num_cell2_per_cell1):
+        return (tuple_idx1+1)*num_cell2_per_cell1 - 1
+
+    def num_cells_to_cover_search_length(self, cell_size, search_length):
+        return int(np.ceil(search_length/float(cell_size)))
+
+    def nonPBC_generator(self, dim_idx, num_covering_steps, num_cell2_per_cell1):
+        """
+        """
+        leftmost_tuple_idx = (
+            self.leftmost_cell_tuple_idx2(dim_idx, num_cell2_per_cell1) - 
+            num_covering_steps)
+
+        rightmost_tuple_idx = (
+            self.rightmost_cell_tuple_idx2(dim_idx, num_cell2_per_cell1) + 
+            num_covering_steps)
+
+        return xrange(leftmost_tuple_idx, rightmost_tuple_idx+1)
+
+
+    def adjacent_cell_generator(self, icell1, 
+        search_xlength, search_ylength, search_zlength):
+
+        # Determine the cell tuple from the input cellID
+        ix1, iy1, iz1 = self.tree1.cell_tuple_from_cell_idx(icell1)
+
+        # Determine the number of d2 cells are necessary to guarantee that 
+        ### we search for all points within the search length 
+        num_x2_covering_steps = self.num_cells_to_cover_search_length(
+            self.x2cell_size, search_xlength) 
+
+        num_y2_covering_steps = self.num_cells_to_cover_search_length(
+            self.y2cell_size, search_ylength)    
+
+        num_z2_covering_steps = self.num_cells_to_cover_search_length(
+            self.z2cell_size, search_zlength)  
+
+
+        # For each spatial dimension, retrieve a generator that yields 
+        ### the tuple indices of the adjacent cells that 
+        ### we need to search for pairs 
+        nonPBC_ix2_generator = self.nonPBC_generator(ix1, 
+            num_x2_covering_steps, self.num_xcell2_per_xcell1)
+
+        nonPBC_iy2_generator = self.nonPBC_generator(iy1, 
+            num_y2_covering_steps, self.num_ycell2_per_ycell1)
+
+        nonPBC_iz2_generator = self.nonPBC_generator(iz1, 
+            num_z2_covering_steps, self.num_zcell2_per_zcell1)
+
+        for nonPBC_ix2 in nonPBC_ix2_generator:
+            # determine the pre-shift in the x dimension
+            if nonPBC_ix2 < 0:
+                x2shift = -self.xperiod
+            elif nonPBC_ix2 >= self.num_x2divs:
+                x2shift = +self.xperiod
+            else:
+                x2shift = 0.
+            # Now apply the PBCs
+            ix2 = nonPBC_ix2 % self.num_x2divs
+
+            for nonPBC_iy2 in nonPBC_iy2_generator:
+                # determine the pre-shift in the y dimension
+                if nonPBC_iy2 < 0:
+                    y2shift = -self.yperiod
+                elif nonPBC_iy2 >= self.num_y2divs:
+                    y2shift = +self.yperiod
+                else:
+                    y2shift = 0.
+                # Now apply the PBCs
+                iy2 = nonPBC_iy2 % self.num_y2divs
+
+                for nonPBC_iz2 in nonPBC_iz2_generator:
+                    # determine the pre-shift in the z dimension
+                    if nonPBC_iz2 < 0:
+                        z2shift = -self.zperiod
+                    elif nonPBC_iz2 >= self.num_z2divs:
+                        z2shift = +self.zperiod
+                    else:
+                        z2shift = 0.
+                    # Now apply the PBCs
+                    iz2 = nonPBC_iz2 % self.num_z2divs
+
+                    # Get icell2 from ix2, iy2, iz2
+                    icell2 = self.tree2.cell_idx_from_cell_tuple(ix2, iy2, iz2)
+
+                    yield icell2, x2shift*self._PBCs, y2shift*self._PBCs, z2shift*self._PBCs
+
+
+
+
+

--- a/halotools/mock_observables/pair_counters/double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pairs.py
@@ -65,6 +65,20 @@ def double_tree_npairs(data1, data2, rbins, period = None,
         If ``num_threads`` is set to the string 'max', use all available cores. 
         Default is 1 thread for a serial calculation that 
         does not open a multiprocessing pool. 
+
+    approx_cell1_size : array_like, optional 
+        Length-3 array serving as a guess for the optimal manner by which 
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
+        will apportion the ``data`` points into subvolumes of the simulation box. 
+        The optimum choice unavoidably depends on the specs of your machine. 
+        Default choice is to use 1/10 of the box size in each dimension, 
+        which will return reasonable result performance for most use-cases. 
+        Performance can vary sensitively with this parameter, so it is highly 
+        recommended that you experiment with this parameter when carrying out  
+        performance-critical calculations. 
+
+    approx_cell2_size : array_like, optional 
+        See comments for ``approx_cell1_size``. 
     
     Returns
     -------

--- a/halotools/mock_observables/pair_counters/double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pairs.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+
+"""
+rectangular Cuboid Pair Counter. 
+
+This module contains pair counting functions used to count the number of pairs with 
+separations less than or equal to r, optimized for simulation boxes.
+
+This module also contains a 'main' function which runs speed tests.
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+from time import time
+import sys
+import multiprocessing
+from functools import partial
+
+from .double_tree import FlatRectanguloidDoubleTree
+from .cpairs import *
+
+from ...custom_exceptions import *
+from ...utils.array_utils import convert_to_ndarray
+
+__all__ = ['double_tree_npairs']
+__author__ = ['Duncan Campbell', 'Andrew Hearin']
+
+
+def double_tree_npairs(x1, y1, z1, x2, y2, z2,  
+    rbins, period = None, verbose = False, num_threads = 1):
+    """
+    real-space pair counter.
+    
+    Count the number of pairs (x1,x2) that can be formed, with x1 drawn from data1 and x2
+    drawn from data2, and where distance(x1, x2) <= rbins[i]. 
+    
+    Parameters
+    ----------
+    x1, y1, z1: array_like
+        Length-Npts1 arrays giving the 3d position of the points in sample 1. 
+
+    x2, y2, z2: array_like
+        Length-Npts2 arrays giving the 3d position of the points in sample 2. 
+            
+    rbins: array_like
+        Boundaries defining the bins in which pairs are counted.
+        
+    period: array_like, optional
+        Length-3 array defining the periodic boundary conditions. 
+        If only one number is specified, the enclosing volume is assumed to 
+        be a periodic cube (by far the most common case). 
+        If period is set to None, the default option, 
+        PBCs are set to infinity.  
+
+    verbose: Boolean, optional
+        If True, print out information and progress.
+    
+    num_threads: int, optional
+        Number of CPU cores to use in the pair counting. 
+        If ``num_threads`` is set to the string 'max', use all available cores. 
+        Default is 1 thread for a serial calculation that 
+        does not open a multiprocessing pool. 
+    
+    Returns
+    -------
+    num_pairs : array of length len(rbins)
+        number of pairs
+    """
+    
+    if num_threads is not 1:
+        if num_threads=='max':
+            num_threads = multiprocessing.cpu_count()
+        if isinstance(num_threads,int):
+            pool = multiprocessing.Pool(num_threads)
+        else: 
+            msg = "Input ``num_threads`` argument must be an integer or 'max'"
+            raise HalotoolsError(msg)
+    
+    # Passively enforce that we are working with ndarrays
+    x1 = convert_to_ndarray(x1)
+    y1 = convert_to_ndarray(y1)
+    z1 = convert_to_ndarray(z1)
+    x2 = convert_to_ndarray(x2)
+    y2 = convert_to_ndarray(y2)
+    z2 = convert_to_ndarray(z2)
+    rbins = convert_to_ndarray(rbins)
+
+    try:
+        assert len(x1) == len(y1) == len(z1)
+    except AssertionError:
+        msg = ("Input x1, y1, z1 must all be the same length")
+        raise HalotoolsError(msg)
+    try:
+        assert len(x2) == len(y2) == len(z2)
+    except AssertionError:
+        msg = ("Input x2, y2, z2 must all be the same length")
+        raise HalotoolsError(msg)
+    try:
+        assert rbins.ndim == 1
+    except AssertionError:
+        msg = "Input ``rbins`` must be a 1D array"
+        raise HalotoolsError(msg)
+
+    # Set the boolean value for the PBCs variable
+    if period is None:
+        PBCs = False
+        x1, y1, z1, x2, y2, z2, period = (
+            _enclose_in_box(x1, y1, z1, x2, y2, z2))
+    else:
+        PBCs = True
+        period = convert_to_ndarray(period)
+        if len(period) == 1:
+            period = np.array([period[0]]*3)
+        try:
+            assert np.all(period < np.inf)
+            assert np.all(period > 0)
+        except AssertionError:
+            msg = "Input ``period`` cannot be zero or unbounded in any dimension"
+            raise HalotoolsError(msg)
+
+    rmax = np.max(rbins)
+    if np.any(rmax >= period/2.):
+        msg = ("It is not permissible to attempt to count pairs with seperations "
+            "larger than Lbox/2. \nIf you need to count pairs on such a length scale, "
+            "you should use a larger simulation. ")
+        raise HalotoolsError(msg)
+    
+    #build grids for data1 and data2
+    ### THIS PART NEEDS TO BE INTEGRATED INTO THE FUNCTION SIGNATURE
+    cell_size1 = period[0]/10.
+    cell_size2 = period[0]/10.
+
+    double_tree = FlatRectanguloidDoubleTree(
+        x1, y1, z1, x2, y2, z2,  cell_size1, cell_size1, cell_size1, 
+        cell_size2, cell_size2, cell_size2, 
+        rmax, rmax, rmax, *period)
+
+    #square radial bins to make distance calculation cheaper
+    rbins_squared = rbins**2.0
+        
+    #number of cells
+    Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
+
+    #create a function to call with only one argument
+    engine = partial(_npairs_engine, 
+        double_tree, rbins_squared, period, PBCs)
+    
+    #do the pair counting
+    if num_threads>1:
+        counts = np.sum(pool.map(engine,range(Ncell1)),axis=0)
+        pool.close()
+    if num_threads==1:
+        counts = np.sum(map(engine,range(Ncell1)),axis=0)
+
+    return counts.astype(int)
+
+def _npairs_engine(double_tree, rbins_squared, period, PBCs, icell1):
+    """
+    pair counting engine for npairs function.  This code calls a cython function.
+    """
+    # print("...working on icell1 = %i" % icell1)
+    
+    counts = np.zeros(len(rbins_squared))
+    
+    #extract the points in the cell
+    s1 = double_tree.tree1.slice_array[icell1]
+    x_icell1, y_icell1, z_icell1 = (
+        double_tree.tree1.x[s1],
+        double_tree.tree1.y[s1],
+        double_tree.tree1.z[s1])
+        
+    xsearch_length = np.sqrt(rbins_squared[-1])
+    ysearch_length = np.sqrt(rbins_squared[-1])
+    zsearch_length = np.sqrt(rbins_squared[-1])
+    adj_cell_generator = double_tree.adjacent_cell_generator(
+        icell1, xsearch_length, ysearch_length, zsearch_length)
+            
+    adj_cell_counter = 0
+    for icell2, xshift, yshift, zshift in adj_cell_generator:
+                
+        #extract the points in the cell
+        s2 = double_tree.tree2.slice_array[icell2]
+        x_icell2 = double_tree.tree2.x[s2] + xshift
+        y_icell2 = double_tree.tree2.y[s2] + yshift 
+        z_icell2 = double_tree.tree2.z[s2] + zshift
+
+
+        #use cython functions to do pair counting
+        counts += npairs_no_pbc(
+            x_icell1, y_icell1, z_icell1,
+            x_icell2, y_icell2, z_icell2,
+            rbins_squared)
+            
+    return counts
+
+
+def _enclose_in_box(x1, y1, z1, x2, y2, z2):
+    """
+    build axis aligned box which encloses all points. 
+    shift points so cube's origin is at 0,0,0.
+    """
+    
+    xmin = np.min([np.min(x1),np.min(x2)])
+    ymin = np.min([np.min(y1),np.min(y2)])
+    zmin = np.min([np.min(z1),np.min(z2)])
+    xmax = np.max([np.max(x1),np.max(x2)])
+    ymax = np.max([np.max(y1),np.max(y2)])
+    zmax = np.max([np.max(z1),np.max(z2)])
+    
+    xyzmin = np.min([xmin,ymin,zmin])
+    xyzmax = np.min([xmax,ymax,zmax])-xyzmin
+    
+    x1 = x1 - xyzmin
+    y1 = y1 - xyzmin
+    z1 = z1 - xyzmin
+    x2 = x2 - xyzmin
+    y2 = y2 - xyzmin
+    z2 = z2 - xyzmin
+    
+    period = np.array([xyzmax, xyzmax, xyzmax])
+    
+    return x1, y1, z1, x2, y2, z2, period

--- a/halotools/mock_observables/pair_counters/double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pairs.py
@@ -121,11 +121,6 @@ def double_tree_npairs(x1, y1, z1, x2, y2, z2,
             raise HalotoolsError(msg)
 
     rmax = np.max(rbins)
-    if np.any(rmax >= period/2.):
-        msg = ("It is not permissible to attempt to count pairs with seperations "
-            "larger than Lbox/2. \nIf you need to count pairs on such a length scale, "
-            "you should use a larger simulation. ")
-        raise HalotoolsError(msg)
     
     #build grids for data1 and data2
     ### THIS PART NEEDS TO BE INTEGRATED INTO THE FUNCTION SIGNATURE

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
@@ -20,12 +20,30 @@ def test_double_tree_npairs_periodic():
     x = np.random.uniform(0, Lbox[0], Npts)
     y = np.random.uniform(0, Lbox[1], Npts)
     z = np.random.uniform(0, Lbox[2], Npts)
+    data1 = np.vstack((x,y,z)).T
 
     rbins = np.array([0.0,0.1,0.2,0.3])
 
-    result = double_tree_npairs(x, y, z, x, y, z, rbins, period)
+    result = double_tree_npairs(data1, data1, rbins, period)
     
-    data1 = np.vstack((x,y,z)).T
     test_result = simp_npairs(data1, data1, rbins, period=period)
 
-    assert np.all(test_result==result), "pair counts are incorrect"
+    assert np.all(test_result==result), "pair counts for PBC-case are incorrect"
+
+def test_double_tree_npairs_nonperiodic():
+    
+    Npts = 1e3
+    Lbox = [1.0,1.0,1.0]
+    period = np.array(Lbox)
+    
+    x = np.random.uniform(0, Lbox[0], Npts)
+    y = np.random.uniform(0, Lbox[1], Npts)
+    z = np.random.uniform(0, Lbox[2], Npts)
+    data1 = np.vstack((x,y,z)).T
+    
+    rbins = np.array([0.0,0.1,0.2,0.3])
+
+    result = double_tree_npairs(data1, data1, rbins, period=None)
+    test_result = simp_npairs(data1, data1, rbins, period=None)
+    
+    assert np.all(test_result==result), "pair counts for non-PBC case are incorrect"

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+#load comparison simple pair counters
+from ..pairs import npairs as simp_npairs
+from ..pairs import wnpairs as simp_wnpairs
+#load rect_cuboid_pairs pair counters
+from ..double_tree_pairs import double_tree_npairs
+
+np.random.seed(1)
+
+def test_double_tree_npairs_periodic():
+    
+    Npts = 1e3
+    Lbox = [1.0,1.0,1.0]
+    period = np.array(Lbox)
+    
+    x = np.random.uniform(0, Lbox[0], Npts)
+    y = np.random.uniform(0, Lbox[1], Npts)
+    z = np.random.uniform(0, Lbox[2], Npts)
+
+    rbins = np.array([0.0,0.1,0.2,0.3])
+
+    result = double_tree_npairs(x, y, z, x, y, z, rbins, period)
+    
+    data1 = np.vstack((x,y,z)).T
+    test_result = simp_npairs(data1, data1, rbins, period=period)
+
+    assert np.all(test_result==result), "pair counts are incorrect"


### PR DESCRIPTION
As of this PR submission, the current branch is **NOT READY TO BE MERGED**. This is a code-review request. 

The underlying engine that drives the two-point function calculations has been rewritten. This is now being handled by the FlatRectanguloidDoubleTree class. The most important change is that the size of the cells into which the simulation subdivided is now *mostly* decoupled from Rmax and Lbox, and all three dimensions are now being treated entirely independently. The currently pushed version has only been implemented for the 3d, unweighted pair-counter. I anticipate the generalizations to the MCF, jackknife, 2+1 dimensional counters to be *mostly* straightforward, but will involve careful attention to details. 

In a little more detail, the API is such that an *approximate* cell size is passed to FlatRectanguloidDoubleTree. The constructor uses this approximate guess and chooses the closest cell size that meets the following constraints:
    1. The cell size in each dimension must evenly divide the size of the simulation box in that dimension
    2. The cell size must at least exceed Rmax in each dimension
    3. There must be at least 3 cell-lengths per dimension

I find that I can improve typical pair-counting for SDSS-like samples in Bolshoi by a factor of 2-3, and in Multidark by 2-100x, depending on the regime. However, I have not yet found a universal organizing principle for how to choose the optimal cell size, and the performance depends fairly sensitively on the choice. My current solution is to use Lbox/10 as the default, which I find always gives reasonable results, and to be very explicit in the docstring that some experimentation should be done for performance-critical applications. 

CC @duncandc , @surhudm 