### PR TITLE
Fix overflowing text in sphinx sidebar

### DIFF
--- a/docs/_static/halotools.css
+++ b/docs/_static/halotools.css
@@ -3,3 +3,9 @@
 div.topbar {
   background-image: url("dm-splatting-large.png");
 }
+
+div.sphinxsidebar {
+  word-wrap: break-word;
+  /* overflow-wrap is the name for word-wrap in the draft CSS3.  Include it for future support */
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
This PR fixes the long-standing problem of long strings in the docs overflowing. Before:
![image](https://cloud.githubusercontent.com/assets/346587/12767533/b12aad16-c9d7-11e5-9560-5aac14f58977.png)

After:
![image](https://cloud.githubusercontent.com/assets/346587/12767536/b49b6594-c9d7-11e5-82fa-1fb217c6d362.png)


I'll issue a PR against the astropy-helpers on this so that it goes more widely, so it might be better to hold off on that if this gets merged in there quickly.  But if you want to do a release or just send around cleaner docs before then, then this can just be merged.