### PR TITLE
Add aggregation module to perform group-wise calculations

### DIFF
--- a/halotools/utils/__init__.py
+++ b/halotools/utils/__init__.py
@@ -12,3 +12,4 @@ from .array_utils import *
 from .io_utils import *
 from .table_utils import *
 from .distances import *
+from .aggregation import add_new_table_column

--- a/halotools/utils/aggregation.py
+++ b/halotools/utils/aggregation.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+
+""" Module containing the `add_new_table_column` function 
+the primary engine of the group aggregation calculations. 
+"""
+
+import numpy as np 
+
+from astropy.table import Table 
+
+from ..custom_exceptions import HalotoolsError
+
+__all__ = ('add_new_table_column', )
+
+def add_new_table_column(table, new_colname, new_coltype, grouping_key,  
+    aggregation_function, colnames_needed_by_function, 
+    sorting_keys = None, table_is_already_sorted = False):
+    """
+    Function used to add a new column to an Astropy table by 
+    performing a group-wise calculation on the table elements. 
+
+    The input ``aggregation_function`` operates on the elements 
+    in each group. The value(s) returned by the function 
+    is assigned to the ``new_colname`` column of the group elements. 
+
+    Parameters 
+    ------------
+    table : Astropy `~astropy.table.Table` 
+        Astropy table storing galaxy/halo data 
+
+    new_colname : string 
+        Name of the new column to be added to the input ``table``
+
+    new_coltype = algebraic type
+        Algebraic type used to initialize the new column. Must be 
+        compatible with the usual method for declaring a Numpy data type, 
+        e.g., 'f4' for float, 'f8' for double, 'i8' for long integer, etc.
+
+    grouping_key : string 
+        Column name defining how the elements of the input ``table`` 
+        are arranged into groups
+
+    aggregation_function : function 
+        Function object that operates on the members of each group and 
+        calculates the values stored in ``new_colname`` for the group. 
+        The function must accept *num_colnames_needed* positional 
+        arguments, where *num_colnames_needed* is the length of 
+        the input ``colnames_needed_by_function``. 
+
+    colnames_needed_by_function : list 
+        List of strings of column names of the input ``table``. 
+        The length and order of this sequence must match the 
+        signature of the input ``aggregation_function``. 
+
+    sorting_keys : list, optional 
+        List of columns that defines how the input ``table`` is sorted. 
+        The first element of this list must be the input ``grouping_key``. 
+        Additional list elements define intra-group sorting. 
+        Default is [grouping_key]. 
+
+    table_is_already_sorted : bool, optional 
+        If set to True, `add_new_table_column` will skip the pre-processing 
+        step of sorting the table. This improves performance, 
+        but `add_new_table_column` will return incorrect values 
+        if the table has not been sorted properly. Default is False. 
+
+    Examples 
+    ----------
+    First let's retrieve a Halotools-formatted halo catalog storing 
+    some randomly generated data. 
+
+    >>> from halotools.sim_manager import FakeSim
+    >>> halocat = FakeSim()
+
+    The ``halo_hostid`` is a natural grouping key for a halo table. 
+    Let's use this key to broadcast the host halo mass to all members 
+    of the same host halo. 
+
+    >>> new_colname = 'halo_mhost'
+    >>> new_coltype = 'f4'
+    >>> grouping_key = 'halo_hostid'
+    >>> aggregation_function = lambda x: x[0] # return the value of the first group member
+    >>> colnames_needed_by_function = ['halo_mvir']
+
+    >>> sorting_keys = ['halo_hostid', 'halo_upid'] # upid = -1 for the the host halo, so that hosts occupy the first element in each grouping array
+    >>> add_new_table_column(halocat.halo_table, new_colname, new_coltype, grouping_key, aggregation_function, colnames_needed_by_function, sorting_keys=sorting_keys)
+
+    After calling `add_new_table_column` as above, 
+    the ``halo_table`` has a new column named ``halo_mhost``. 
+
+    We can also use the `add_new_table_column` to compute more complicated quantities. 
+    For example, let's calculate the mean mass-weighted spin of all halo members, 
+    and then broadcast the result to the members. 
+
+    >>> new_colname = 'mass_weighted_spin'
+    >>> new_coltype = 'f4'
+    >>> grouping_key = 'halo_hostid'
+    >>> def avg_mass_weighted_spin(mass, spin): return sum(mass*spin)/float(len(mass))
+    >>> aggregation_function =  avg_mass_weighted_spin
+    >>> colnames_needed_by_function = ['halo_mvir', 'halo_spin'] # In general, order is important here
+    >>> sorting_keys = ['halo_hostid', 'halo_upid'] 
+    >>> add_new_table_column(halocat.halo_table, new_colname, new_coltype, grouping_key, aggregation_function, colnames_needed_by_function, sorting_keys=sorting_keys)
+
+    After calling `add_new_table_column` as above, 
+    the ``halo_table`` has a new column named ``mass_weighted_spin``. 
+
+    """
+    try:
+        assert type(table) == Table 
+    except AssertionError:
+        msg = ("\nThe input ``table`` must be an Astropy `~astropy.table.Table` object\n")
+        raise HalotoolsError(msg)
+
+    try:
+        assert new_colname not in table.keys()
+    except AssertionError:
+        msg = ("\nThe input ``new_colname`` cannot be an existing column of the input ``table``\n")
+        raise HalotoolsError(msg)
+
+    try:
+        assert grouping_key in table.keys()
+    except AssertionError:
+        msg = ("\nThe input ``grouping_key`` must be an existing column of the input ``table``\n")
+        raise HalotoolsError(msg)
+
+    try:
+        assert callable(aggregation_function) is True
+    except AssertionError:
+        msg = ("\nThe input ``aggregation_function`` must be a callable function\n")
+        raise HalotoolsError(msg)
+
+    try:
+        _ = iter(colnames_needed_by_function)
+        for colname in colnames_needed_by_function:
+            assert colname in table.keys()
+    except TypeError:
+        msg = ("\nThe input ``colnames_needed_by_function`` must be an iterable sequence\n")
+        raise HalotoolsError(msg)
+    except AssertionError:
+        if type(colnames_needed_by_function) in (str, unicode):
+            msg = ("\n Your input ``colnames_needed_by_function`` should be a \n"
+                "list of strings, not a single string\n")
+        else:
+            msg = ("\nEach element of the input ``colnames_needed_by_function`` must be \n"
+                "an existing column name of the input ``table``.\n")
+        raise HalotoolsError(msg)
+
+    if sorting_keys == None:
+        sorting_keys = [grouping_key]
+
+    try:
+        _ = iter(sorting_keys)
+        for colname in sorting_keys:
+            assert colname in table.keys()
+    except TypeError:
+        msg = ("\nThe input ``sorting_keys`` must be an iterable sequence\n")
+        raise HalotoolsError(msg)
+    except AssertionError:
+        if type(sorting_keys) in (str, unicode):
+            msg = ("\n Your input ``sorting_keys`` should be a \n"
+                "list of strings, not a single string\n")
+        else:
+            msg = ("\nEach element of the input ``sorting_keys`` must be \n"
+                "an existing column name of the input ``table``.\n")
+        raise HalotoolsError(msg)
+    else:
+        try:
+            assert sorting_keys[0] == grouping_key
+        except AssertionError:
+            msg = ("\nThe first element of the input ``sorting_keys`` must be \n"
+                "equal to the input ``grouping_key``\n")
+            raise HalotoolsError(msg)
+
+
+    if table_is_already_sorted is False:
+        table.sort(sorting_keys)
+
+    group_ids_data, idx_groups_data, group_richness_data = np.unique(
+        table[grouping_key].data, 
+        return_index = True, return_counts = True)
+
+    try:
+        dt = np.dtype([(new_colname, new_coltype)])
+    except TypeError:
+        msg = ("\nThe input ``new_coltype`` must be Numpy-compatible.\n"
+            "In particular, your input must work properly with the following syntax:\n\n"
+            ">>> dt = np.dtype([(new_colname, new_coltype)]) \n\n")
+        raise HalotoolsError(msg)
+    result = np.zeros(len(table), dtype=dt[new_colname])
+
+    func_arglist = [table[key].data for key in colnames_needed_by_function]
+
+    for igroup, host_halo_id in enumerate(group_ids_data):
+        first_igroup_idx = idx_groups_data[igroup]
+        last_igroup_idx = first_igroup_idx + group_richness_data[igroup]
+        group_data_list = [arg[first_igroup_idx:last_igroup_idx] for arg in func_arglist]
+        result[first_igroup_idx:last_igroup_idx] = aggregation_function(*group_data_list)
+
+    table[new_colname] = result
+
+
+

