### PR TITLE
factory bugfixes

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -738,6 +738,8 @@ class HodModelFactory(ModelFactory):
                 haloprop_list.append(component_model.prim_haloprop_key)
             if hasattr(component_model, 'sec_haloprop_key'):
                 haloprop_list.append(component_model.sec_haloprop_key)
+            if hasattr(component_model, 'list_of_haloprops_needed'):
+                haloprop_list.extend(component_model.list_of_haloprops_needed)
 
         self._haloprop_list = list(set(haloprop_list))
 

--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -701,31 +701,26 @@ class HodModelFactory(ModelFactory):
     def set_model_redshift(self):
         """ 
         """
-        msg = ("Inconsistency between the redshifts of the component models:\n"
-            "    For gal_type = ``%s``, the %s model has redshift = %.2f.\n"
-            "    For gal_type = ``%s``, the %s model has redshift = %.2f.\n")
 
+        zlist = list(model.redshift for model in self.model_dictionary.values() 
+            if hasattr(model, 'redshift'))
 
-        for component_model in self.model_dictionary.values():
-            gal_type = component_model.gal_type
-
-            if hasattr(component_model, 'redshift'):
-                redshift = component_model.redshift 
-                try:
-                    if redshift != existing_redshift:
-                        t = (gal_type, component_model.__class__.__name__, redshift, 
-                            last_gal_type, last_component.__class__.__name__, existing_redshift)
-                        raise HalotoolsError(msg % t)
-                except NameError:
-                    existing_redshift = redshift 
-
-            last_component = component_model
-            last_gal_type = gal_type
-
-        try:
-            self.redshift = redshift
-        except NameError:
+        if len(set(zlist)) == 0:
             self.redshift = sim_defaults.default_redshift
+        elif len(set(zlist)) == 1:
+            self.redshift = float(zlist[0])
+        else:
+            msg = ("Inconsistency between the redshifts of the component models:\n\n")
+            for model in self.model_dictionary.values():
+                gal_type = model.gal_type
+                clname = model.__class__.__name__
+                if hasattr(model, 'redshift'):
+                    zs = str(model.redshift)
+                    msg += ("For gal_type = ``" + gal_type + "``, the "
+                        +clname+" instance has redshift = " + zs + "\n")
+            raise HalotoolsError(msg)
+
+
 
 
     def build_prim_sec_haloprop_list(self):

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -620,32 +620,26 @@ class SubhaloModelFactory(ModelFactory):
                 warn(missing_calling_sequence_msg % component_model.__class__.__name__)
 
     def set_model_redshift(self):
-        """ Method sets the redshift of the composite model, simultaneously enforcing self-consistency 
-        between the the redshifts of the component models. 
+        """ 
         """
-        msg = ("Inconsistency between the redshifts of the component models:\n"
-            "    For component model 1 = ``%s``, the model has redshift = %.2f.\n"
-            "    For component model 2 = ``%s``, the model has redshift = %.2f.\n")
 
-        # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        zlist = list(model.redshift for model in self.model_dictionary.values() 
+            if hasattr(model, 'redshift'))
 
-            if hasattr(component_model, 'redshift'):
-                redshift = component_model.redshift 
-                try:
-                    if redshift != existing_redshift:
-                        t = (component_model.__class__.__name__, redshift, 
-                            last_component.__class__.__name__, existing_redshift)
-                        raise HalotoolsError(msg % t)
-                except NameError:
-                    existing_redshift = redshift 
-
-            last_component = component_model
-
-        try:
-            self.redshift = redshift
-        except NameError:
+        if len(set(zlist)) == 0:
             self.redshift = sim_defaults.default_redshift
+        elif len(set(zlist)) == 1:
+            self.redshift = float(zlist[0])
+        else:
+            msg = ("Inconsistency between the redshifts of the component models:\n\n")
+            for modelname, model in self.model_dictionary.iteritems():
+                clname = model.__class__.__name__
+                if hasattr(model, 'redshift'):
+                    zs = str(model.redshift)
+                    msg += ("For modelname = ``" + modelname + "``, the "
+                        +clname+" instance has redshift = " + zs + "\n")
+            raise HalotoolsError(msg)
+
 
     def build_prim_sec_haloprop_list(self):
         """ Method builds the ``_haloprop_list`` of strings. 

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -657,6 +657,8 @@ class SubhaloModelFactory(ModelFactory):
                 haloprop_list.append(component_model.prim_haloprop_key)
             if hasattr(component_model, 'sec_haloprop_key'):
                 haloprop_list.append(component_model.sec_haloprop_key)
+            if hasattr(component_model, 'list_of_haloprops_needed'):
+                haloprop_list.extend(component_model.list_of_haloprops_needed)
 
         self._haloprop_list = list(set(haloprop_list))
 

--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -70,6 +70,11 @@ class OccupationComponent(object):
             raise SyntaxError("Any sub-class of OccupationComponent must "
                 "implement a method named %s " % required_method_name)
 
+        try:
+            self.redshift = kwargs['redshift']
+        except KeyError:
+            pass
+
         # The _methods_to_inherit determines which methods will be directly callable 
         # by the composite model built by the HodModelFactory
         try:


### PR DESCRIPTION
This PR fixes a bug in how a composite model determines its redshift from the collection of components, which is now more robust. Component models can now also specify list_of_haloprops_needed. 