### PR TITLE
Make autosummary tables work

### DIFF
--- a/docs/autosummary_workaround.py
+++ b/docs/autosummary_workaround.py
@@ -1,0 +1,112 @@
+import sphinx
+from sphinx.ext.autosummary import *
+from distutils.version import LooseVersion
+
+class FixedAutosummary(Autosummary):
+    def get_items(self, names):
+        """Try to import the given names, and return a list of
+        ``[(name, signature, summary_string, real_name), ...]``.
+        """
+        env = self.state.document.settings.env
+
+        prefixes = get_import_prefixes_from_env(env)
+
+        items = []
+
+        max_item_chars = 50
+
+        for name in names:
+            display_name = name
+            if name.startswith('~'):
+                name = name[1:]
+                display_name = name.split('.')[-1]
+
+            try:
+                real_name, obj, parent, modname = import_by_name(name, prefixes=prefixes)
+            except ImportError:
+                self.warn('failed to import %s' % name)
+                items.append((name, '', '', name))
+                continue
+
+            self.result = ViewList()  # initialize for each documenter
+            full_name = real_name
+            if not isinstance(obj, ModuleType):
+                # give explicitly separated module name, so that members
+                # of inner classes can be documented
+                full_name = modname + '::' + full_name[len(modname)+1:]
+            # NB. using full_name here is important, since Documenters
+            #     handle module prefixes slightly differently
+            documenter = get_documenter(obj, parent)(self, full_name)
+            if not documenter.parse_name():
+                self.warn('failed to parse name %s' % real_name)
+                items.append((display_name, '', '', real_name))
+                continue
+            if not documenter.import_object():
+                self.warn('failed to import object %s' % real_name)
+                items.append((display_name, '', '', real_name))
+                continue
+            if documenter.options.members and not documenter.check_module():
+                continue
+
+            # try to also get a source code analyzer for attribute docs
+            try:
+                documenter.analyzer = ModuleAnalyzer.for_module(
+                    documenter.get_real_modname())
+                # parse right now, to get PycodeErrors on parsing (results will
+                # be cached anyway)
+                documenter.analyzer.find_attr_docs()
+            except PycodeError as err:
+                documenter.env.app.debug(
+                    '[autodoc] module analyzer failed: %s', err)
+                # no source file -- e.g. for builtin and C modules
+                documenter.analyzer = None
+
+            # -- Grab the signature
+
+            sig = documenter.format_signature()
+            if not sig:
+                sig = ''
+            else:
+                max_chars = max(10, max_item_chars - len(display_name))
+                sig = mangle_signature(sig, max_chars=max_chars)
+                sig = sig.replace('*', r'\*')
+
+            # -- Grab the summary
+
+            documenter.add_content(None)
+            doc = list(documenter.process_doc([self.result.data]))
+
+            while doc and not doc[0].strip():
+                doc.pop(0)
+
+            # If there's a blank line, then we can assume the first sentence /
+            # paragraph has ended, so anything after shouldn't be part of the
+            # summary
+            for i, piece in enumerate(doc):
+                if not piece.strip():
+                    doc = doc[:i]
+                    break
+
+            # Try to find the "first sentence", which may span multiple lines
+            m = re.search(r"^([A-Z].*?\.)(?:\s|$)", " ".join(doc).strip())
+            if m:
+                summary = m.group(1).strip()
+            elif doc:
+                summary = doc[0].strip()
+            else:
+                summary = ''
+
+            items.append((display_name, sig, summary, real_name))
+
+        return items
+
+
+
+
+def setup(app):
+    app.setup_extension('sphinx.ext.autosummary')
+    if LooseVersion(sphinx.__version__) > LooseVersion('1.3.1'):
+        app.add_directive('fixed_autosummary', Autosummary)
+    else:
+        app.add_directive('fixed_autosummary', FixedAutosummary)
+

--- a/docs/autosummary_workaround.py
+++ b/docs/autosummary_workaround.py
@@ -104,9 +104,9 @@ class FixedAutosummary(Autosummary):
 
 
 def setup(app):
+    # need to make sure autosummary is already setup so we can override it below
     app.setup_extension('sphinx.ext.autosummary')
