### PR TITLE
Support User-Supplied Particle Catalogs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         # Here we list the dependencies to be installed that are in conda
-        - CONDA_DEPENDENCIES='Cython scipy beautifulsoup4 requests matplotlib h5py'
+        - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/docs/quickstart_and_tutorials/tutorials/user_supplied_halo_catalogs.rst
+++ b/docs/quickstart_and_tutorials/tutorials/user_supplied_halo_catalogs.rst
@@ -21,7 +21,7 @@ work with the mock-population factories of Halotools, with or without caching th
 Basic usage of the `~halotools.sim_manager.UserSuppliedHaloCatalog` class
 ============================================================================
 
-In order to put your halo catalog into a standard form recognized by halos, 
+In order to put your halo catalog into a standard form recognized by Halotools, 
 the only thing you need to do is instantiate the 
 `~halotools.sim_manager.UserSuppliedHaloCatalog` class 
 by passing your simulation data and metadata to the constructor. 

--- a/docs/quickstart_and_tutorials/tutorials/working_with_alternative_particle_data.rst
+++ b/docs/quickstart_and_tutorials/tutorials/working_with_alternative_particle_data.rst
@@ -6,5 +6,79 @@
 Instructions for Working with Alternative Particle Data
 **************************************************************
 
+This section of the documentation describes how to 
+put your collection of particles into a standard form 
+and optionally store the particle data in your cache. 
+The :ref:`storing_user_supplied_ptcl_catalog_in_cache` section 
+below describes how to cache your particles for convenient future use. 
+If you do not want to use the Halotools cache system, 
+instead refer to the :ref:`using_user_supplied_ptcl_catalog_without_the_cache` section. 
+
+This tutorial is intended to be read together with the 
+docstring of the `~halotools.sim_manager.UserSuppliedPtclCatalog` class. 
+Please refer to the docstring as you follow the explanation below. 
+
+
+.. _basic_usage_of_user_supplied_ptcl_catalog: 
+
+Basic usage of the `~halotools.sim_manager.UserSuppliedPtclCatalog` class
+============================================================================
+
+In order to put your particle catalog into a standard form recognized by Halotools, 
+the only thing you need to do is instantiate the 
+`~halotools.sim_manager.UserSuppliedPtclCatalog` class 
+by passing your data and metadata to the constructor. 
+Once you have an instance of `~halotools.sim_manager.UserSuppliedPtclCatalog`, 
+the particle data is bound to the ``ptcl_table`` attribute of the instance in the form 
+of an Astropy `~astropy.table.Table`; 
+see the `~astropy.table.Table`documentation  
+for more information about this data structure. 
+Additional metadata about your simulation is also stored as attributes 
+of the `~halotools.sim_manager.UserSuppliedPtclCatalog` instance. 
+The docstring of `~halotools.sim_manager.UserSuppliedPtclCatalog` 
+gives a detailed description of the arguments required by the constructor. 
+
+
+.. _storing_user_supplied_ptcl_catalog_in_cache:
+
+Storing a `~halotools.sim_manager.UserSuppliedPtclCatalog` in cache 
+=======================================================================
+
+All instances of the `~halotools.sim_manager.UserSuppliedPtclCatalog` class 
+have a `~halotools.sim_manager.UserSuppliedPtclCatalog.add_ptclcat_to_cache` 
+method that can be used to store your catalog for convenient future use. 
+If you call this method and no exceptions are raised, from then on 
+you will be able to use this collection of dark matter particles together with 
+the associated `~halotools.sim_manager.CachedHaloCatalog`. 
+The docstring of the `~halotools.sim_manager.UserSuppliedPtclCatalog` class 
+provides an explicit worked example of how to use your 
+particle data together with the `~halotools.sim_manager.CachedHaloCatalog` class. 
+
+
+.. _using_user_supplied_ptcl_catalog_without_the_cache:
+
+Using your particle catalog without the cache
+=======================================================================
+
+None of the functionality of Halotools requires you to use the caching system. 
+The constructor of the `~halotools.sim_manager.UserSuppliedHaloCatalog` class 
+accepts a ``user_supplied_ptclcat`` argument. This argument accepts an 
+instance of the `~halotools.sim_manager.UserSuppliedPtclCatalog` class, 
+allowing you to completely bypass the Halotools cache system. 
+The docstring of the `~halotools.sim_manager.UserSuppliedHaloCatalog` class 
+provides an explicit worked example for this feature. 
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 

--- a/halotools/sim_manager/__init__.py
+++ b/halotools/sim_manager/__init__.py
@@ -17,6 +17,7 @@ from .download_manager import *
 
 from .cached_halo_catalog import CachedHaloCatalog
 from .user_supplied_halo_catalog import UserSuppliedHaloCatalog
+from .user_supplied_ptcl_catalog import UserSuppliedPtclCatalog
 
 from .rockstar_hlist_reader import RockstarHlistReader
 from .tabular_ascii_reader import TabularAsciiReader

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -72,6 +72,15 @@ class CachedHaloCatalog(object):
             Default is set by the ``default_version_name`` variable in the 
             `~halotools.sim_manager.sim_defaults` module. 
 
+        ptcl_version_name : string, optional    
+            Nicknake of the version of the particle catalog associated with 
+            the halos. 
+
+            This argument is typically only used if you have cached your own 
+            particles via the `~halotools.sim_manager.UserSuppliedPtclCatalog` class.
+            Default is set by the ``default_version_name`` variable in the 
+            `~halotools.sim_manager.sim_defaults` module.             
+
         fname : string, optional 
             Absolute path to the location on disk storing the hdf5 file 
             of halo data. If passing ``fname``, do not pass the metadata keys 
@@ -167,6 +176,12 @@ class CachedHaloCatalog(object):
     def _determine_cache_log_entry(self, **kwargs):
         """
         """ 
+        try:
+            self.ptcl_version_name = kwargs['ptcl_version_name']
+            self._default_ptcl_version_name_choice = False
+        except KeyError:
+            self.ptcl_version_name = sim_defaults.default_version_name
+            self._default_ptcl_version_name_choice = True
 
         if 'fname' in kwargs:
             fname = kwargs['fname']
