### PR TITLE
update travis builds for conda and travis changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,22 @@ python:
     - 3.3
     - 3.4
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
+
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+# The apt packages below are needed for sphinx builds. A full list of packages 
+# that can be included can be found here:
+#
+# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
+
+addons:
+    apt:
+        packages:
+            - graphviz
+            - texlive-latex-extra
+            - dvipng
+
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -47,13 +63,12 @@ matrix:
           env: SETUP_CMD='test'
 
         # Try older numpy versions
-        # currently these are commented out because the conda copy of astropy is only up-to-date for numpy 1.9
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+        - python: 2.7
+          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+        - python: 2.7
+          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+        - python: 2.7
+          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
 before_install:
 
@@ -61,16 +76,12 @@ before_install:
     # future changes
     - export PYTHONIOENCODING=UTF8
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda/bin:$PATH
-    - conda update --yes conda
-
-    # UPDATE APT-GET LISTINGS
-    - sudo apt-get update
-
-    # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - cconda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    - conda info -a
 
 install:
 
@@ -101,7 +112,7 @@ install:
     - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
 
     # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage coveralls; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage==3.7.1 coveralls; fi
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,11 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.10
 
+    allow_failures:
+        - python: 3.3
+        - python: 3.4
+        - python: 3.5
+
 before_install:
 
     # If there are matplotlib tests, comment these out to

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython'
+        - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ python:
     - 2.7
     - 3.3
     - 3.4
-    # This is just for "egg_info".  All other builds are explicitly given in the matrix
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds. A full list of packages 
+# The apt packages below are needed for sphinx builds. A full list of packages
 # that can be included can be found here:
 #
 # https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
@@ -29,10 +28,17 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
         - ASTROPY_VERSION=stable
-        - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
-        - PIP_INSTALL='pip install'
+        - SETUP_CMD='test'
+        - PIP_DEPENDENCIES=''
+        # For this package-template, we include examples of Cython modules,
+        # so Cython is required for testing. If your package does not include
+        # Cython code, you can set CONDA_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='Cython'
     matrix:
+        # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
+        # Try all python versions with the latest numpy
+        - SETUP_CMD='test'
 
 matrix:
     include:
@@ -48,71 +54,49 @@ matrix:
 
         # Try Astropy development version
         - python: 2.7
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-        - python: 3.3
-          env: ASTROPY_VERSION=development SETUP_CMD='test'
-
-        # Try all python versions with the latest numpy
-        - python: 2.6
-          env: SETUP_CMD='test'
-        - python: 2.7
-          env: SETUP_CMD='test'
-        - python: 3.3
-          env: SETUP_CMD='test'
+          env: ASTROPY_VERSION=development
         - python: 3.4
-          env: SETUP_CMD='test'
+          env: ASTROPY_VERSION=development
 
         # Try older numpy versions
         - python: 2.7
-          env: NUMPY_VERSION=1.8 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.8
         - python: 2.7
-          env: NUMPY_VERSION=1.7 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.7
         - python: 2.7
-          env: NUMPY_VERSION=1.6 SETUP_CMD='test'
+          env: NUMPY_VERSION=1.6
 
 before_install:
 
-    # Use utf8 encoding. Should be default, but this is insurance against
-    # future changes
-    - export PYTHONIOENCODING=UTF8
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - cconda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    - conda info -a
+    # If there are matplotlib tests, comment these out to
+    # Make sure that interactive matplotlib backends work
+    # - export DISPLAY=:99.0
+    # - sh -e /etc/init.d/xvfb start
 
 install:
 
-    # CONDA
-    - conda create --yes -n test -c astropy-ci-extras python=$TRAVIS_PYTHON_VERSION
-    - source activate test
+    # We now use the ci-helpers package to set up our testing environment.
+    # This is done by using Miniconda and then using conda and pip to install
+    # dependencies. Which dependencies are installed using conda and pip is
+    # determined by the CONDA_DEPDENDENCIES and PIP_DEPENDENCIES variables,
+    # which should be space-delimited lists of package names. See the README
+    # in https://github.com/astropy/ci-helpers for information about the full
+    # list of environment variables that can be used to customize your
+    # environment. In some cases, ci-helpers may not offer enough flexibility
+    # in how to install a package, in which case you can have additional
+    # commands in the install: section below.
 
