### PR TITLE
Fake mock population

### DIFF
--- a/halotools/empirical_models/composite_models/hod_models/tests/test_tinker13.py
+++ b/halotools/empirical_models/composite_models/hod_models/tests/test_tinker13.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
 from unittest import TestCase
-import pytest
+from astropy.tests.helper import pytest
+
 import numpy as np
 from astropy.table import Table
 
 from ....factories import PrebuiltHodModelFactory
 
+from .....sim_manager import FakeSim
 from .....custom_exceptions import *
 
 ### Determine whether the machine is mine
@@ -33,6 +35,19 @@ class TestTinker13(TestCase):
 			quiescent_fraction_abcissa = [1e12, 1e13, 1e14, 1e15], 
 			quiescent_fraction_ordinates = [0.25, 0.5, 0.75, 0.9])
 
+	@pytest.mark.slow
+	def test_tinker13_populate1(self):
+		model = PrebuiltHodModelFactory('tinker13')
+		fake_sim = FakeSim()
+		model.populate_mock(halocat = fake_sim)
+
+	@pytest.mark.slow
+	def test_tinker13_populate2(self):
+		model = PrebuiltHodModelFactory('tinker13')
+		fake_sim = FakeSim()
+		model.populate_mock(simname = 'fake')
+
+	
 
 
 

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -548,7 +548,16 @@ class ModelFactory(object):
         if 'halo_finder' in kwargs:
             halocat_kwargs['halo_finder'] = kwargs['halo_finder']
 
-        halocat = CachedHaloCatalog(preload_halo_table = True, **halocat_kwargs)
+        try:
+            assert kwargs['simname'] == 'fake'
+            use_fake_sim = True
+        except (AssertionError, KeyError):
+            use_fake_sim = False
+
+        if use_fake_sim is True:
+            halocat = FakeSim(num_ptcl=1e5, **halocat_kwargs)
+        else:
+            halocat = CachedHaloCatalog(preload_halo_table = True, **halocat_kwargs)
 
         if 'rbins' in kwargs:
             rbins = kwargs['rbins']

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -116,7 +116,6 @@ class ModelFactory(object):
             "and the halo-finder passed as a keyword argument = ``%s``.\n"
             "You should instantiate a new model object if you wish to switch halo catalogs.")
 
-
         def test_consistency_with_existing_mock(**kwargs):
             if 'redshift' in kwargs:
                 redshift = kwargs['redshift']
@@ -147,20 +146,33 @@ class ModelFactory(object):
             if halo_finder != self.mock.halocat.halo_finder:
                 raise HalotoolsError(inconsistent_halo_finder_error_msg % (self.mock.halocat.halo_finder,halo_finder ))
 
-        if hasattr(self, 'mock'):
-            test_consistency_with_existing_mock(**kwargs)
-        else:
-            if 'halocat' in kwargs.keys():
-                halocat = kwargs['halocat']
-                del kwargs['halocat'] # otherwise the call to the mock factory below has multiple halocat kwargs
-            else:
-                if 'redshift' in kwargs:
-                    halocat = CachedHaloCatalog(**kwargs)
-                elif hasattr(self, 'redshift'):
-                    halocat = CachedHaloCatalog(redshift = self.redshift, **kwargs)
-                else:
-                    halocat = CachedHaloCatalog(**kwargs)
 
+        try:
+            assert kwargs['simname'] == 'fake'
+            use_fake_sim = True
+        except (AssertionError, KeyError):
+            use_fake_sim = False
+
+        if hasattr(self, 'mock'):
+            if use_fake_sim is True:
+                halocat = FakeSim(**kwargs)
+                test_consistency_with_existing_mock(halocat=halocat)
+            else:
+                test_consistency_with_existing_mock(**kwargs)
+        else:
+            if use_fake_sim is True:
+                halocat = FakeSim(**kwargs)
+            else:
+                if 'halocat' in kwargs.keys():
+                    halocat = kwargs['halocat']
+                    del kwargs['halocat'] # otherwise the call to the mock factory below has multiple halocat kwargs
+                else:
+                    if 'redshift' in kwargs:
+                        halocat = CachedHaloCatalog(**kwargs)
+                    elif hasattr(self, 'redshift'):
+                        halocat = CachedHaloCatalog(redshift = self.redshift, **kwargs)
+                    else:
+                        halocat = CachedHaloCatalog(**kwargs)
 
             if hasattr(self, 'redshift'):
                 if abs(self.redshift - halocat.redshift) > 0.05:

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -362,7 +362,16 @@ class ModelFactory(object):
         if 'halo_finder' in kwargs:
             halocat_kwargs['halo_finder'] = kwargs['halo_finder']
 
-        halocat = CachedHaloCatalog(preload_halo_table = True, **halocat_kwargs)
+        try:
+            assert kwargs['simname'] == 'fake'
+            use_fake_sim = True
+        except (AssertionError, KeyError):
+            use_fake_sim = False
+
+        if use_fake_sim is True:
+            halocat = FakeSim(**halocat_kwargs)
+        else:
+            halocat = CachedHaloCatalog(preload_halo_table = True, **halocat_kwargs)
 
         if 'rbins' in kwargs:
             rbins = kwargs['rbins']