@@ -287,10 +302,10 @@ class CachedHaloCatalog(object):
             raise HalotoolsError(msg)
 
         gen0 = ptcl_table_cache.matching_log_entry_generator(
-            simname = self.simname, version_name = self.version_name, 
+            simname = self.simname, version_name = self.ptcl_version_name, 
             redshift = self.redshift, dz_tol = self._dz_tol)
         gen1 = ptcl_table_cache.matching_log_entry_generator(
-            simname = self.simname, version_name = self.version_name)
+            simname = self.simname, version_name = self.ptcl_version_name)
         gen2 = ptcl_table_cache.matching_log_entry_generator(simname = self.simname)
 
         matching_entries = list(gen0)     
@@ -304,11 +319,11 @@ class CachedHaloCatalog(object):
         else:
             msg += "simname = ``" + str(self.simname) + "``\n"
 
-        if self._default_version_name_choice is True:
-            msg += ("version_name = ``" + str(self.version_name) 
+        if self._default_ptcl_version_name_choice is True:
+            msg += ("ptcl_version_name = ``" + str(self.ptcl_version_name) 
                 + "``  (set by sim_defaults.default_version_name)\n")
         else:
-            msg += "version_name = ``" + str(self.version_name) + "``\n"
+            msg += "ptcl_version_name = ``" + str(self.ptcl_version_name) + "``\n"
 
         if self._default_redshift_choice is True:
             msg += ("redshift = ``" + str(self.redshift) 

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -559,9 +559,44 @@ class CachedHaloCatalog(object):
             else:
                 raise InvalidCacheLogEntry(ptcl_log_entry._cache_safety_message)
 
+    def _enforce_halo_ptcl_catalog_consistency(self, halo_log_entry, ptcl_log_entry):
+        """
+        """
+        halo_fname = halo_log_entry.fname
+        ptcl_fname = ptcl_log_entry.fname
 
+        hf = self.h5py.File(halo_fname)
+        pf = self.h5py.File(ptcl_fname)
 
+        try:
+            assert abs(float(hf.attrs['redshift']) - float(pf.attrs['redshift'])) < 0.001
+        except AssertionError:
+            msg = ("\nYour halo and particle catalogs have inconsistent redshifts:\n\n"
+                "Halo catalog redshift = " + str(hf.attrs['redshift']) + "\n"
+                "Ptcl catalog redshift = " + str(pf.attrs['redshift']) + "\n\n"
+                )
+            raise HalotoolsError(msg)
 
+        try:
+            assert hf.attrs['simname'] == pf.attrs['simname']
+        except AssertionError:
+            msg = ("\nYour halo and particle catalogs have inconsistent simnames:\n\n"
+                "Halo catalog simname = " + str(hf.attrs['simname']) + "\n"
+                "Ptcl catalog simname = " + str(pf.attrs['simname']) + "\n\n"
+                )
+            raise HalotoolsError(msg)
+
+        try:
+            assert abs(float(hf.attrs['Lbox']) - float(pf.attrs['Lbox'])) < 0.01
+        except AssertionError:
+            msg = ("\nYour halo and particle catalogs have inconsistent Lbox:\n\n"
+                "Halo catalog Lbox = " + str(hf.attrs['Lbox']) + "\n"
+                "Ptcl catalog Lbox = " + str(pf.attrs['Lbox']) + "\n\n"
+                )
+            raise HalotoolsError(msg)
+
+        hf.close()
+        pf.close()
 
 
 

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -295,7 +295,7 @@ class CachedHaloCatalog(object):
 
         matching_entries = list(gen0)     
 
-        msg = ("\nYou tried to load a cached halo catalog "
+        msg = ("\nYou tried to load a cached particle catalog "
             "with the following characteristics:\n\n")
 
         if self._default_simname_choice is True:

--- a/halotools/sim_manager/ptcl_table_cache.py
+++ b/halotools/sim_manager/ptcl_table_cache.py
@@ -35,6 +35,9 @@ class PtclTableCache(object):
         else:
             self.log = []
 
+    def update_log_from_current_ascii(self):
+        self.log = self.retrieve_log_from_ascii()
+
     def _overwrite_log_ascii(self, new_log):
         new_log.sort()
         log_table = self._log_table_from_log(new_log)

--- a/halotools/sim_manager/ptcl_table_cache_log_entry.py
+++ b/halotools/sim_manager/ptcl_table_cache_log_entry.py
@@ -234,7 +234,6 @@ class PtclTableCacheLogEntry(object):
                 assert 'x' in keys
                 assert 'y' in keys
                 assert 'z' in keys
-                assert len(keys) >= 5
             except AssertionError:
                 num_failures += 1
                 msg += (str(num_failures)+". The particle table "

--- a/halotools/sim_manager/tests/test_cached_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_cached_halo_catalog.py
@@ -69,6 +69,14 @@ class TestCachedHaloCatalog(TestCase):
     def test_halo_ptcl_consistency(self):
         """
         """
+        type_mismatch_msg = ("\nThe redshift attribute of your particle catalog\n"
+            "is formatted as a float, not a string, \nwhich conflicts with the "
+            "formatting of the redshfit attribute \nof the corresponding halo catalog.\n"
+            "This is due to a now-fixed bug in the production of the \n"
+            "Halotools-provided particle catalogs. \n"
+            "To resolve this, just run the scripts/download_additional_halocat.py script \n"
+            "and throw the -ptcls_only and -overwrite flags")
+
         cache = HaloTableCache()
         for entry in cache.log:
             constructor_kwargs = (
@@ -84,8 +92,16 @@ class TestCachedHaloCatalog(TestCase):
 
                 hf = h5py.File(halo_log_entry.fname)
                 pf = h5py.File(ptcl_log_entry.fname)
+
                 assert hf.attrs['simname'] == pf.attrs['simname']
-                assert hf.attrs['redshift'] == pf.attrs['redshift']
+
+                try:
+                    assert type(hf.attrs['redshift']) == type(pf.attrs['redshift'])
+                except AssertionError:
+                    msg = ("Type error for the redshift attribute of the ``"+hf.attrs['simname']
+                        +"`` simulation.\n")
+                    msg += type_mismatch_msg
+                    raise HalotoolsError(msg)
 
                 hf.close()
                 pf.close()

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -383,15 +383,6 @@ class TestUserSuppliedHaloCatalog(TestCase):
             update_ascii = True,
             delete_corresponding_halo_catalog = True)
 
-    @pytest.mark.skipif('not HAS_H5PY')
-    @pytest.mark.xfail
-    def test_add_ptcl_table_to_cache(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
-            **self.good_halocat_args)
-        halocat.add_ptcl_table_to_cache()
-
-
     def tearDown(self):
         try:
             shutil.rmtree(self.dummy_cache_baseloc)

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -21,6 +21,7 @@ from . import helper_functions
 from astropy.table import Table
 
 from .. import UserSuppliedHaloCatalog
+from ..user_supplied_ptcl_catalog import UserSuppliedPtclCatalog
 from ..halo_table_cache import HaloTableCache
 
 from ...custom_exceptions import HalotoolsError, InvalidCacheLogEntry
@@ -65,7 +66,6 @@ class TestUserSuppliedHaloCatalog(TestCase):
             'y': np.zeros(self.num_ptcl), 
             'z': np.zeros(self.num_ptcl)}
             )
-
 
         self.dummy_cache_baseloc = helper_functions.dummy_cache_baseloc
         try:
@@ -203,43 +203,81 @@ class TestUserSuppliedHaloCatalog(TestCase):
     def test_ptcl_table_exists_when_given_goodargs(self):
    
         # Must have ptcl_table attribute when argument is legitimate
+        ptclcat = UserSuppliedPtclCatalog(
+            x = np.zeros(self.num_ptcl), 
+            y = np.zeros(self.num_ptcl), 
+            z = np.zeros(self.num_ptcl), 
+            Lbox = 200, particle_mass = 100, 
+            redshift = self.redshift
+            )
+
         halocat = UserSuppliedHaloCatalog(
             Lbox = 200, particle_mass = 100, redshift = self.redshift,
-            ptcl_table = self.good_ptcl_table, **self.good_halocat_args)
+            user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
         assert hasattr(halocat, 'ptcl_table')
 
-    def test_min_numptcl_requirement(self):
-        # Must have at least 1e4 particles
-        num_ptcl2 = 1e3
-        ptcl_table2 = Table(
-            {'x': np.zeros(num_ptcl2), 
-            'y': np.zeros(num_ptcl2), 
-            'z': np.zeros(num_ptcl2)}
-            )
-        with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedHaloCatalog(
-                Lbox = 200, particle_mass = 100, redshift = self.redshift,
-                ptcl_table = ptcl_table2, **self.good_halocat_args)
+    def test_ptcl_table_bad_args1(self):
 
-    def test_ptcls_have_zposition(self):
-        # Must have a 'z' column 
-        num_ptcl2 = 1e4
-        ptcl_table2 = Table(
-            {'x': np.zeros(num_ptcl2), 
-            'y': np.zeros(num_ptcl2)}
+        # Must have ptcl_table attribute when argument is legitimate
+        ptclcat = UserSuppliedPtclCatalog(
+            x = np.zeros(self.num_ptcl), 
+            y = np.zeros(self.num_ptcl), 
+            z = np.zeros(self.num_ptcl), 
+            Lbox = 100, particle_mass = 100, 
+            redshift = self.redshift
             )
-        with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedHaloCatalog(
-                Lbox = 200, particle_mass = 100, redshift = self.redshift,
-                ptcl_table = ptcl_table2, **self.good_halocat_args)
 
-    def test_ptcls_are_astropy_table(self):
-        # Data structure must be an astropy table, not an ndarray
-        ptcl_table2 = self.good_ptcl_table.as_array()
-        with pytest.raises(HalotoolsError):
+        with pytest.raises(HalotoolsError) as err:
             halocat = UserSuppliedHaloCatalog(
                 Lbox = 200, particle_mass = 100, redshift = self.redshift,
-                ptcl_table = ptcl_table2, **self.good_halocat_args)
+                user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
+        substr = "Inconsistent values of Lbox"
+        assert substr in err.value.message
+
+    def test_ptcl_table_bad_args2(self):
+
+        # Must have ptcl_table attribute when argument is legitimate
+        ptclcat = UserSuppliedPtclCatalog(
+            x = np.zeros(self.num_ptcl), 
+            y = np.zeros(self.num_ptcl), 
+            z = np.zeros(self.num_ptcl), 
+            Lbox = 200, particle_mass = 200, 
+            redshift = self.redshift
+            )
+
+        with pytest.raises(HalotoolsError) as err:
+            halocat = UserSuppliedHaloCatalog(
+                Lbox = 200, particle_mass = 100, redshift = self.redshift,
+                user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
+        substr = "Inconsistent values of particle_mass"
+        assert substr in err.value.message
+
+    def test_ptcl_table_bad_args3(self):
+
+        # Must have ptcl_table attribute when argument is legitimate
+        ptclcat = UserSuppliedPtclCatalog(
+            x = np.zeros(self.num_ptcl), 
+            y = np.zeros(self.num_ptcl), 
+            z = np.zeros(self.num_ptcl), 
+            Lbox = 200, particle_mass = 200, 
+            redshift = self.redshift + 0.1
+            )
+
+        with pytest.raises(HalotoolsError) as err:
+            halocat = UserSuppliedHaloCatalog(
+                Lbox = 200, particle_mass = 200, redshift = self.redshift,
+                user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
+        substr = "Inconsistent values of redshift"
+        assert substr in err.value.message
+
+    def test_ptcl_table_bad_args4(self):
+
+        with pytest.raises(HalotoolsError) as err:
+            halocat = UserSuppliedHaloCatalog(
+                Lbox = 200, particle_mass = 200, redshift = self.redshift,
+                user_supplied_ptclcat = 98, **self.good_halocat_args)
+        substr = "an instance of UserSuppliedPtclCatalog"
+        assert substr in err.value.message
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache1(self):

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -191,6 +191,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
         * Enforce that ptcl_table input is an Astropy `~astropy.table.Table` object, not a Numpy recarray
         """
+        pass
 
     def test_ptcl_table_dne(self):
         # Must not have a ptcl_table attribute when none is passed

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -186,6 +186,26 @@ class TestUserSuppliedPtclCatalog(TestCase):
         substr = "The directory you are trying to store the file does not exist."
         assert substr in err.value.message
 
+    @pytest.mark.skipif('not HAS_H5PY')
+    def test_add_ptclcat_to_cache3(self):
+    	""" Verify that the .hdf5 extension requirement is enforced.
+    	"""
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+
+        basename = 'abc'
+        fname = os.path.join(self.dummy_cache_baseloc, basename)
+        os.system('touch ' + fname)
+        assert os.path.isfile(fname)
+
+        dummy_string = '  '
+        with pytest.raises(HalotoolsError) as err:
+            ptclcat.add_ptclcat_to_cache(
+                fname, dummy_string, dummy_string, dummy_string, 
+                overwrite = True)
+        substr = "The fname must end with an ``.hdf5`` extension."
+        assert substr in err.value.message
 
 
     def tearDown(self):

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -236,34 +236,6 @@ class TestUserSuppliedPtclCatalog(TestCase):
         assert substr in err.value.message
 
 
-    @pytest.mark.skipif('not HAS_H5PY')
-    def test_add_ptclcat_to_cache5(self):
-    	""" Enforce string representation of metadata 
-    	"""
-        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
-            **self.good_ptclcat_args)
-
-        basename = 'abc.hdf5'
-        fname = os.path.join(self.dummy_cache_baseloc, basename)
-        os.system('touch ' + fname)
-        assert os.path.isfile(fname)
-
-        dummy_string = '  '
-        class Dummy(object):
-            pass
-            
-            def __str__(self):
-                raise TypeError
-        not_representable_as_string = Dummy()
-
-        with pytest.raises(HalotoolsError) as err:
-            ptclcat.add_ptclcat_to_cache(
-                fname, dummy_string, dummy_string, dummy_string, 
-                overwrite = True, some_more_metadata = not_representable_as_string)
-        substr = "keyword is not representable as a string."
-        assert substr in err.value.message
-
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache6(self):
@@ -283,8 +255,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
         assert 'z' in ptclcat.ptcl_table.keys()
 
         ptclcat.add_ptclcat_to_cache(
-            fname, simname, version_name, processing_notes, 
-            overwrite = True, some_additional_metadata = processing_notes)
+            fname, simname, version_name, processing_notes, overwrite = True)
 
         cache = PtclTableCache()
         assert ptclcat.log_entry in cache.log

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -70,29 +70,41 @@ class TestUserSuppliedPtclCatalog(TestCase):
     def test_particle_mass_requirement(self):
 
         with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedPtclCatalog(Lbox = 200, 
+            ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
                 **self.good_ptclcat_args)
 
     def test_lbox_requirement(self):
 
         with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedPtclCatalog(particle_mass = 200, 
+            ptclcat = UserSuppliedPtclCatalog(particle_mass = 200, 
                 **self.good_ptclcat_args)
 
     def test_ptcls_contained_inside_lbox(self):
 
         with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedPtclCatalog(Lbox = 20, particle_mass = 100, 
+            ptclcat = UserSuppliedPtclCatalog(Lbox = 20, particle_mass = 100, 
                 **self.good_ptclcat_args)
 
     def test_redshift_is_float(self):
 
         with pytest.raises(HalotoolsError) as err:
-            halocat = UserSuppliedPtclCatalog(
+            ptclcat = UserSuppliedPtclCatalog(
                 Lbox = 200, particle_mass = 100, redshift = '1.0', 
                 **self.good_ptclcat_args)
         substr = "The ``redshift`` metadata must be a float."
         assert substr in err.value.message
+
+
+    def test_successful_load(self):
+
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+        assert hasattr(ptclcat, 'Lbox')
+        assert ptclcat.Lbox == 200
+        assert hasattr(ptclcat, 'particle_mass')
+        assert ptclcat.particle_mass == 100
+
 
     def tearDown(self):
         try:

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -133,7 +133,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
                 particle_mass = 100, redshift = self.redshift,
                 **bad_ptclcat_args)
 
-    def test_has_halo_x_column(self):
+    def test_has_x_column(self):
         # must have x column 
         bad_ptclcat_args = deepcopy(self.good_ptclcat_args)
         with pytest.raises(HalotoolsError):
@@ -141,6 +141,35 @@ class TestUserSuppliedPtclCatalog(TestCase):
             ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
                 particle_mass = 100, redshift = self.redshift,
                 **bad_ptclcat_args)
+
+
+    @pytest.mark.skipif('not HAS_H5PY')
+    def test_add_ptclcat_to_cache1(self):
+    	""" Verify the overwrite requirement is enforced
+    	"""
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+
+        basename = 'abc'
+        fname = os.path.join(self.dummy_cache_baseloc, basename)
+        os.system('touch ' + fname)
+        assert os.path.isfile(fname)
+
+        dummy_string = '  '
+        with pytest.raises(HalotoolsError) as err:
+            ptclcat.add_ptclcat_to_cache(
+                fname, dummy_string, dummy_string, dummy_string)
+        substr = "Either choose a different fname or set ``overwrite`` to True"
+        assert substr in err.value.message
+
+        with pytest.raises(HalotoolsError) as err:
+            ptclcat.add_ptclcat_to_cache(
+                fname, dummy_string, dummy_string, dummy_string, 
+                overwrite = True)
+        assert substr not in err.value.message
+
+
 
 
     def tearDown(self):

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -169,6 +169,22 @@ class TestUserSuppliedPtclCatalog(TestCase):
                 overwrite = True)
         assert substr not in err.value.message
 
+    @pytest.mark.skipif('not HAS_H5PY')
+    def test_add_ptclcat_to_cache2(self):
+    	""" Verify that the appropriate message is issued when trying to save the file to a non-existent directory.
+    	""" 
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+
+        basename = 'abc'
+
+        dummy_string = '  '
+        with pytest.raises(HalotoolsError) as err:
+            ptclcat.add_ptclcat_to_cache(
+                basename, dummy_string, dummy_string, dummy_string, dummy_string)
+        substr = "The directory you are trying to store the file does not exist."
+        assert substr in err.value.message
 
 
 

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -105,6 +105,24 @@ class TestUserSuppliedPtclCatalog(TestCase):
         assert hasattr(ptclcat, 'particle_mass')
         assert ptclcat.particle_mass == 100
 
+    def test_additional_metadata(self):
+
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift,
+            arnold_schwarzenegger = 'Stick around!', 
+            **self.good_ptclcat_args)
+        assert hasattr(ptclcat, 'arnold_schwarzenegger')
+        assert ptclcat.arnold_schwarzenegger == 'Stick around!'
+
+    def test_all_halo_columns_have_length_nhalos(self):
+
+        # All halo catalog columns must have length-Nhalos
+        bad_ptclcat_args = deepcopy(self.good_ptclcat_args)
+        with pytest.raises(HalotoolsError):
+            bad_ptclcat_args['x'][0] = -1
+            ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+                particle_mass = 100, redshift = self.redshift,
+                **bad_ptclcat_args)
 
     def tearDown(self):
         try:

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -235,6 +235,35 @@ class TestUserSuppliedPtclCatalog(TestCase):
         substr = "must all be strings."
         assert substr in err.value.message
 
+
+    @pytest.mark.skipif('not HAS_H5PY')
+    def test_add_ptclcat_to_cache5(self):
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+
+        basename = 'abc.hdf5'
+        fname = os.path.join(self.dummy_cache_baseloc, basename)
+        os.system('touch ' + fname)
+        assert os.path.isfile(fname)
+
+        dummy_string = '  '
+        class Dummy(object):
+            pass
+            
+            def __str__(self):
+                raise TypeError
+        not_representable_as_string = Dummy()
+
+        with pytest.raises(HalotoolsError) as err:
+            ptclcat.add_ptclcat_to_cache(
+                fname, dummy_string, dummy_string, dummy_string, 
+                overwrite = True, some_more_metadata = not_representable_as_string)
+        substr = "keyword is not representable as a string."
+        assert substr in err.value.message
+
+
+
     def tearDown(self):
         try:
             shutil.rmtree(self.dummy_cache_baseloc)

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -209,7 +209,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache4(self):
-    	""" Enforce string representation of metadata
+    	""" Enforce string representation of positional arguments
     	"""
         ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
             particle_mass = 100, redshift = self.redshift, 
@@ -238,6 +238,8 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache5(self):
+    	""" Enforce string representation of metadata 
+    	"""
         ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
             particle_mass = 100, redshift = self.redshift, 
             **self.good_ptclcat_args)
@@ -262,6 +264,39 @@ class TestUserSuppliedPtclCatalog(TestCase):
         substr = "keyword is not representable as a string."
         assert substr in err.value.message
 
+
+    @pytest.mark.skipif('not HAS_H5PY')
+    def test_add_ptclcat_to_cache6(self):
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+
+        basename = 'abc.hdf5'
+        fname = os.path.join(self.dummy_cache_baseloc, basename)
+
+        simname = 'dummy_simname'
+        version_name = 'dummy_version_name'
+        processing_notes = 'dummy processing notes'
+
+        assert 'x' in ptclcat.ptcl_table.keys()
+        assert 'y' in ptclcat.ptcl_table.keys()
+        assert 'z' in ptclcat.ptcl_table.keys()
+
+        ptclcat.add_ptclcat_to_cache(
+            fname, simname, version_name, processing_notes, 
+            overwrite = True, some_additional_metadata = processing_notes)
+
+        cache = PtclTableCache()
+        assert ptclcat.log_entry in cache.log
+
+        cache.remove_entry_from_cache_log(
+            ptclcat.log_entry.simname, 
+            ptclcat.log_entry.version_name,
+            ptclcat.log_entry.redshift,
+            ptclcat.log_entry.fname, 
+            raise_non_existence_exception = True, 
+            update_ascii = True,
+            delete_corresponding_ptcl_catalog = True)
 
 
     def tearDown(self):

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -124,6 +124,25 @@ class TestUserSuppliedPtclCatalog(TestCase):
                 particle_mass = 100, redshift = self.redshift,
                 **bad_ptclcat_args)
 
+    def test_positions_contained_inside_lbox_alt_test(self):
+        # positions must be < Lbox
+        bad_ptclcat_args = deepcopy(self.good_ptclcat_args)
+        with pytest.raises(HalotoolsError):
+            bad_ptclcat_args['x'][0] = 10000
+            ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+                particle_mass = 100, redshift = self.redshift,
+                **bad_ptclcat_args)
+
+    def test_has_halo_x_column(self):
+        # must have x column 
+        bad_ptclcat_args = deepcopy(self.good_ptclcat_args)
+        with pytest.raises(HalotoolsError):
+            del bad_ptclcat_args['x']
+            ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+                particle_mass = 100, redshift = self.redshift,
+                **bad_ptclcat_args)
+
+
     def tearDown(self):
         try:
             shutil.rmtree(self.dummy_cache_baseloc)

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -207,6 +207,33 @@ class TestUserSuppliedPtclCatalog(TestCase):
         substr = "The fname must end with an ``.hdf5`` extension."
         assert substr in err.value.message
 
+    @pytest.mark.skipif('not HAS_H5PY')
+    def test_add_ptclcat_to_cache4(self):
+    	""" Enforce string representation of metadata
+    	"""
+        ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
+            particle_mass = 100, redshift = self.redshift, 
+            **self.good_ptclcat_args)
+
+        basename = 'abc.hdf5'
+        fname = os.path.join(self.dummy_cache_baseloc, basename)
+        os.system('touch ' + fname)
+        assert os.path.isfile(fname)
+
+        dummy_string = '  '
+        class Dummy(object):
+            pass
+            
+            def __str__(self):
+                raise TypeError
+        not_representable_as_string = Dummy()
+
+        with pytest.raises(HalotoolsError) as err:
+            ptclcat.add_ptclcat_to_cache(
+                fname, not_representable_as_string, dummy_string, dummy_string, 
+                overwrite = True)
+        substr = "must all be strings."
+        assert substr in err.value.message
 
     def tearDown(self):
         try:

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+
+from unittest import TestCase
+import warnings, os, shutil
+
+from astropy.config.paths import _find_home 
+from astropy.tests.helper import remote_data, pytest
+
+try:
+    import h5py 
+    HAS_H5PY = True
+except ImportError:
+    HAS_H5PY = False
+
+import numpy as np 
+from copy import copy, deepcopy 
+
+from . import helper_functions
+
+from astropy.table import Table
+
+from ..user_supplied_ptcl_catalog import UserSuppliedPtclCatalog
+from ..ptcl_table_cache import PtclTableCache
+
+from ...custom_exceptions import HalotoolsError, InvalidCacheLogEntry
+
+### Determine whether the machine is mine
+# This will be used to select tests whose 
+# returned values depend on the configuration 
+# of my personal cache directory files
+aph_home = u'/Users/aphearin'
+detected_home = _find_home()
+if aph_home == detected_home:
+    APH_MACHINE = True
+else:
+    APH_MACHINE = False
+
+__all__ = ('TestUserSuppliedPtclCatalog', )
+
+class TestUserSuppliedPtclCatalog(TestCase):
+    """ Class providing tests of the `~halotools.sim_manager.UserSuppliedPtclCatalog`. 
+    """
+
+    def setUp(self):
+        """ Pre-load various arrays into memory for use by all tests. 
+        """
+        self.Nptcls = 1e4
+        self.Lbox = 100
+        self.redshift = 0.0
+        self.x = np.linspace(0, self.Lbox, self.Nptcls)
+        self.y = np.linspace(0, self.Lbox, self.Nptcls)
+        self.z = np.linspace(0, self.Lbox, self.Nptcls)
+
+        self.good_ptclcat_args = (
+            {'x': self.x, 'y': self.y, 
+            'z': self.z}
+            )
+
+        self.good_ptcl_table = Table(self.good_ptclcat_args)
+
+        self.dummy_cache_baseloc = helper_functions.dummy_cache_baseloc
+
+        try:
+            shutil.rmtree(self.dummy_cache_baseloc)
+        except:
+            pass
+        os.makedirs(self.dummy_cache_baseloc)
+
+    def test_particle_mass_requirement(self):
+
+        with pytest.raises(HalotoolsError):
+            halocat = UserSuppliedPtclCatalog(Lbox = 200, 
+                **self.good_ptclcat_args)
+
+    def test_lbox_requirement(self):
+
+        with pytest.raises(HalotoolsError):
+            halocat = UserSuppliedPtclCatalog(particle_mass = 200, 
+                **self.good_ptclcat_args)
+
+    def test_ptcls_contained_inside_lbox(self):
+
+        with pytest.raises(HalotoolsError):
+            halocat = UserSuppliedPtclCatalog(Lbox = 20, particle_mass = 100, 
+                **self.good_ptclcat_args)
+
+    def test_redshift_is_float(self):
+
+        with pytest.raises(HalotoolsError) as err:
+            halocat = UserSuppliedPtclCatalog(
+                Lbox = 200, particle_mass = 100, redshift = '1.0', 
+                **self.good_ptclcat_args)
+        substr = "The ``redshift`` metadata must be a float."
+        assert substr in err.value.message
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.dummy_cache_baseloc)
+        except:
+            pass
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -275,7 +275,7 @@ class UserSuppliedHaloCatalog(object):
             Nickname of the version of the halo catalog. 
             The ``version_name`` is used as a bookkeeping tool in the cache log.
 
