### PR TITLE
Masked population

### DIFF
--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -127,15 +127,32 @@ class HodMockFactory(MockFactory):
         except AttributeError:
             pass
 
-        self.halo_table = Table()
+        self._orig_halo_table = Table()
         for key in self.additional_haloprops:
-            self.halo_table[key] = halo_table[key]
+            self._orig_halo_table[key] = halo_table[key][:]
 
         self.model.build_lookup_tables()
 
     def populate(self, **kwargs):
         """ Method populating halos with mock galaxies. 
+
+        Parameters 
+        ------------
+        masking_function : function, optional 
+            Function object used to place a mask on the halo table prior to 
+            calling the mock generating functions. Calling signature of the 
+            function should be to accept a single positional argument storing 
+            a table, and returning a boolean numpy array that will be used 
+            as a fancy indexing mask. All masked halos will be ignored during 
+            mock population. Default is None. 
         """
+        try:
+            masking_function = kwargs['masking_function']
+            mask = masking_function(self._orig_halo_table)
+            self.halo_table = self._orig_halo_table[mask]
+        except:
+            self.halo_table = self._orig_halo_table
+
         self.allocate_memory()
 
         # Loop over all gal_types in the model 

--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -50,7 +50,7 @@ class HodMockFactory(MockFactory):
 
     """
 
-    def __init__(self, populate=True, **kwargs):
+    def __init__(self, **kwargs):
         """
         Parameters 
         ----------
@@ -68,24 +68,16 @@ class HodMockFactory(MockFactory):
             If ``additional_haloprops`` is set to the string value ``all``, 
             the galaxy table will inherit every halo property in the catalog. Default is None. 
 
-        populate : boolean, optional   
-            If set to ``False``, the class will perform all pre-processing tasks 
-            but will not call the ``model`` to populate the ``galaxy_table`` 
-            with mock galaxies and their observable properties. Default is ``True``. 
-
         apply_completeness_cut : bool, optional 
             If True, only halos passing the mass completeness cut defined in 
             `~halotools.empirical_models.model_defaults` will be used to populate the mock. 
             Default is True. 
         """
 
-        MockFactory.__init__(self, populate=populate, **kwargs)
+        MockFactory.__init__(self, **kwargs)
 
         halocat = kwargs['halocat']
         self.preprocess_halo_catalog(halocat)
-
-        if populate is True:
-            self.populate()
 
     def preprocess_halo_catalog(self, halocat, apply_completeness_cut = True):
         """ Method to pre-process a halo catalog upon instantiation of 

--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -27,7 +27,7 @@ class SubhaloMockFactory(MockFactory):
 
     """
 
-    def __init__(self, populate=True, **kwargs):
+    def __init__(self, **kwargs):
         """
         Parameters 
         ----------
@@ -45,21 +45,14 @@ class SubhaloMockFactory(MockFactory):
             If ``additional_haloprops`` is set to the string value ``all``, 
             the galaxy table will inherit every halo property in the catalog. Default is None. 
 
-        populate : boolean, optional   
-            If set to ``False``, the class will perform all pre-processing tasks 
-            but will not call the ``model`` to populate the ``galaxy_table`` 
-            with mock galaxies and their observable properties. Default is ``True``. 
         """
 
-        MockFactory.__init__(self, populate = populate, **kwargs)
+        MockFactory.__init__(self, **kwargs)
         halocat = kwargs['halocat']
 
         # Pre-compute any additional halo properties required by the model
         self.preprocess_halo_catalog(halocat)
         self.precompute_galprops()
-
-        if populate is True:
-            self.populate()
 
     def preprocess_halo_catalog(self, halocat):
         """ Method to pre-process a halo catalog upon instantiation of the mock object. 

--- a/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+
+from unittest import TestCase
+from astropy.tests.helper import pytest
+
+import numpy as np 
+from copy import copy 
+
+from ....sim_manager import FakeSim
+from ..prebuilt_model_factory import PrebuiltHodModelFactory
+from ....custom_exceptions import HalotoolsError
+
+__all__ = ['TestHodMockFactory']
+
+class TestHodMockFactory(TestCase):
+    """ Class providing tests of the `~halotools.empirical_models.HodMockFactory`. 
+    """
+    
+    @pytest.mark.slow
+    def test_mock_population_mask(self):
+
+    	model = PrebuiltHodModelFactory('zheng07')
+
+    	f100x = lambda t: t['halo_x'] > 100
+    	f150z = lambda t: t['halo_z'] > 150
+
+    	model.populate_mock(simname = 'fake', masking_function = f100x)
+    	assert np.all(model.mock.galaxy_table['halo_x'] > 100)
+    	model.populate_mock(simname = 'fake')
+    	assert np.any(model.mock.galaxy_table['halo_x'] < 100)
+    	model.populate_mock(simname = 'fake', masking_function = f100x)
+    	assert np.all(model.mock.galaxy_table['halo_x'] > 100)
+
+    	model.populate_mock(simname = 'fake', masking_function = f150z)
+    	assert np.all(model.mock.galaxy_table['halo_z'] > 150)
+    	assert np.any(model.mock.galaxy_table['halo_x'] < 100)
+    	model.populate_mock(simname = 'fake')
+    	assert np.any(model.mock.galaxy_table['halo_z'] < 150)
+
+
+
+

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -39,6 +39,9 @@ class CachedHaloCatalog(object):
     See the Examples section below for details on how to 
     access and manipulate this data. 
     """
+    acceptable_kwargs = ('ptcl_version_name', 'fname', 'simname', 
+        'halo_finder', 'redshift', 'version_name', 'dz_tol', 'update_cached_fname', 
+        'preload_halo_table')
 
     def __init__(self, *args, **kwargs):
         """
@@ -197,17 +200,13 @@ class CachedHaloCatalog(object):
             msg = ("\nCachedHaloCatalog only accepts keyword arguments, not position arguments. \n")
             raise HalotoolsError(msg)
 
-        acceptable_kwargs = ('ptcl_version_name', 'fname', 'simname', 
-            'halo_finder', 'redshift', 'version_name', 'dz_tol', 'update_cached_fname', 
-            'preload_halo_table')
-
         for key in kwargs.keys():
             try:
-                assert key in acceptable_kwargs
+                assert key in self.acceptable_kwargs
             except AssertionError:
                 msg = ("\nCachedHaloCatalog got an unexpected keyword ``" + key + "``\n"
                     "The only acceptable keywords are listed below:\n\n")
-                for acceptable_key in acceptable_kwargs:
+                for acceptable_key in self.acceptable_kwargs:
                     msg += "``" + acceptable_key + "``\n"
                 raise HalotoolsError(msg)
 


### PR DESCRIPTION
This PR introduces a new 'masking_function' keyword argument to the populate() method bound to HodMockFactory objects. The masking function can be used to select a specific sub-population of halos in the halo catalog *prior* to calling any of the mock-generating functions. As discussed with @mjvakili and @changhoonhahn, this feature can be exploited to forward model sample variance during a Halotools likelihood analysis by populating randomly selected subvolumes of a simulation. 

This PR is only a baby step towards the full functionality that will be offered when #333 is resolved. 