--- a/halotools/empirical_models/factories/prebuilt_model_factory.py
+++ b/halotools/empirical_models/factories/prebuilt_model_factory.py
@@ -31,6 +31,7 @@ class PrebuiltSubhaloModelFactory(SubhaloModelFactory):
     * 'smhm_binary_sfr' (see `~halotools.empirical_models.smhm_binary_sfr_model_dictionary`)
 
     """
+    prebuilt_model_nickname_list = ['behroozi10']
 
     def __init__(self, model_nickname, **kwargs):
         """
@@ -142,6 +143,8 @@ class PrebuiltHodModelFactory(HodModelFactory):
     * 'hearin15' (see `~halotools.empirical_models.hearin15_model_dictionary`)
 
     """
+
+    prebuilt_model_nickname_list = ['zheng07', 'leauthaud11', 'tinker13', 'hearin15']
 
     def __init__(self, model_nickname, **kwargs):
         """

--- a/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
@@ -23,9 +23,13 @@ class TestPrebuiltHodModelFactory(TestCase):
         for modelname in PrebuiltHodModelFactory.prebuilt_model_nickname_list:
             model = PrebuiltHodModelFactory(modelname)
             model.populate_mock(simname = 'fake')
+        model.populate_mock(simname = 'fake')
 
     @pytest.mark.slow
     def test_fake_mock_observations1(self):
         for modelname in PrebuiltHodModelFactory.prebuilt_model_nickname_list:
             model = PrebuiltHodModelFactory(modelname)
-            model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')
+            result = model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')
+        result = model.compute_average_galaxy_clustering(
+            num_iterations=1, simname='fake', 
+            gal_type = 'centrals', include_crosscorr = True)

--- a/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
@@ -26,6 +26,6 @@ class TestPrebuiltHodModelFactory(TestCase):
 
     @pytest.mark.slow
     def test_fake_mock_observations1(self):
-        modelname = np.random.choice(PrebuiltHodModelFactory.prebuilt_model_nickname_list)
-        model = PrebuiltHodModelFactory(modelname)
-        model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')
+        for modelname in PrebuiltHodModelFactory.prebuilt_model_nickname_list:
+            model = PrebuiltHodModelFactory(modelname)
+            model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')

--- a/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
@@ -24,3 +24,8 @@ class TestPrebuiltHodModelFactory(TestCase):
             model = PrebuiltHodModelFactory(modelname)
             model.populate_mock(simname = 'fake')
 
+    @pytest.mark.slow
+    def test_fake_mock_observations1(self):
+        modelname = np.random.choice(PrebuiltHodModelFactory.prebuilt_model_nickname_list)
+        model = PrebuiltHodModelFactory(modelname)
+        model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')

--- a/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_hod_model_factory.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+
+from unittest import TestCase
+from astropy.tests.helper import pytest
+
+import numpy as np 
+from copy import copy 
+
+from ...factories import PrebuiltHodModelFactory
+
+
+from ....sim_manager import FakeSim
+from ....custom_exceptions import HalotoolsError
+
+__all__ = ['TestPrebuiltHodModelFactory']
+
+class TestPrebuiltHodModelFactory(TestCase):
+    """ Class providing tests of the `~halotools.empirical_models.PrebuiltHodModelFactory`. 
+    """
+    @pytest.mark.slow
+    def test_fake_mock_population(self):
+        for modelname in PrebuiltHodModelFactory.prebuilt_model_nickname_list:
+            model = PrebuiltHodModelFactory(modelname)
+            model.populate_mock(simname = 'fake')
+

--- a/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
@@ -58,6 +58,12 @@ class TestPrebuiltSubhaloModelFactory(TestCase):
             model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')
         model.compute_average_galaxy_clustering(num_iterations=2, simname='fake')
 
+    @pytest.mark.slow
+    def test_fake_mock_observations2(self):
+        modelname = 'behroozi10'
+        model = PrebuiltSubhaloModelFactory(modelname)
+        model.compute_average_galaxy_matter_cross_clustering(
+            num_iterations=1, simname='fake')
 
 
 

--- a/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
-import pytest 
+from astropy.tests.helper import pytest
 
 import numpy as np 
 from copy import copy 
