### PR TITLE
Sped up many tests using approx_cell1_size = [rmax, rmax, rmax]

### DIFF
--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
@@ -4,6 +4,8 @@ from __future__ import (absolute_import, division, print_function,
 
 import numpy as np
 import pytest 
+slow = pytest.mark.slow
+
 from copy import copy 
 
 from ..pairs import wnpairs as pure_python_weighted_pairs
@@ -62,7 +64,7 @@ def test_marked_npairs_nonperiodic():
     
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
 
-
+@slow
 def test_marked_npairs_wfuncs_signatures():
     """ Loop over all wfuncs and ensure that the wfunc signature is handled correctly. 
     """
@@ -77,6 +79,7 @@ def test_marked_npairs_wfuncs_signatures():
     data1 = np.vstack((x,y,z)).T
     
     rbins = np.array([0.0,0.1,0.2,0.3])
+    rmax = rbins.max()
 
 
     # Determine how many wfuncs have currently been implemented
@@ -94,7 +97,8 @@ def test_marked_npairs_wfuncs_signatures():
         signature = _func_signature_int_from_wfunc(wfunc_index)
         weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
         result = marked_npairs(data1, data1, rbins, period=period, 
-            weights1=weights, weights2=weights, wfunc=wfunc_index)
+            weights1=weights, weights2=weights, wfunc=wfunc_index, 
+            approx_cell1_size = [rmax, rmax, rmax])
 
         with pytest.raises(HalotoolsError):
             signature = _func_signature_int_from_wfunc(wfunc_index) + 1
@@ -102,7 +106,7 @@ def test_marked_npairs_wfuncs_signatures():
             result = marked_npairs(data1, data1, rbins, period=period, 
                 weights1=weights, weights2=weights, wfunc=wfunc_index)
 
-
+@slow
 def test_marked_npairs_wfuncs_behavior():
     """ Verify the behavior of a few wfunc-weighted counters by comparing pure python, unmarked 
     pairs to the returned result from a uniformly weighted set of points.  
@@ -123,6 +127,7 @@ def test_marked_npairs_wfuncs_behavior():
     data1 = np.vstack((x,y,z)).T
 
     rbins = np.array([0.0,0.1,0.2,0.3])
+    rmax = rbins.max()
 
     test_result = pure_python_weighted_pairs(data1, data1, 
         rbins, period=period)
@@ -130,13 +135,13 @@ def test_marked_npairs_wfuncs_behavior():
     # wfunc = 1
     weights = np.ones(Npts)*3
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=1)
+    weights1=weights, weights2=weights, wfunc=1, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 9.*test_result), error_msg
 
     # wfunc = 2
     weights = np.ones(Npts)*3
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=2)
+    weights1=weights, weights2=weights, wfunc=2, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 6.*test_result), error_msg
 
     # wfunc = 3
@@ -145,12 +150,12 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=3)
+    weights1=weights, weights2=weights, wfunc=3, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 9.*test_result), error_msg
 
     weights = np.vstack([weights3, weights2]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=3)
+    weights1=weights, weights2=weights, wfunc=3, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 4.*test_result), error_msg
 
     # wfunc = 4
@@ -159,7 +164,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=4)
+    weights1=weights, weights2=weights, wfunc=4, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
     # wfunc = 5
@@ -168,7 +173,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=5)
+    weights1=weights, weights2=weights, wfunc=5, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
     # wfunc = 6
@@ -177,7 +182,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=6)
+    weights1=weights, weights2=weights, wfunc=6, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
     # wfunc = 7
@@ -186,7 +191,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=7)
+    weights1=weights, weights2=weights, wfunc=7, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == -test_result), error_msg
 
     # wfunc = 8
@@ -195,7 +200,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=8)
+    weights1=weights, weights2=weights, wfunc=8, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 3*test_result), error_msg
 
     # wfunc = 9
@@ -204,7 +209,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=9)
+    weights1=weights, weights2=weights, wfunc=9, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 3*test_result), error_msg
 
     # wfunc = 10
@@ -213,7 +218,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=10)
+    weights1=weights, weights2=weights, wfunc=10, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
     weights2 = np.ones(Npts)
@@ -221,7 +226,7 @@ def test_marked_npairs_wfuncs_behavior():
 
     weights = np.vstack([weights2, weights3]).T
     result = marked_npairs(data1, data1, rbins, period=period, 
-    weights1=weights, weights2=weights, wfunc=10)
+    weights1=weights, weights2=weights, wfunc=10, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == -3*test_result), error_msg
 
 

--- a/halotools/mock_observables/test_clustering/test_marked_tpcf.py
+++ b/halotools/mock_observables/test_clustering/test_marked_tpcf.py
@@ -18,6 +18,7 @@ sample1 = np.random.random((N_pts,3))
 sample2 = np.random.random((N_pts,3))
 period = np.array([1.0,1.0,1.0])
 rbins = np.linspace(0,0.3,5)
+rmax = rbins.max()
 
 def test_marked_tpcf_auto_periodic():
     """

