### PR TITLE
Now adding halo_hostid to all subhalo mocks, if available

### DIFF
--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -63,6 +63,10 @@ class SubhaloMockFactory(MockFactory):
 
         """
         halo_table = halocat.halo_table
+
+        if ( ('halo_hostid' not in self.additional_haloprops) & ('halo_hostid' in halo_table.keys()) ):
+            self.additional_haloprops.append('halo_hostid')
+
         ### Create new columns of the halo catalog, if applicable
         try:
             d = self.model.new_haloprop_func_dict


### PR DESCRIPTION
Having upid and hostid together makes group analysis very easy, so it should be the default behavior to include this column if it is available. 

Together with #355, this PR resolves #287 . 