-    if LooseVersion(sphinx.__version__) > LooseVersion('1.3.1'):
-        app.add_directive('fixed_autosummary', Autosummary)
-    else:
-        app.add_directive('fixed_autosummary', FixedAutosummary)
+
+    if LooseVersion(sphinx.__version__) <= LooseVersion('1.3.1'):
+        app.add_directive('autosummary', FixedAutosummary)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ setup_cfg = dict(conf.items('metadata'))
 
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.
-# check_sphinx_version("1.2.1")
+check_sphinx_version("1.3.1")
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,3 +163,5 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
+
+extensions += ['autosummary_workaround']

--- a/docs/full_ref_api/halotools_full_api.rst
+++ b/docs/full_ref_api/halotools_full_api.rst
@@ -1,10 +1,8 @@
-:orphan:
-
 .. _complete_reference_api:
 
-***************************************
+*************************************
 Comprehensive Halotools Reference/API
-***************************************
+*************************************
 
 .. automodapi:: halotools.empirical_models
 

--- a/docs/function_usage/empirical_model_factory_functions.rst
+++ b/docs/function_usage/empirical_model_factory_functions.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. _empirical_model_factory_functions:
 
 Model Factories
@@ -35,4 +33,4 @@ Subhalo Model Factories
 
 	SubhaloMockFactory
 
-	
+

--- a/docs/function_usage/hod_occupation_functions.rst
+++ b/docs/function_usage/hod_occupation_functions.rst
@@ -1,8 +1,6 @@
-:orphan:
-
 .. _hod_occupation_functions:
 
-HOD Occupation Component Models 
+HOD Occupation Component Models
 ==================================
 
 Zheng et al. (2007)

--- a/docs/function_usage/phase_space_models_functions.rst
+++ b/docs/function_usage/phase_space_models_functions.rst
@@ -10,7 +10,7 @@ All of these can be imported from `halotools.empirical_models`.
 Halo Mass Definitions
 ---------------------
 
-.. fixed_autosummary::
+.. autosummary::
 
    halo_mass_to_halo_radius
    halo_radius_to_halo_mass
@@ -20,7 +20,7 @@ Halo Mass Definitions
 NFW Profile Models
 ------------------
 
-.. fixed_autosummary::
+.. autosummary::
 
 	NFWProfile
 	NFWPhaseSpace
@@ -29,7 +29,7 @@ NFW Profile Models
 Central Galaxy Profile Models
 -----------------------------
 
-.. fixed_autosummary::
+.. autosummary::
 
 	TrivialProfile
 	TrivialPhaseSpace
@@ -37,7 +37,7 @@ Central Galaxy Profile Models
 Monte Carlo Realizations of Galaxy Profiles
 -------------------------------------------
 
-.. fixed_autosummary::
+.. autosummary::
 
 	NFWPhaseSpace.mc_generate_nfw_phase_space_points
 	NFWProfile.mc_generate_nfw_radial_positions

--- a/docs/function_usage/phase_space_models_functions.rst
+++ b/docs/function_usage/phase_space_models_functions.rst
@@ -2,15 +2,17 @@
 
 .. _phase_space_models_functions:
 
-Phase Space Component Models 
+Phase Space Component Models
 ===============================
+
+All of these can be imported from `halotools.empirical_models`.
+
+.. currentmodule:: halotools.empirical_models
 
 Halo Mass Definitions
 ------------------------
 
-.. currentmodule:: halotools.empirical_models.phase_space_models.profile_models.profile_helpers
-
-.. autosummary::
+.. fixed_autosummary::
 
    halo_mass_to_halo_radius
    halo_radius_to_halo_mass
@@ -20,52 +22,26 @@ Halo Mass Definitions
 NFW Profile Models
 ------------------------
 
-.. currentmodule:: halotools.empirical_models.phase_space_models.profile_models.nfw_profile
-
-.. autosummary::
+.. fixed_autosummary::
 
 	NFWProfile
-
-.. currentmodule:: halotools.empirical_models.phase_space_models.nfw_phase_space
-
-.. autosummary::
-
 	NFWPhaseSpace
-
-.. currentmodule:: halotools.empirical_models.phase_space_models.profile_models.conc_mass_models
-
-.. autosummary:: 
-
 	ConcMass
 
 Central Galaxy Profile Models
 -------------------------------
 
-.. currentmodule:: halotools.empirical_models.phase_space_models.profile_models.trivial_profile
-
-.. autosummary:: 
+.. fixed_autosummary::
 
 	TrivialProfile