-        processing_notes : string, optional 
+        processing_notes : string 
             String used to provide supplementary notes that will be attached to 
             the hdf5 file storing your halo catalog. 
 

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -380,10 +380,6 @@ class UserSuppliedHaloCatalog(object):
         cache.add_entry_to_cache_log(log_entry, update_ascii = True)
         self.log_entry = log_entry
 
-    def add_ptcl_table_to_cache(self):
-        """ Not implemented yet. 
-        """
-        raise NotImplementedError
 
 
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -74,7 +74,45 @@ class UserSuppliedPtclCatalog(object):
     	return ptcl_table_dict, metadata_dict 
 
     def _test_metadata_dict(self, **metadata_dict):
-    	pass
+        try:
+            assert 'Lbox' in metadata_dict
+            assert custom_len(metadata_dict['Lbox']) == 1
+            assert 'particle_mass' in metadata_dict
+            assert custom_len(metadata_dict['particle_mass']) == 1
+            assert 'redshift' in metadata_dict
+        except AssertionError:
+            msg = ("\nThe UserSuppliedPtclCatalog requires "
+                "keyword arguments ``Lbox``, ``particle_mass`` and ``redshift``\n"
+                "storing scalars that will be interpreted as metadata about the particle catalog.\n")
+            raise HalotoolsError(msg)
+
+        Lbox = metadata_dict['Lbox']
+        assert Lbox > 0, "``Lbox`` must be a positive number"
+
+        try:
+            x, y, z = (
+                self.ptcl_table['x'], 
+                self.ptcl_table['x'], 
+                self.ptcl_table['z']
+                )
+            assert np.all(x >= 0)
+            assert np.all(x <= Lbox)
+            assert np.all(y >= 0)
+            assert np.all(y <= Lbox)
+            assert np.all(z >= 0)
+            assert np.all(z <= Lbox)
+        except AssertionError:
+            msg = ("The ``x``, ``y`` and ``z`` columns must only store arrays\n"
+                "that are bound by 0 and the input ``Lbox``. \n")
+            raise HalotoolsError(msg)
+
+        redshift = metadata_dict['redshift']
+        try:
+            assert type(redshift) == float
+        except AssertionError:
+            msg = ("\nThe ``redshift`` metadata must be a float.\n")
+            raise HalotoolsError(msg)
+
 
     def add_ptclcat_to_cache(self, 
         fname, simname, version_name, processing_notes, 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -146,6 +146,8 @@ class UserSuppliedPtclCatalog(object):
 
 
     def _parse_constructor_kwargs(self, **kwargs):
+        """
+        """
         try:
             x = kwargs['x']
             assert type(x) is np.ndarray 
@@ -217,9 +219,34 @@ class UserSuppliedPtclCatalog(object):
 
 
     def add_ptclcat_to_cache(self, 
-        fname, simname, version_name, processing_notes, 
-        overwrite = False, **additional_metadata):
+        fname, simname, version_name, processing_notes, overwrite = False):
+        """
+        Parameters 
+        ------------
+        fname : string 
+            Absolute path of the file to be stored in cache. 
+            Must conclude with an `.hdf5` extension. 
 
+        simname : string 
+            Nickname of the simulation used as a shorthand way to keep track 
+            of the catalogs in your cache. 
+
+        version_name : string 
+            Nickname of the version of the particle catalog. 
+            The ``version_name`` is used as a bookkeeping tool in the cache log.
+            As described in the `~halotools.sim_manager.UserSuppliedPtclCatalog` docstring, 
+            the version name selected here need not match the version name 
+            of the associated halo catalog. 
+
+        processing_notes : string 
+            String used to provide supplementary notes that will be attached to 
+            the hdf5 file storing your particle data. 
+
+        overwrite : bool, optional 
+            If the chosen ``fname`` already exists, then you must set ``overwrite`` 
+            to True in order to write the file to disk. Default is False. 
+
+        """
         try:
             import h5py 
         except ImportError:
@@ -258,17 +285,6 @@ class UserSuppliedPtclCatalog(object):
                 "and ``processing_notes``\nmust all be strings.")
             raise HalotoolsError(msg)
 
-        for key, value in additional_metadata.iteritems():
-            try:
-                _ = str(value)
-            except:
-                msg = ("\nIf you use ``additional_metadata`` keyword arguments \n"
-                    "to provide supplementary metadata about your catalog, \n"
-                    "all such metadata will be bound to the hdf5 file in the "
-                    "format of a string.\nHowever, the value you bound to the "
-                    "``"+key+"`` keyword is not representable as a string.\n")
-                raise HalotoolsError(msg)
-
         ############################################################
         ## Now write the file to disk and add the appropriate metadata 
 
@@ -290,9 +306,6 @@ class UserSuppliedPtclCatalog(object):
         f.attrs.create('time_catalog_was_originally_cached', time_right_now)
 
         f.attrs.create('processing_notes', str(processing_notes))
-
-        for key, value in additional_metadata.iteritems():
-            f.attrs.create(key, str(value))
 
         f.close()
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -32,7 +32,15 @@ class UserSuppliedPtclCatalog(object):
     
     """
     def __init__(self, **kwargs):
-    	pass
+
+        ptcl_table_dict, metadata_dict = self._parse_constructor_kwargs(**kwargs)
+        self.ptcl_table = Table(ptcl_table_dict)
+
+        self._test_metadata_dict(**metadata_dict)
+        for key, value in metadata_dict.iteritems():
+            setattr(self, key, value)
+
+        self._passively_bind_ptcl_table(**kwargs)
 
 
     def _parse_constructor_kwargs(self, **kwargs):

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -117,7 +117,94 @@ class UserSuppliedPtclCatalog(object):
     def add_ptclcat_to_cache(self, 
         fname, simname, version_name, processing_notes, 
         overwrite = False, **additional_metadata):
-    	pass
+
+        try:
+            import h5py 
+        except ImportError:
+            msg = ("\nYou must have h5py installed if you want to \n"
+                "store your catalog in the Halotools cache. \n")
+            raise HalotoolsError(msg)
+
+        ############################################################
+        ## Perform some consistency checks in the fname
+        if (os.path.isfile(fname)) & (overwrite == False):
+            msg = ("\nYou attempted to store your particle catalog "
+                "in the following location: \n\n" + str(fname) + 
+                "\n\nThis path points to an existing file. \n"
+                "Either choose a different fname or set ``overwrite`` to True.\n")
+            raise HalotoolsError(msg)
+
+        try:
+            dirname = os.path.dirname(fname)
+            assert os.path.exists(dirname)
+        except:
+            msg = ("\nThe directory you are trying to store the file does not exist. \n")
+            raise HalotoolsError(msg)
+
+        if fname[-5:] != '.hdf5':
+            msg = ("\nThe fname must end with an ``.hdf5`` extension.\n")
+            raise HalotoolsError(msg)
+
+        ############################################################
+        ## Perform consistency checks on the remaining log entry attributes
+        try:
+            _ = str(simname)
+            _ = str(version_name)
+            _ = str(processing_notes)
+        except:
+            msg = ("\nThe input ``simname``, ``version_name`` "
+                "and ``processing_notes``\nmust all be strings.")
+            raise HalotoolsError(msg)
+
+        for key, value in additional_metadata.iteritems():
+            try:
+                _ = str(value)
+            except:
+                msg = ("\nIf you use ``additional_metadata`` keyword arguments \n"
+                    "to provide supplementary metadata about your catalog, \n"
+                    "all such metadata will be bound to the hdf5 file in the "
+                    "format of a string.\nHowever, the value you bound to the "
+                    "``"+key+"`` keyword is not representable as a string.\n")
+                raise HalotoolsError(msg)
+
+        ############################################################
+        ## Now write the file to disk and add the appropriate metadata 
+
+        self.ptcl_table.write(fname, path='data', overwrite = overwrite)
+
+        f = h5py.File(fname)
+
+        redshift_string = str(get_redshift_string(self.redshift))
+
+        f.attrs.create('simname', str(simname))
+        f.attrs.create('version_name', str(version_name))
+        f.attrs.create('redshift', redshift_string)
+        f.attrs.create('fname', str(fname))
+
+        f.attrs.create('Lbox', self.Lbox)
+        f.attrs.create('particle_mass', self.particle_mass)
+
+        time_right_now = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        f.attrs.create('time_catalog_was_originally_cached', time_right_now)
+
+        f.attrs.create('processing_notes', str(processing_notes))
+
+        for key, value in additional_metadata.iteritems():
+            f.attrs.create(key, str(value))
+
+        f.close()
+
+        ############################################################
+        # Now that the file is on disk, add it to the cache
+        cache = PtclTableCache()
+
+        log_entry = PtclTableCacheLogEntry(
+            simname = simname, version_name = version_name, 
+            redshift = self.redshift, fname = fname)
+
+        cache.add_entry_to_cache_log(log_entry, update_ascii = True)
+        self.log_entry = log_entry
+
 
 
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -89,7 +89,7 @@ class UserSuppliedPtclCatalog(object):
         whatever the redshift is of the associated halo catalog. Your ``redshift`` 
         should be accurate to four decimal places. 
 
-        Now that we have built a Halotools-formatted particle, we add it to the cache as follows. 
+        Now that we have built a Halotools-formatted particle catalog, we can add it to the cache as follows. 
 
         First choose a relatively permanent location on disk where you will be storing the particle data: 
 
@@ -134,6 +134,10 @@ class UserSuppliedPtclCatalog(object):
         The particle catalog itself is stored in the ``ptcl_table`` attribute, with columns accessed as follows:
 
         >>> array_of_x_positions = halocat.ptcl_table['x'] # doctest: +SKIP
+
+        If you do not wish to store your particle catalog in cache, 
+        see the :ref:`using_user_supplied_ptcl_catalog_without_the_cache` section 
+        of the :ref:`working_with_alternative_particle_data` tutorial. 
 
         """
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -44,10 +44,34 @@ class UserSuppliedPtclCatalog(object):
 
 
     def _parse_constructor_kwargs(self, **kwargs):
