### PR TITLE
Pre-compute Mhost and hostID upon loading any CachedHaloCatalog

### DIFF
--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -14,6 +14,7 @@ except ImportError:
 
 from ..sim_manager import sim_defaults, supported_sims
 
+from ..utils import broadcast_host_halo_property, add_halo_hostid
 
 from .halo_table_cache import HaloTableCache
 from .ptcl_table_cache import PtclTableCache
@@ -516,9 +517,17 @@ class CachedHaloCatalog(object):
         except AttributeError:
             if self.log_entry.safe_for_cache == True:
                 self._halo_table = Table.read(self.fname, path='data')
+                self._add_new_derived_columns(self._halo_table)
                 return self._halo_table
             else:
                 raise InvalidCacheLogEntry(self.log_entry._cache_safety_message)
+
+    def _add_new_derived_columns(self, t):
+        if 'halo_hostid' not in t.keys():
+            add_halo_hostid(t)
+
+        if 'halo_mvir_host_halo' not in t.keys():
+            broadcast_host_halo_property(t, 'halo_mvir')
 
     def _bind_additional_metadata(self):
         """ Create convenience bindings of all metadata to the `CachedHaloCatalog` instance. 


### PR DESCRIPTION
Now, when any CachedHaloCatalog loads into memory, two halo properties are automatically added to the table (if not already present): 

1. halo_hostID (=-1 for hosts and =upid for subhalos)
2. halo_mvir_host_halo 

Uses the underlying group aggregation engine immediately after reading the table from disk. So halo tables now take another 1-2 seconds to initially load, but now they automatically have halo_hostid and halo_mvir_host_halo columns. Implementation is quite general, as it relies on the abstractly-written aggregation module, so this will naturally extend to requests for additional halo catalog properties as becoming "standard issue". This framework also resolves the problem of having multiple halo catalogs lying around on disk simply because one is a more useful "value-added" version of another. 