### PR TITLE
Fix bug in populating mocks at high redshift

### DIFF
--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -46,7 +46,7 @@ class TestHearin15(TestCase):
 		self.highz_toy_halos = self.toy_halo_table[highz_mask]
 		self.lowz_toy_halos = self.toy_halo_table[np.invert(highz_mask)]
 
-		self.halocat = CachedHaloCatalog(preload_halo_table = True)
+		self.halocat = CachedHaloCatalog(preload_halo_table = True, redshift = 0.)
 
 		self.halocat2 = CachedHaloCatalog(preload_halo_table = True, redshift = 2.)
 
@@ -54,31 +54,48 @@ class TestHearin15(TestCase):
 	@pytest.mark.skipif('not APH_MACHINE')
 	def test_Hearin15(self):
 
-		model = PrebuiltHodModelFactory('hearin15', concentration_binning = (1, 35, 5))
+		model = PrebuiltHodModelFactory('hearin15')
 		model.populate_mock(halocat = self.halocat)
 
 	@pytest.mark.slow
 	@pytest.mark.skipif('not APH_MACHINE')
 	def test_Leauthaud11(self):
 
-		model = PrebuiltHodModelFactory('leauthaud11', concentration_binning = (1, 35, 5))
+		model = PrebuiltHodModelFactory('leauthaud11')
 		model.populate_mock(halocat = self.halocat)
 
+	@pytest.mark.slow
+	@pytest.mark.skipif('not APH_MACHINE')
+	def test_Leauthaud11b(self):
+
+		model = PrebuiltHodModelFactory('leauthaud11') 
 		# Test that an attempt to repopulate with a different halocat raises an exception
 		with pytest.raises(HalotoolsError) as exc:
-			model.populate_mock(redshift=2)
-		with pytest.raises(HalotoolsError) as exc:
-			model.populate_mock(simname='consuelo')
-		with pytest.raises(HalotoolsError) as exc:
-			model.populate_mock(halo_finder='bdm')
+			model.populate_mock(redshift=2) #default redshift != 2
 
-		model_highz = PrebuiltHodModelFactory('leauthaud11', redshift = 2., 
-			concentration_binning = (1, 35, 5))
+	@pytest.mark.slow
+	@pytest.mark.skipif('not APH_MACHINE')
+	def test_Leauthaud11c(self):
+
+		model_highz = PrebuiltHodModelFactory('leauthaud11', redshift = 2.)
 		model_highz.populate_mock(halocat = self.halocat2)
+
+	@pytest.mark.slow
+	@pytest.mark.skipif('not APH_MACHINE')
+	def test_Leauthaud11d(self):
+
+		model_highz = PrebuiltHodModelFactory('leauthaud11', redshift = 2.)
+
 		with pytest.raises(HalotoolsError) as exc:
-			model_highz.populate_mock()
+			model_highz.populate_mock(redshift = 0.)
 		with pytest.raises(HalotoolsError) as exc:
 			model_highz.populate_mock(halocat = self.halocat)
+
+	@pytest.mark.slow
+	@pytest.mark.skipif('not APH_MACHINE')
+	def test_Leauthaud11e(self):
+
+		model_highz = PrebuiltHodModelFactory('leauthaud11', redshift = 2.)
 		model_highz.populate_mock(redshift = 2.)
 
 

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -114,6 +114,8 @@ class ModelFactory(object):
         def test_consistency_with_existing_mock(**kwargs):
             if 'redshift' in kwargs:
                 redshift = kwargs['redshift']
+            elif hasattr(self, 'redshift'):
+                redshift = self.redshift
             elif 'halocat' in kwargs:
                 redshift = kwargs['halocat'].redshift
             else:
@@ -146,7 +148,13 @@ class ModelFactory(object):
                 halocat = kwargs['halocat']
                 del kwargs['halocat'] # otherwise the call to the mock factory below has multiple halocat kwargs
             else:
-                halocat = CachedHaloCatalog(**kwargs)
+                if 'redshift' in kwargs:
+                    halocat = CachedHaloCatalog(**kwargs)
+                elif hasattr(self, 'redshift'):
+                    halocat = CachedHaloCatalog(redshift = self.redshift, **kwargs)
+                else:
+                    halocat = CachedHaloCatalog(**kwargs)
+
 
             if hasattr(self, 'redshift'):
                 if abs(self.redshift - halocat.redshift) > 0.05:

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -331,6 +331,8 @@ class ModelFactory(object):
             halocat_kwargs['simname'] = kwargs['simname']
         if 'redshift' in kwargs:
             halocat_kwargs['redshift'] = kwargs['redshift']
