### PR TITLE
Add catalog_analysis_helpers module 

### DIFF
--- a/halotools/mock_observables/__init__.py
+++ b/halotools/mock_observables/__init__.py
@@ -19,3 +19,4 @@ from .pairwise_velocity_stats import *
 from .isolation_criteria import *
 from .nearest_neighbor import *
 from .void_stats import *
+from .catalog_analysis_helpers import *

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+""" Common functions used when analyzing 
+catalogs of galaxies/halos.
+
+"""
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+
+from copy import deepcopy 
+
+import numpy as np
+from scipy.stats import binned_statistic
+
+from ..custom_exceptions import HalotoolsError
+
+__all__ = ('mean_y_vs_x', )
+
+def mean_y_vs_x(x, y, error_estimator = 'error_on_mean', **kwargs):
+    """
+    Estimate the mean value of the property *y* as a function of *x* 
+    for an input sample of galaxies/halos, 
+    optionally returning an error estimate. 
+
+    The `mean_y_vs_x` function is just a convenience wrapper 
+    around `scipy.stats.binned_statistic` and `np.histogram`. 
+
+    Parameters 
+    -----------
+    x : array_like 
+        Array storing values of the independent variable of the sample. 
+
+    y : array_like 
+        Array storing values of the dependent variable of the sample. 
+
+    bins : array_like, optional 
+        Bins of the input *x*. 
+        Defaults are set by `scipy.stats.binned_statistic`.  
+
+    error_estimator : string, optional 
+        If set to ``error_on_mean``, function will also return an array storing  
+        :math:`\\sigma_{y}/\\sqrt{N}`, where :math:`\\sigma_{y}` is the 
+        standard deviation of *y* in the bin 
+        and :math:`\\sqrt{N}` is the counts in each bin. 
+
+        If set to ``variance``, function will also return an array storing  
+        :math:`\\sigma_{y}`. 
+
+        Default is ``error_on_mean``
+
+    Returns 
+    ----------
+    bin_midpoints : array_like 
+        Midpoints of the *x*-bins. 
+
+    mean : array_like 
+        Mean of *y* estimated in bins 
+
+    err : array_like 
+        Error on *y* estimated in bins
+
+    Examples 
+    ---------
+    >>> from halotools.sim_manager import FakeSim
+    >>> halocat = FakeSim()
+    >>> halos = halocat.halo_table 
+    >>> halo_mass, mean_spin, err = mean_y_vs_x(halos['halo_mvir'], halos['halo_spin'])
+
+    """
+    try:
+        assert error_estimator in ('error_on_mean', 'variance')
+    except AssertionError:
+        msg = ("\nInput ``error_estimator`` must be either "
+            "``error_on_mean`` or ``variance``\n")
+        raise HalotoolsError(msg)
+
+    modified_kwargs = {key:kwargs[key] for key in kwargs if key != 'error_estimator'}
+    result = binned_statistic(x, y, statistic='mean', **modified_kwargs)
+    mean, bin_edges, binnumber = result
+    bin_midpoints = (bin_edges[1:] + bin_edges[:-1])/2.
+
+    modified_kwargs['bins'] = bin_edges
+
+    result = binned_statistic(x, y, statistic=np.std, **modified_kwargs)
+    variance, _, _ = result
+
+    if error_estimator == 'variance':
+        err = variance
+    else:
+        counts = np.histogram(x, bins = bin_edges)
+        err = variance/np.sqrt(counts[0])
+
+    return bin_midpoints, mean, err
+
+
+
+
+
+
+
+

--- a/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
+++ b/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+
+from unittest import TestCase
+from copy import deepcopy 
+
+from collections import Counter
+
+import numpy as np 
+
+from astropy.tests.helper import pytest
+from astropy.table import Table 
+
+from .. import catalog_analysis_helpers as cat_helpers
+
+from ...sim_manager import FakeSim
+
+from ...custom_exceptions import HalotoolsError
+
+__all__ = ['TestCatalogAnalysisHelpers']
+
+class TestCatalogAnalysisHelpers(TestCase):
+    """ Class providing tests of the `~halotools.mock_observables.catalog_analysis_helpers`. 
+    """
+    
+    def setUp(self):
+
+        halocat = FakeSim()
+        self.halo_table = halocat.halo_table
+
+    def test_mean_y_vs_x1(self):
+        abscissa, mean, err = cat_helpers.mean_y_vs_x(
+            self.halo_table['halo_mvir'], self.halo_table['halo_spin'])
+
+    def test_mean_y_vs_x2(self):
+        abscissa, mean, err = cat_helpers.mean_y_vs_x(
+            self.halo_table['halo_mvir'], self.halo_table['halo_spin'], 
+            error_estimator = 'variance')
+
+    def test_mean_y_vs_x3(self):
+        with pytest.raises(HalotoolsError) as err:
+            abscissa, mean, err = cat_helpers.mean_y_vs_x(
+                self.halo_table['halo_mvir'], self.halo_table['halo_spin'], 
+                error_estimator = 'Jose Canseco')
+        substr = "Input ``error_estimator`` must be either"
+        assert substr in err.value.message
+
+    def tearDown(self):
+        del self.halo_table
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This new mock_observables module has just one new function, mean_y_vs_x. 

This gives simple wrapper behavior around `scipy.stats.binned_statistic` and `np.histogram` so that with one line of code you can pass in a sample of *x* and *y* arrays and get <y>(x) in bins, and optionally an estimate of either the Poisson error-on-the-mean or just the variance. 
