### PR TITLE
Include 'halo_upid' as default inherited halo column

### DIFF
--- a/halotools/empirical_models/model_defaults.py
+++ b/halotools/empirical_models/model_defaults.py
@@ -58,7 +58,7 @@ galprop_prefix = 'gal_'
 default_haloprop_list_inherited_by_mock = (
     ['halo_id', 'halo_x', 'halo_y', 'halo_z', 
     'halo_vx', 'halo_vy', 'halo_vz', 
-    'halo_mvir', 'halo_rvir']
+    'halo_mvir', 'halo_rvir', 'halo_upid']
     )
 
 prim_haloprop_key = 'halo_mvir'


### PR DESCRIPTION
Change model_defaults.default_haloprop_list_inherited_by_mock to include 'halo_upid' so that subhalo-based mocks can identify centrals/satellites