### PR TITLE
Change version string to 0.1.dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '0.0a0'
+VERSION = '0.1.dev'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
This changes the version to 0.1.dev .  Some parts of the setup function and doc builders assume the version is in-development only if it ends in "dev", so having a "a0" ending might confuse some of them.  At the very least it makes debbuging doc issues easier because it includes the git commit number...

It could also be 0.0.dev if the first release is supposed to be 0.0, though, @aphearin