### PR TITLE
Mock factory memory improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
         # Here we list the dependencies to be installed that are in conda
-        - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
+        - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib!=1.5.1 h5py'
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'

--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -79,7 +79,7 @@ class HodMockFactory(MockFactory):
             Default is True. 
         """
 
-        super(HodMockFactory, self).__init__(populate=populate, **kwargs)
+        MockFactory.__init__(self, populate=populate, **kwargs)
 
         self.preprocess_halo_catalog()
 

--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -121,7 +121,7 @@ class HodMockFactory(MockFactory):
         # make a conservative mvir completeness cut 
         # This cut can be controlled by changing sim_defaults.Num_ptcl_requirement
         if apply_completeness_cut is True:
-            cutoff_mvir = sim_defaults.Num_ptcl_requirement*self.halocat.particle_mass
+            cutoff_mvir = sim_defaults.Num_ptcl_requirement*self.particle_mass
             mass_cut = (self.halo_table['halo_mvir'] > cutoff_mvir)
             self.halo_table = self.halo_table[mass_cut]
 
@@ -178,11 +178,11 @@ class HodMockFactory(MockFactory):
         # Positions are now assigned to all populations. 
         # Now enforce the periodic boundary conditions for all populations at once
         self.galaxy_table['x'] = model_helpers.enforce_periodicity_of_box(
-            self.galaxy_table['x'], self.halocat.Lbox)
+            self.galaxy_table['x'], self.Lbox)
         self.galaxy_table['y'] = model_helpers.enforce_periodicity_of_box(
-            self.galaxy_table['y'], self.halocat.Lbox)
+            self.galaxy_table['y'], self.Lbox)
         self.galaxy_table['z'] = model_helpers.enforce_periodicity_of_box(
-            self.galaxy_table['z'], self.halocat.Lbox)
+            self.galaxy_table['z'], self.Lbox)
 
         if hasattr(self.model, 'galaxy_selection_func'):
             mask = self.model.galaxy_selection_func(self.galaxy_table)

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -70,7 +70,6 @@ class MockFactory(object):
         # Make any cuts on the halo catalog requested by the model
         try:
             halocat = kwargs['halocat']
-            self.halo_table = halocat.halo_table
             self.model = kwargs['model']
         except KeyError:
             msg = ("\n``halocat`` and ``model`` are required ``MockFactory`` arguments\n")

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -125,8 +125,8 @@ class ModelFactory(object):
                 redshift = kwargs['halocat'].redshift
             else:
                 redshift = sim_defaults.default_redshift
-            if abs(redshift - self.mock.halocat.redshift) > 0.05:
-                raise HalotoolsError(inconsistent_redshift_error_msg % (redshift, self.mock.halocat.redshift))
+            if abs(redshift - self.mock.redshift) > 0.05:
+                raise HalotoolsError(inconsistent_redshift_error_msg % (redshift, self.mock.redshift))
 
             if 'simname' in kwargs:
                 simname = kwargs['simname']
@@ -134,8 +134,8 @@ class ModelFactory(object):
                 simname = kwargs['halocat'].simname
             else:
                 simname = sim_defaults.default_simname
-            if simname != self.mock.halocat.simname:
-                raise HalotoolsError(inconsistent_simname_error_msg % (self.mock.halocat.simname, simname))
+            if simname != self.mock.simname:
+                raise HalotoolsError(inconsistent_simname_error_msg % (self.mock.simname, simname))
 
             if 'halo_finder' in kwargs:
                 halo_finder = kwargs['halo_finder']
@@ -143,8 +143,8 @@ class ModelFactory(object):
                 halo_finder = kwargs['halocat'].halo_finder
             else:
                 halo_finder = sim_defaults.default_halo_finder
-            if halo_finder != self.mock.halocat.halo_finder:
-                raise HalotoolsError(inconsistent_halo_finder_error_msg % (self.mock.halocat.halo_finder,halo_finder ))
+            if halo_finder != self.mock.halo_finder:
+                raise HalotoolsError(inconsistent_halo_finder_error_msg % (self.mock.halo_finder,halo_finder ))
 
 
         try:

--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -50,6 +50,7 @@ class SubhaloMockFactory(MockFactory):
         """
 
         MockFactory.__init__(self, populate = populate, **kwargs)
+        self.halo_table = kwargs['halocat'].halo_table
 
         # Pre-compute any additional halo properties required by the model
         self.preprocess_halo_catalog()

--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -49,7 +49,7 @@ class SubhaloMockFactory(MockFactory):
             with mock galaxies and their observable properties. Default is ``True``. 
         """
 
-        super(SubhaloMockFactory, self).__init__(populate = populate, **kwargs)
+        MockFactory.__init__(self, populate = populate, **kwargs)
 
         # Pre-compute any additional halo properties required by the model
         self.preprocess_halo_catalog()


### PR DESCRIPTION
Previously, when populating mocks, the *entire* halo catalog was bound to the mock object. This memory usage was needless. Now only the rows passing the appropriate cuts are stored, and also only the columns required by the model. This should reduce the dominant source of memory usage of the mock factories factory by a few hundred percent. 

CC @mjvakili - this is a pre-requisite to implementing the sample variance feature we have been discussing, but it should immediately improve the memory leak issue you may have been encountering. 