### PR TITLE
Make h5py a travis dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
-        - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests matplotlib'
+        - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
@@ -61,6 +61,10 @@ matrix:
         # Try numpy 1.10 - might want to switch this so that 1.10 is *default* and 1.9 is checked here down the road
         - python: 2.7
           env: NUMPY_VERSION=1.10
+
+         # try a version *without* h5py - we need this for RTD
+        - python: 2.7
+          env: CONDA_DEPENDENCIES="'Cython scipy beautifulsoup4 requests matplotlib'
 
     allow_failures:
         - python: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,9 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.10
 
-        # try a version *without* h5py - we need this for RTD
+        # try a version *without* h5py - we need this for readthedocs
         - python: 2.7
-          env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`"
+          env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
     allow_failures:
         - python: 3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        # For this package-template, we include examples of Cython modules,
-        # so Cython is required for testing. If your package does not include
-        # Cython code, you can set CONDA_DEPENDENCIES=''
+        # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
         # Make sure that egg_info works without dependencies
@@ -62,9 +60,9 @@ matrix:
         - python: 2.7
           env: NUMPY_VERSION=1.10
 
-         # try a version *without* h5py - we need this for RTD
+        # try a version *without* h5py - we need this for RTD
         - python: 2.7
-          env: CONDA_DEPENDENCIES="'Cython scipy beautifulsoup4 requests matplotlib'
+          env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`"
 
     allow_failures:
         - python: 3.3


### PR DESCRIPTION
This implements a change to the tests that I discussed earlier today with @aphearin: it adds `h5py` as a dependency for the travis tests.  Testing `h5py` functionality is generally desired because basically the only reason h5py is not a required dependency is because it won't build on RTD.

This also adds an additional Travis build that's the same as the standard py2.7 build *except* that it does *not* have `h5py` this is here to make sure that an "accidental" dependency isn't injected (e.g., a module-level import of `h5py`), as in that case the RTD builds will start failing.