@@ -35,3 +35,19 @@ class TestPrebuiltSubhaloModelFactory(TestCase):
         """
         model = PrebuiltSubhaloModelFactory('smhm_binary_sfr')
         alt_model = SubhaloModelFactory(**model.model_dictionary)
+
+    @pytest.mark.slow
+    def test_fake_mock_population(self):
+        for modelname in PrebuiltSubhaloModelFactory.prebuilt_model_nickname_list:
+            model = PrebuiltSubhaloModelFactory(modelname)
+            model.populate_mock(simname = 'fake')
+
+
+
+
+
+
+
+
+
+

--- a/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
@@ -51,6 +51,15 @@ class TestPrebuiltSubhaloModelFactory(TestCase):
 
             model2.populate_mock(simname = 'fake', redshift = 2.)
 
+    @pytest.mark.slow
+    def test_fake_mock_observations1(self):
+        for modelname in PrebuiltSubhaloModelFactory.prebuilt_model_nickname_list:
+            model = PrebuiltSubhaloModelFactory(modelname)
+            model.compute_average_galaxy_clustering(num_iterations=1, simname='fake')
+        model.compute_average_galaxy_clustering(num_iterations=2, simname='fake')
+
+
+
 
 
 

--- a/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
@@ -41,6 +41,16 @@ class TestPrebuiltSubhaloModelFactory(TestCase):
         for modelname in PrebuiltSubhaloModelFactory.prebuilt_model_nickname_list:
             model = PrebuiltSubhaloModelFactory(modelname)
             model.populate_mock(simname = 'fake')
+            model.populate_mock(simname = 'fake')
+
+            model2 = PrebuiltSubhaloModelFactory(modelname, redshift=2)
+            with pytest.raises(HalotoolsError) as err:
+                model2.populate_mock(simname = 'fake')
+            substr = "Inconsistency between the model redshift"
+            assert substr in err.value.message
+
+            model2.populate_mock(simname = 'fake', redshift = 2.)
+
 
 
 

--- a/halotools/sim_manager/fake_sim.py
+++ b/halotools/sim_manager/fake_sim.py
@@ -28,7 +28,7 @@ class FakeSim(UserSuppliedHaloCatalog):
 	for calls with the same arguments. 
 	"""
 
-	def __init__(self, num_massbins = 6, num_halos_per_massbin = int(1e3), 
+	def __init__(self, num_massbins = 6, num_halos_per_massbin = int(100), 
 		num_ptcl = int(1e4), seed = 43, redshift = 0., **kwargs):
 		"""
 		Parameters 

--- a/halotools/sim_manager/fake_sim.py
+++ b/halotools/sim_manager/fake_sim.py
@@ -49,7 +49,9 @@ class FakeSim(UserSuppliedHaloCatalog):
 		"""
 		Lbox = 250.0
 		particle_mass = 1.e8
-		simname = 'fake'
+		self.simname = 'fake'
+		self.halo_finder = 'fake'
+		self.version_name = 'dummy_version'
 
 		self.seed = seed
 		np.random.seed(self.seed)

--- a/halotools/sim_manager/fake_sim.py
+++ b/halotools/sim_manager/fake_sim.py
@@ -9,6 +9,7 @@ from astropy.table import Table
 import numpy as np
 
 from .user_supplied_halo_catalog import UserSuppliedHaloCatalog
+from .user_supplied_ptcl_catalog import UserSuppliedPtclCatalog
 
 __all__ = ('FakeSim', )
 
@@ -98,8 +99,11 @@ class FakeSim(UserSuppliedHaloCatalog):
 		pvx = np.random.uniform(-1000, 1000, self.num_ptcl)
 		pvy = np.random.uniform(-1000, 1000, self.num_ptcl)
 		pvz = np.random.uniform(-1000, 1000, self.num_ptcl)
+		ptclcat = UserSuppliedPtclCatalog(
+			Lbox = Lbox, redshift = redshift, particle_mass = particle_mass, 
+			x = px, y = py, z = pz, vx = pvx, vy = pvy, vz = pvz)
+		
 		d = {'x': px, 'y': py, 'z': pz, 'vx': pvx, 'vy': pvy, 'vz': pvz}
-		ptcl_table = Table(d)
 
 
 		UserSuppliedHaloCatalog.__init__(self, 
@@ -118,7 +122,7 @@ class FakeSim(UserSuppliedHaloCatalog):
 			halo_nfw_conc = conc, 
 			halo_vmax = vmax, 
 			halo_vpeak = vpeak, 
-			ptcl_table = ptcl_table
+			user_supplied_ptclcat = ptclcat
 			)
 
 

--- a/halotools/sim_manager/fake_sim.py
+++ b/halotools/sim_manager/fake_sim.py
@@ -29,7 +29,7 @@ class FakeSim(UserSuppliedHaloCatalog):
 	"""
 
 	def __init__(self, num_massbins = 6, num_halos_per_massbin = int(1e3), 
-		num_ptcl = int(1e4), seed = 43, redshift = 0.):
+		num_ptcl = int(1e4), seed = 43, redshift = 0., **kwargs):
 		"""
 		Parameters 
 		----------
@@ -102,7 +102,7 @@ class FakeSim(UserSuppliedHaloCatalog):
 
 		UserSuppliedHaloCatalog.__init__(self, 
 			Lbox = Lbox, particle_mass = particle_mass, 
-			redshift = 0.0, 
+			redshift = redshift, 
 			halo_id = halo_id, 
 			halo_x = x, halo_y = y, halo_z = z, 
 			halo_vx = vx, halo_vy = vy, halo_vz = vz, 


### PR DESCRIPTION
The populate_mock, compute_average_galaxy_clustering, and compute_average_galaxy_matter_cross_clustering methods now support a simname='fake' keyword argument, which is useful for unit-testing. 