### PR TITLE
Update docs to reflect bs4 and requests being core dependencies

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -60,20 +60,15 @@ Halotools is built upon the following core dependencies:
 
 - `Astropy`_: 1.0 or later
 
+- `BeautifulSoup <http://www.crummy.com/software/BeautifulSoup/>`_: For crawling the web for halo catalogs. 
+
+- `Requests <http://docs.python-requests.org/en/latest/>`_: Also for crawling the web for halo catalogs. 
+
 All of the above come pre-installed with a modern python distribution such as Anaconda. In addition to the above, Halotools also requires the h5py package for fast I/O of large simulated datasets:
 
 - `h5py <http://h5py.org/>`_: 2.5 or later
 
-Optional Dependencies 
------------------------
 
-Some of the features in Halotools are enhanced through the use of additional packages. Although most of the  
-Halotools package will run perfectly fine without them, you will need to install the following software 
-to benefit from the full functionality of the code. 
-
-- `BeautifulSoup <http://www.crummy.com/software/BeautifulSoup/>`_: For crawling the web for halo catalogs. 
-
-- `Requests <http://docs.python-requests.org/en/latest/>`_: Also for crawling the web for halo catalogs. 
 
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -45,11 +45,6 @@ will be automatically handled for you. However, if you installed using setup.py 
 cloning the main repository (currently the only available method), 
 then you will need to be aware of the following dependencies.
 
-Core Dependencies
----------------------
-
-Halotools is built upon the following core dependencies:
-
 - `Python <http://www.python.org/>`_: 2.7.x
 
 - `Numpy <http://www.numpy.org/>`_: 1.9 or later


### PR DESCRIPTION
Now there is no optional dependencies section. 