### PR TITLE
Update helpers to version with fix for overflowing documentation

### DIFF
--- a/docs/_static/halotools.css
+++ b/docs/_static/halotools.css
@@ -3,9 +3,3 @@
 div.topbar {
   background-image: url("dm-splatting-large.png");
 }
-
-div.sphinxsidebar {
-  word-wrap: break-word;
-  /* overflow-wrap is the name for word-wrap in the draft CSS3.  Include it for future support */
-  overflow-wrap: break-word;
-}


### PR DESCRIPTION
This PR just updates halotools' helpers to include the fix from astropy/astrop-helpers#217

This should do the same thing as #331, but using the updated helpers instead of customizing halotools' css.  So this closes #331 (i.e., #331 should not be merged assuming this works).