-    	return ptcl_table_dict, metadata_dict 
+        try:
+            x = kwargs['x']
+            assert type(x) is np.ndarray 
+            y = kwargs['y']
+            assert type(y) is np.ndarray 
+            z = kwargs['z']
+            assert type(z) is np.ndarray 
 
-    def _test_ptcl_table_dict(self, ptcl_table_dict):
-    	pass
+            Nptcls = custom_len(x)
+            assert Nptcls >= 1e4
+            assert Nptcls == len(y)
+            assert Nptcls == len(z)
+        except KeyError, AssertionError:
+            msg = ("\nThe UserSuppliedHaloCatalog requires ``x``, ``y`` and ``z`` keyword arguments,\n "
+                "each of which must store an ndarray of the same length Nptcls >= 1e4.\n")
+            raise HalotoolsError(msg)
+
+        ptcl_table_dict = (
+            {key: kwargs[key] for key in kwargs 
+            if (type(kwargs[key]) is np.ndarray) 
+            and (custom_len(kwargs[key]) == Nptcls)}
+            )
+
+        metadata_dict = (
+            {key: kwargs[key] for key in kwargs if key not in ptcl_table_dict}
+            )
+
+    	return ptcl_table_dict, metadata_dict 
 
     def _test_metadata_dict(self, **metadata_dict):
     	pass

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -1,0 +1,65 @@
+""" Module containing the UserSuppliedPtclCatalog class. 
+"""
+
+import numpy as np
+import os, sys, urllib2, fnmatch
+from warnings import warn 
+import datetime 
+
+from astropy import cosmology
+from astropy import units as u
+from astropy.table import Table
+
+try:
+    import h5py
+except ImportError:
+    warn("Most of the functionality of the sim_manager "
+        "sub-package requires h5py to be installed,\n"
+        "which can be accomplished either with pip or conda")
+
+from .ptcl_table_cache import PtclTableCache 
+from .ptcl_table_cache_log_entry import PtclTableCacheLogEntry
+from .halo_table_cache_log_entry import get_redshift_string
+
+from ..utils.array_utils import custom_len, convert_to_ndarray
+from ..custom_exceptions import HalotoolsError
+
+__all__ = ('UserSuppliedPtclCatalog', )
+
+class UserSuppliedPtclCatalog(object):
+    """ Class used to transform a user-provided particle catalog 
+    into the standard form recognized by Halotools. 
+    
+    """
+    def __init__(self, **kwargs):
+    	pass
+
+
+    def _parse_constructor_kwargs(self, **kwargs):
+    	return ptcl_table_dict, metadata_dict 
+
+    def _test_ptcl_table_dict(self, ptcl_table_dict):
+    	pass
+
+    def _test_metadata_dict(self, **metadata_dict):
+    	pass
+
+    def add_ptclcat_to_cache(self, 
+        fname, simname, version_name, processing_notes, 
+        overwrite = False, **additional_metadata):
+    	pass
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -57,7 +57,7 @@ class UserSuppliedPtclCatalog(object):
             assert Nptcls == len(y)
             assert Nptcls == len(z)
         except KeyError, AssertionError:
-            msg = ("\nThe UserSuppliedHaloCatalog requires ``x``, ``y`` and ``z`` keyword arguments,\n "
+            msg = ("\nThe UserSuppliedPtclCatalog requires ``x``, ``y`` and ``z`` keyword arguments,\n "
                 "each of which must store an ndarray of the same length Nptcls >= 1e4.\n")
             raise HalotoolsError(msg)
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -40,8 +40,6 @@ class UserSuppliedPtclCatalog(object):
         for key, value in metadata_dict.iteritems():
             setattr(self, key, value)
 
-        self._passively_bind_ptcl_table(**kwargs)
-
 
     def _parse_constructor_kwargs(self, **kwargs):
         try:


### PR DESCRIPTION
This PR introduces the UserSuppliedPtclCatalog class and associated functionality. Users can now obtain their own downsamplings of dark matter particles and use them with Halotools, optionally storing them in cache. This functionality is needed, for example, if users want to use different simulations besides the Halotools-provided ones, or even just different redshifts of the same simulations. This way, users can compute, for example, the galaxy-galaxy lensing signal with both halos and particles that they provide themselves. 