--- a/halotools/utils/tests/test_aggregation.py
+++ b/halotools/utils/tests/test_aggregation.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+
+from unittest import TestCase
+from copy import deepcopy 
+
+from collections import Counter
+
+import numpy as np 
+
+from astropy.tests.helper import pytest
+from astropy.table import Table 
+
+from ..aggregation import add_new_table_column
+
+from ...sim_manager import FakeSim
+
+from ...custom_exceptions import HalotoolsError
+
+__all__ = ['TestAggregation']
+
+# def add_new_table_column(table, new_colname, grouping_key,  
+#   aggregation_function, colnames_needed_by_function, 
+#   sorting_keys = None, table_is_already_sorted = False, 
+#   group_ids = None, idx_groups = None, group_richness = None):
+
+class TestAggregation(TestCase):
+    """ Class providing tests of the `~halotools.utils.aggregation`. 
+    """
+    def setUp(self):
+        fake_sim = FakeSim()
+        self.halo_table = fake_sim.halo_table
+
+    def test_argument_checks1(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'abc'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['abc']
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(5, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The input ``table`` must be an Astropy `~astropy.table.Table`"
+        assert substr in err.value.message
+
+    def test_argument_checks2(self):
+        new_colname = 'halo_mvir'
+        new_coltype = 'f4'
+        grouping_key = 'abc'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['abc']
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The input ``new_colname`` cannot be an existing column of the input ``table``"
+        assert substr in err.value.message
+
+    def test_argument_checks3(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'abc'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['abc']
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The input ``grouping_key`` must be an existing column of the input ``table``"
+        print(err.value.message)
+        assert substr in err.value.message
+        
+    def test_argument_checks4(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = 5
+        colnames_needed_by_function = ['abc']
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The input ``aggregation_function`` must be a callable function"
+        assert substr in err.value.message
+        
+    def test_argument_checks5(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = 3
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The input ``colnames_needed_by_function`` must be an iterable sequence"
+        assert substr in err.value.message
+
+    def test_argument_checks6(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = 'abc'
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "Your input ``colnames_needed_by_function`` should be a"
+        assert substr in err.value.message
+        substr = "list of strings, not a single string"
+        assert substr in err.value.message
+
+    def test_argument_checks7(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['abc']
+        sorting_keys = None
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "Each element of the input ``colnames_needed_by_function`` must be"
+        assert substr in err.value.message
+        substr = "an existing column name of the input ``table``"
+        assert substr in err.value.message
+
+    def test_argument_checks8(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['halo_hostid']
+        sorting_keys = 5
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The input ``sorting_keys`` must be an iterable sequence"
+        assert substr in err.value.message
+
+    def test_argument_checks9(self):
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['halo_hostid']
+        sorting_keys = 'def'
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "Your input ``sorting_keys`` should be a"
+        assert substr in err.value.message
+        substr = "list of strings, not a single string"
+        assert substr in err.value.message
+
+    def test_argument_checks10(self):
+        """ Verify that the aggregation function raises an exception when 
+        an element of the input ``sorting_keys`` is not  
+        an existing column name of the input ``table``
+        """
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['halo_hostid']
+        sorting_keys = ['def']
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "Each element of the input ``sorting_keys`` must be"
+        assert substr in err.value.message
+        substr = "an existing column name of the input ``table``"
+        assert substr in err.value.message
+
+    def test_argument_checks11(self):
+        """ Verify that the aggregation function raises an exception when 
+        the first element of the input ``sorting_keys`` does not equal 
+        the input ``grouping_key``. 
+        """
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: 5
+        colnames_needed_by_function = ['halo_hostid']
+        sorting_keys = ['halo_mvir']
+
+        with pytest.raises(HalotoolsError) as err:
+            _ = add_new_table_column(self.halo_table, new_colname, new_coltype, 
+                grouping_key, aggregation_function, 
+                colnames_needed_by_function, 
+                sorting_keys=sorting_keys)
+        substr = "The first element of the input ``sorting_keys`` must be"
+        assert substr in err.value.message
+        substr = "equal to the input ``grouping_key``"
+        assert substr in err.value.message
+
+    def test_function_correctness1(self):
+        """ Verify that the aggregation function can correctly compute 
+        and broadcast the result of a trivial group-wise function. 
+        """
+        new_colname = 'abc'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: x
+        colnames_needed_by_function = ['halo_hostid']
+        sorting_keys = ['halo_hostid']
+
+        temp_table = deepcopy(self.halo_table)
+        add_new_table_column(
+            temp_table, new_colname, new_coltype, 
+            grouping_key, aggregation_function, 
+            colnames_needed_by_function, 
+            sorting_keys=sorting_keys)
+        assert new_colname in temp_table.keys()
+        assert np.all(temp_table[new_colname] == temp_table[colnames_needed_by_function[0]])
+
+        del temp_table
+
+    def test_function_correctness2(self):
+        """ Verify that the aggregation function can correctly compute 
+        and broadcast the values of the group-wise host halo mass. 
+        """
+        new_colname = 'halo_mhost'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+        aggregation_function = lambda x: x[0]
+        colnames_needed_by_function = ['halo_mvir']
+        sorting_keys = ['halo_hostid', 'halo_upid']
+
+        temp_table = deepcopy(self.halo_table)
+        add_new_table_column(
+            temp_table, new_colname, new_coltype, 
+            grouping_key, aggregation_function, 
+            colnames_needed_by_function, 
+            sorting_keys=sorting_keys)
+        assert new_colname in temp_table.keys()
+
+        host_mask = temp_table['halo_upid'] == -1
+        assert np.allclose(temp_table['halo_mhost'][host_mask], 
+            temp_table['halo_mvir'][host_mask])
+
+        assert np.any(temp_table['halo_mhost'][~host_mask] != 
+            temp_table['halo_mvir'][~host_mask])
+
+        del temp_table
+
+    def test_function_correctness3(self):
+        """ Verify that the aggregation function can correctly compute 
+        and broadcast the values of the group-wise mean mass-weighted spin. 
+        """
+        new_colname = 'mean_mass_weighted_spin'
+        new_coltype = 'f4'
+        grouping_key = 'halo_hostid'
+
+        colnames_needed_by_function = ['halo_mvir', 'halo_spin']
+        sorting_keys = ['halo_hostid']
+
+        def mean_mass_weighted_spin(mass, spin):
+            return sum(mass*spin)/float(len(mass))
+        aggregation_function = mean_mass_weighted_spin
+
+        temp_table = deepcopy(self.halo_table)
+        add_new_table_column(
+            temp_table, new_colname, new_coltype, 
+            grouping_key, aggregation_function, 
+            colnames_needed_by_function, 
+            sorting_keys=sorting_keys)
+        assert new_colname in temp_table.keys()
+
+        data = Counter(temp_table[grouping_key])
+        _ = data.most_common()
+        groupids = np.array([elt[0] for elt in _])
+        richnesses = np.array([elt[1] for elt in _])
+        stride_length = int(len(groupids)/20.)
+
+        for groupid, richness in zip(groupids[::stride_length], richnesses[::stride_length]):
+            idx = np.where(temp_table[grouping_key] == groupid)[0]
+            group = temp_table[idx]
+            assert len(group) == richness
+            correct_result = np.mean(group['halo_mvir']*group['halo_spin'])
+            returned_result = group['mean_mass_weighted_spin'][0]
+            np.testing.assert_approx_equal(correct_result, returned_result)
+        
+        del temp_table
+
+
+
+
+


### PR DESCRIPTION
This PR introduces a new `aggregation` module into `utils`. Currently, this module has just one function, `add_new_table_column`. This function will serve as the engine driving all group-wise calculations, e.g., computing host halo mass, host halo richness, subhalo mass gaps, <Rmem>, and broadcasting the newly computed quantity to the halo members.

 Since `add_new_table_column` accepts an arbitrary callable python object as input, there is a high degree of flexibility for the group-wise calculations this function supports. This flexibility comes at the cost of speed: cython cannot compile an arbitrary unspecified python callable, so the loop over groups is done in pure python. All the same, the algorithm is quite fast as it is based entirely on existing, heavily optimized `Numpy.unique` function. For example, for a table with 10^6 rows, on my laptop the runtime for host halo broadcasting calculations (e.g., Mhost) are just a few hundred ms. CC @andrew-zentner :  this function should be plenty fast enough to use in MCMC-type likelihood analyses using, for example, galaxy group-based statistics. 

@duncandc - the trick to make this fast was to never loop over an astropy column object, but instead loop over the data in its buffer. 