--- a/halotools/mock_observables/test_clustering/test_tpcf.py
+++ b/halotools/mock_observables/test_clustering/test_tpcf.py
@@ -20,6 +20,7 @@ Note that these are almost all unit-tests.  Non tirival tests are a little heard
 of here.
 """
 
+@slow
 def test_tpcf_auto():
     """
     test the tpcf auto-correlation functionality
@@ -30,20 +31,25 @@ def test_tpcf_auto():
     randoms = np.random.random((100,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
-    
+    rmax = rbins.max()
+
     #with randoms
     result = tpcf(sample1, rbins, sample2 = None, 
                   randoms=randoms, period = None, 
-                  max_sample_size=int(1e4), estimator='Natural')
+                  max_sample_size=int(1e4), estimator='Natural', 
+                  approx_cell1_size = [rmax, rmax, rmax], 
+                  approx_cellran_size = [rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
     
     #with out randoms
     result = tpcf(sample1, rbins, sample2 = None, 
                   randoms=None, period = period, 
-                  max_sample_size=int(1e4), estimator='Natural')
+                  max_sample_size=int(1e4), estimator='Natural', 
+                  approx_cell1_size = [rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
 
 
+@slow
 def test_tpcf_cross():
     """
     test the tpcf cross-correlation functionality
@@ -54,20 +60,23 @@ def test_tpcf_cross():
     randoms = np.random.random((100,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
-    
+    rmax = rbins.max()
+
     #with randoms
     result = tpcf(sample1, rbins, sample2 = sample2, 
                   randoms=randoms, period = None, 
-                  max_sample_size=int(1e4), estimator='Natural', do_auto=False)
+                  max_sample_size=int(1e4), estimator='Natural', do_auto=False, 
+                  approx_cell1_size = [rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
     
     #with out randoms
     result = tpcf(sample1, rbins, sample2 = sample2, 
                   randoms=None, period = period, 
-                  max_sample_size=int(1e4), estimator='Natural', do_auto=False)
+                  max_sample_size=int(1e4), estimator='Natural', do_auto=False, 
+                  approx_cell1_size = [rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
 
-
+@slow
 def test_tpcf_estimators():
     """
     test the tpcf different estimators functionality
@@ -78,22 +87,33 @@ def test_tpcf_estimators():
     randoms = np.random.random((100,3))
     period = np.array([1,1,1])
     rbins = np.linspace(0,0.3,5)
-    
+    rmax = rbins.max()
+
     result_1 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e4), estimator='Natural')
+                    max_sample_size=int(1e4), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     result_2 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e4), estimator='Davis-Peebles')
+                    max_sample_size=int(1e4), estimator='Davis-Peebles', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     result_3 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e4), estimator='Hewett')
+                    max_sample_size=int(1e4), estimator='Hewett', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     result_4 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e4), estimator='Hamilton')
+                    max_sample_size=int(1e4), estimator='Hamilton', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     result_5 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e4), estimator='Landy-Szalay')
+                    max_sample_size=int(1e4), estimator='Landy-Szalay', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
                                             
     
     assert len(result_1)==3, "wrong number of correlation functions returned erroneously."
@@ -102,7 +122,7 @@ def test_tpcf_estimators():
     assert len(result_4)==3, "wrong number of correlation functions returned erroneously."
     assert len(result_5)==3, "wrong number of correlation functions returned erroneously."
 
-
+@slow
 def test_tpcf_sample_size_limit():
     """
     test the tpcf sample size limit functionality functionality
@@ -113,14 +133,16 @@ def test_tpcf_sample_size_limit():
     randoms = np.random.random((1000,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
-    
+    rmax = rbins.max()
+
     result_1 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e2), estimator='Natural')
+                    max_sample_size=int(1e2), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax])
     
     assert len(result_1)==3, "wrong number of correlation functions returned erroneously."
 
-
+@slow
 def test_tpcf_randoms():
     """
     test the tpcf possible randoms + PBCs combinations
@@ -131,25 +153,34 @@ def test_tpcf_randoms():
     randoms = np.random.random((100,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
-    
+    rmax = rbins.max()
+
     #No PBCs w/ randoms
     result_1 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = None, 
-                    max_sample_size=int(1e4), estimator='Natural')
+                    max_sample_size=int(1e4), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     #PBCs w/o randoms
     result_2 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=None, period = period, 
-                    max_sample_size=int(1e4), estimator='Natural')
+                    max_sample_size=int(1e4), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     #PBCs w/ randoms
     result_3 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = period, 