-
-.. currentmodule:: halotools.empirical_models.phase_space_models.trivial_phase_space
-
-.. autosummary:: 
-
 	TrivialPhaseSpace
 
-Monte Carlo Realizations of Galaxy Profiles 
+Monte Carlo Realizations of Galaxy Profiles
 ---------------------------------------------
 
-.. currentmodule:: halotools.empirical_models.phase_space_models.nfw_phase_space
-
-.. autosummary::
+.. fixed_autosummary::
 
 	NFWPhaseSpace.mc_generate_nfw_phase_space_points
-
-.. currentmodule:: halotools.empirical_models.phase_space_models.profile_models.nfw_profile
-
-.. autosummary::
-
 	NFWProfile.mc_generate_nfw_radial_positions
 
 

--- a/docs/function_usage/phase_space_models_functions.rst
+++ b/docs/function_usage/phase_space_models_functions.rst
@@ -1,16 +1,14 @@
-:orphan:
-
 .. _phase_space_models_functions:
 
 Phase Space Component Models
-===============================
+============================
 
 All of these can be imported from `halotools.empirical_models`.
 
 .. currentmodule:: halotools.empirical_models
 
 Halo Mass Definitions
-------------------------
+---------------------
 
 .. fixed_autosummary::
 
@@ -20,7 +18,7 @@ Halo Mass Definitions
    density_threshold
 
 NFW Profile Models
-------------------------
+------------------
 
 .. fixed_autosummary::
 
@@ -29,7 +27,7 @@ NFW Profile Models
 	ConcMass
 
 Central Galaxy Profile Models
--------------------------------
+-----------------------------
 
 .. fixed_autosummary::
 
@@ -37,7 +35,7 @@ Central Galaxy Profile Models
 	TrivialPhaseSpace
 
 Monte Carlo Realizations of Galaxy Profiles
----------------------------------------------
+-------------------------------------------
 
 .. fixed_autosummary::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,20 +3,20 @@ Halotools Documentation
 =======================
 
 
-Halotools is a specialized python package for building and testing models of the 
-galaxy-halo connection, and analyzing catalogs of dark matter halos. 
+Halotools is a specialized python package for building and testing models of the
+galaxy-halo connection, and analyzing catalogs of dark matter halos.
 The core functionality of the package includes:
 
 * Fast generation of synthetic galaxy populations using HODs, abundance matching, and related methods
-* Efficient algorithms for calculating galaxy clustering, lensing, z-space distortions, and other astronomical statistics 
+* Efficient algorithms for calculating galaxy clustering, lensing, z-space distortions, and other astronomical statistics
 * A modular, object-oriented framework for designing your own galaxy evolution model
 * End-to-end support for downloading publicly-available halo catalogs and reducing them to fast-loading hdf5 files
 
-For more information about the scope of the package, see :ref:`halotools_science_overview`. The source code is publicly available at https://github.com/astropy/halotools. 
+For more information about the scope of the package, see :ref:`halotools_science_overview`. The source code is publicly available at https://github.com/astropy/halotools.
 
 
 ******************
-Getting Started 
+Getting Started
 ******************
 
 .. toctree::
@@ -26,7 +26,17 @@ Getting Started
    getting_started/index
    function_usage/index
    source_notes/index
- 
+
+*********
+Reference
+*********
+
+.. toctree::
+   :maxdepth: 1
+
+   full_ref_api/halotools_full_api
+
+
 *********************
 License and Credits
 *********************
@@ -36,5 +46,4 @@ License and Credits
 
    getting_started/development/contributors
    getting_started/development/citing_halotools
-
 


### PR DESCRIPTION
As recently discussed at length with @aphearin on slack, it turns out there's a bug in `sphinx`'s autosummary that was causing many of the associated problems with the docs.  This PR addresses that by adding a small sphinx extension that just fixes the bug 

The extension looks complex, but it's really just copied-and-pasted from sphinx, with the one change being on line 28: ``if not documenter.check_module()`` -> ``if documenter.options.members and not documenter.check_module()``. 

This also fixes up `phase_space_models_functions.rst` to be compatible with the extension - other docs that are supposed to have `autosummary` tables will need to be switched to follow this form (or similar).  

This also makes a few changes in the docs, most visible of which is the addition of a section for the Reference/API.  @aphearin, I can back that out if you don't want that in, but it might make sense given that this autosummary stuff is now linking directly to that.
