### PR TITLE
Fix overflow in RTD docs

### DIFF
--- a/docs/rtd-pip-requirements
+++ b/docs/rtd-pip-requirements
@@ -1,6 +1,5 @@
 numpy
 matplotlib
 Cython
-astropy-helpers
 astropy
 scipy


### PR DESCRIPTION
Despite #340 fixing *local* builds of the docs to no longer have the text overflow, the problem remains on readthedocs.  

Some testing with temporary branches leads me to strongly suspect that the problem is that ``docs/rtd-pip-requirements`` contains ``astropy-helpers``, so the *release* version of the helpers gets used on RTD rather than the version that's packaged with halotools.  This removes the helpers from ``rtd-pip-requirements``, hopefully resolving the overflow problem on RTD (what #340 was supposed to fix).