-    # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2 scipy; fi
-    - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
+    - git clone git://github.com/astropy/ci-helpers.git
+    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
-    # ASTROPY
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == development ]]; then $PIP_INSTALL git+http://github.com/astropy/astropy.git#egg=astropy; fi
-    - if [[ $SETUP_CMD != egg_info ]] && [[ $ASTROPY_VERSION == stable ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION astropy; fi
-
-    # OPTIONAL DEPENDENCIES
-    # Here you can add any dependencies your package may have. You can use
-    # conda for packages available through conda, or pip for any other
-    # packages. You should leave the `numpy=$NUMPY_VERSION` in the `conda`
-    # install since this ensures Numpy does not get automatically upgraded.
-    # - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION ... ; fi
-    # - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL ...; fi
-
-    # DOCUMENTATION DEPENDENCIES
-    # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that
-    # this matplotlib will *not* work with py 3.x, but our sphinx build is
-    # currently 2.7, so that's fine
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION Sphinx matplotlib; fi
-
-    # COVERAGE DEPENDENCIES
-    - if [[ $SETUP_CMD == 'test --coverage' ]]; then $PIP_INSTALL coverage==3.7.1 coveralls; fi
+    # As described above, using ci-helpers, you should be able to set up an
+    # environment with dependencies installed using conda and pip, but in some
+    # cases this may not provide enough flexibility in how to install a
+    # specific dependency (and it will not be able to install non-Python 
+    # dependencies). Therefore, you can also include commands below (as
+    # well as at the start of the install section or in the before_install
+    # section if they are needed before setting up conda) to install any
+    # other dependencies.
 
 script:
    - python setup.py $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests'
+        - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests matplotlib'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
@@ -70,8 +70,8 @@ before_install:
 
     # If there are matplotlib tests, comment these out to
     # Make sure that interactive matplotlib backends work
-    # - export DISPLAY=:99.0
-    # - sh -e /etc/init.d/xvfb start
+    - export DISPLAY=:99.0
+    - sh -e /etc/init.d/xvfb start
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,4 +101,4 @@ after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='halotools/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,13 +58,9 @@ matrix:
         - python: 3.4
           env: ASTROPY_VERSION=development
 
-        # Try older numpy versions
+        # Try numpy 1.10 - might want to switch this so that 1.10 is *default* and 1.9 is checked here down the road
         - python: 2.7
-          env: NUMPY_VERSION=1.8
-        - python: 2.7
-          env: NUMPY_VERSION=1.7
-        - python: 2.7
-          env: NUMPY_VERSION=1.6
+          env: NUMPY_VERSION=1.10
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false

--- a/halotools/mock_observables/pair_counters/cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/cpairs/setup_package.py
@@ -1,7 +1,6 @@
 
 
 from distutils.extension import Extension
-import numpy as np
 import os
 import sys
 
@@ -13,11 +12,11 @@ def get_extensions():
 
     names = [THIS_PKG_NAME + "." + src.replace('.pyx', '') for src in SOURCES]
     sources = [os.path.join(PATH_TO_PKG, srcfn) for srcfn in SOURCES]
-    include_dirs = [np.get_include()]
+    include_dirs = ['numpy']
     libraries = []
     language ='c++'
     extra_compile_args = []
-    
+
     extensions = []
     for name, source in zip(names, sources):
         extensions.append(Extension(name=name,

--- a/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
@@ -1,5 +1,4 @@
 from distutils.extension import Extension
-import numpy as np
 import os
 import sys
 
@@ -11,10 +10,10 @@ def get_extensions():
 
     names = [THIS_PKG_NAME + "." + src.replace('.pyx', '') for src in SOURCES]
     sources = [os.path.join(PATH_TO_PKG, srcfn) for srcfn in SOURCES]
-    include_dirs = [np.get_include()]
+    include_dirs = ['numpy']
     libraries = []
     extra_compile_args = []
-    
+
     extensions = []
     for name, source in zip(names, sources):
         extensions.append(Extension(name=name,


### PR DESCRIPTION
This updates the ``.travis.yml`` file to hopefully get travis working again - ``anaconda`` recently made some changes that were causing the tests to not run correctly.

Moving forward, we'll probably want to do what astropy/package-template#140 is suggesting, but I'm not sure how to do that you, so probably best to get this in now, and then when astropy/package-template#140 is merged, pull that out and into halotools.