-                    max_sample_size=int(1e4), estimator='Natural')
+                    max_sample_size=int(1e4), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax], 
+                    approx_cellran_size = [rmax, rmax, rmax])
     
     #No PBCs and no randoms should throw an error.
     try:
         tpcf(sample1, rbins, sample2 = sample2, 
              randoms=None, period = None, 
-             max_sample_size=int(1e4), estimator='Natural')
+             max_sample_size=int(1e4), estimator='Natural', 
+             approx_cell1_size = [rmax, rmax, rmax], 
+             approx_cellran_size = [rmax, rmax, rmax])
     except HalotoolsError:
         pass
     
@@ -157,7 +188,7 @@ def test_tpcf_randoms():
     assert len(result_2)==3, "wrong number of correlation functions returned erroneously."
     assert len(result_3)==3, "wrong number of correlation functions returned erroneously."
 
-
+@slow
 def test_tpcf_period_API():
     """
     test the tpcf period API functionality.
@@ -168,22 +199,26 @@ def test_tpcf_period_API():
     randoms = np.random.random((100,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
+    rmax = rbins.max()
     
     result_1 = tpcf(sample1, rbins, sample2 = sample2,
                     randoms=randoms, period = period, 
-                    max_sample_size=int(1e4), estimator='Natural')
+                    max_sample_size=int(1e4), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax])
     
     period = 1.0
     result_2 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = period, 
-                    max_sample_size=int(1e4), estimator='Natural')
+                    max_sample_size=int(1e4), estimator='Natural', 
+                    approx_cell1_size = [rmax, rmax, rmax])
     
     #should throw an error.  period must be positive!
     period = np.array([1.0,1.0,-1.0])
     try:
         tpcf(sample1, rbins, sample2 = sample2, 
              randoms=randoms, period = period, 
-             max_sample_size=int(1e4), estimator='Natural')
+             max_sample_size=int(1e4), estimator='Natural', 
+             approx_cell1_size = [rmax, rmax, rmax])
     except HalotoolsError:
         pass
     

--- a/halotools/mock_observables/test_clustering/test_tpcf_jackknife.py
+++ b/halotools/mock_observables/test_clustering/test_tpcf_jackknife.py
@@ -20,6 +20,7 @@ sample1 = np.random.random((Npts,3))
 randoms = np.random.random((Npts*10,3))
 period = np.array([1.0,1.0,1.0])
 rbins = np.linspace(0.0,0.3,5).astype(float)
+rmax = rbins.max()
 
 @pytest.mark.slow
 def test_tpcf_jackknife_corr_func():
@@ -27,8 +28,11 @@ def test_tpcf_jackknife_corr_func():
     test the correlation function
     """
     
-    result_1,err = tpcf_jackknife(sample1, randoms, rbins, Nsub=5, period = period, num_threads=1)
-    result_2 = tpcf(sample1, rbins, randoms=randoms, period = period, num_threads=1)
+    result_1,err = tpcf_jackknife(sample1, randoms, rbins, 
+        Nsub=5, period = period, num_threads=1)
+
+    result_2 = tpcf(sample1, rbins,
+        randoms=randoms, period = period, num_threads=1)
     
     assert np.allclose(result_1,result_2,rtol=1e-09), "correlation functions do not match"
 

--- a/halotools/mock_observables/test_clustering/test_tpcf_one_two_halo.py
+++ b/halotools/mock_observables/test_clustering/test_tpcf_one_two_halo.py
@@ -22,28 +22,32 @@ sample2 = np.random.random((Npts,3))
 randoms = np.random.random((Npts*3,3))
 period = np.array([1.0,1.0,1.0])
 rbins = np.linspace(0,0.3,5)
+rmax = rbins.max()
 
+@slow
 def test_tpcf_one_two_halo_auto_periodic():
     """
     test the tpcf_one_two_halo autocorrelation with periodic boundary conditions
     """
     
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2 = None, 
-                                      randoms=None, period = period, 
-                                      max_sample_size=int(1e4), estimator='Natural')
+      randoms=None, period = period, 
+      max_sample_size=int(1e4), estimator='Natural')
     
     assert len(result)==2, "wrong number of correlation functions returned."
 
-
+@slow
 def test_tpcf_one_two_halo_cross_periodic():
     """
     test the tpcf_one_two_halo cross-correlation with periodic boundary conditions
     """
     
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2 = sample2,
-                                      sample2_host_halo_id=IDs2,randoms=None,
-                                      period = period, max_sample_size=int(1e4),
-                                      estimator='Natural')
+      sample2_host_halo_id=IDs2,randoms=None,
+      period = period, max_sample_size=int(1e4),
+      estimator='Natural', approx_cell1_size = [rmax, rmax, rmax], 
+      approx_cell2_size = [rmax, rmax, rmax], 
+      approx_cellran_size = [rmax, rmax, rmax])
     
     assert len(result)==6, "wrong number of correlation functions returned."
 


### PR DESCRIPTION
Runtime on my machine improved from ~100s to ~60s with these changes. The remaining big slow-downs are test_pair_matrix and test_marked_tpcf, as neither of these permit cell_size manipulation. They're all marked as "slow", so the test suite can be run much faster by throwing the appropriate py.test flag. 