+        elif hasattr(self, 'redshift'):
+            halocat_kwargs['redshift'] = self.redshift
         if 'halo_finder' in kwargs:
             halocat_kwargs['halo_finder'] = kwargs['halo_finder']
 
@@ -506,6 +508,8 @@ class ModelFactory(object):
             halocat_kwargs['simname'] = kwargs['simname']
         if 'redshift' in kwargs:
             halocat_kwargs['redshift'] = kwargs['redshift']
+        elif hasattr(self, 'redshift'):
+            halocat_kwargs['redshift'] = self.redshift
         if 'halo_finder' in kwargs:
             halocat_kwargs['halo_finder'] = kwargs['halo_finder']
 

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -227,7 +227,7 @@ class ModelFactory(object):
             will be populated, e.g., `rockstar` or `bdm`. 
             Default is set in `~halotools.sim_manager.sim_defaults`. 
 
-        desired_redshift : float, optional
+        redshift : float, optional
             Redshift of the desired halocat into which mock galaxies will be populated. 
             Default is set in `~halotools.sim_manager.sim_defaults`. 
 
@@ -287,7 +287,7 @@ class ModelFactory(object):
         To control how which simulation is used, you use the same syntax you use to load 
         a `~halotools.sim_manager.CachedHaloCatalog` into memory from your cache directory: 
 
-        >>> r, clustering = model.compute_average_galaxy_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_clustering(simname = 'multidark', redshift=1) # doctest: +SKIP 
 
         You can control the number of mock catalogs that are generated via: 
 
@@ -329,8 +329,8 @@ class ModelFactory(object):
         halocat_kwargs = {}
         if 'simname' in kwargs:
             halocat_kwargs['simname'] = kwargs['simname']
-        if 'desired_redshift' in kwargs:
-            halocat_kwargs['redshift'] = kwargs['desired_redshift']
+        if 'redshift' in kwargs:
+            halocat_kwargs['redshift'] = kwargs['redshift']
         if 'halo_finder' in kwargs:
             halocat_kwargs['halo_finder'] = kwargs['halo_finder']
 
@@ -402,7 +402,7 @@ class ModelFactory(object):
             will be populated, e.g., `rockstar` or `bdm`. 
             Default is set in `~halotools.sim_manager.sim_defaults`. 
 
-        desired_redshift : float, optional
+        redshift : float, optional
             Redshift of the desired halocat into which mock galaxies will be populated. 
             Default is set in `~halotools.sim_manager.sim_defaults`. 
 
@@ -443,7 +443,7 @@ class ModelFactory(object):
         To control how which simulation is used, you use the same syntax you use to load 
         a `~halotools.sim_manager.CachedHaloCatalog` into memory from your cache directory: 
 
-        >>> r, clustering = model.compute_average_galaxy_matter_cross_clustering(simname = 'multidark', desired_redshift=1) # doctest: +SKIP 
+        >>> r, clustering = model.compute_average_galaxy_matter_cross_clustering(simname = 'multidark', redshift=1) # doctest: +SKIP 
 
         You can control the number of mock catalogs that are generated via: 
 
@@ -504,8 +504,8 @@ class ModelFactory(object):
         halocat_kwargs = {}
         if 'simname' in kwargs:
             halocat_kwargs['simname'] = kwargs['simname']
-        if 'desired_redshift' in kwargs:
-            halocat_kwargs['redshift'] = kwargs['desired_redshift']
+        if 'redshift' in kwargs:
+            halocat_kwargs['redshift'] = kwargs['redshift']
         if 'halo_finder' in kwargs:
             halocat_kwargs['halo_finder'] = kwargs['halo_finder']
 


### PR DESCRIPTION
Fix bug related to which simulation/snapshot is populated during calls to the compute_average_galaxy_matter_cross_clustering and compute_average_galaxy_clustering convenience functions. There is also a related bug fix in the populate_mock method. 

Resolves #303  and #304 . 
