### PR TITLE
Add documentation for how to put x, y, z arrays into the mock_observables-accepted format

### DIFF
--- a/docs/quickstart_and_tutorials/mock_observations/mock_obs_pos_formatting.rst
+++ b/docs/quickstart_and_tutorials/mock_observations/mock_obs_pos_formatting.rst
@@ -1,0 +1,133 @@
+:orphan:
+
+.. _mock_obs_pos_formatting:
+
+**************************************************************************
+Formatting your xyz coordinates for Mock Observables calculations
+**************************************************************************
+
+The `~halotools.mock_observables` package adopts a specific convention for 
+how its functions accept spatial coordinate inputs. 
+If you have a collection of *Npts* coordinates for either *Ndim=2* or *Ndim=3*, 
+the convention is that you will pass a multi-dimensional Numpy array 
+of shape *(Npts, Ndim)* storing the coordinates. 
+All the `~halotools.mock_observables` functions that operate on multi-dimensional data 
+follow this convention. For example, 
+`~halotools.mock_observables.tpcf`, `~halotools.mock_observables.void_prob_func` 
+and `~halotools.mock_observables.delta_sigma` all accept data formatted as 
+`~numpy.ndarray` of shape *(Npts, 3)*, while `~halotools.mock_observables.angular_tpcf` accepts 
+a `~numpy.ndarray` of shape *(Npts, 2)*. 
+
+Example of how to transform your coordinates
+===============================================
+Suppose you have a collection of *x, y, z* arrays 
+storing the spatial positions of halos or galaxies. 
+
+>>> Npts = 1e5
+>>> Lbox = 250
+>>> x = np.random.uniform(0, Lbox, Npts)
+>>> y = np.random.uniform(0, Lbox, Npts)
+>>> z = np.random.uniform(0, Lbox, Npts)
+
+In order to bundle these arrays into the shape of the multi-dimensional array 
+used by the `~halotools.mock_observables` package:
+
+>>> pos = np.vstack((x, y, z)).T
+
+The ``pos`` array is now formatted in a form that can be directly passed, for example, 
+to the `~halotools.mock_observables.tpcf` function as the first positional argument. 
+
+If you had two-dimensional data instead:
+
+>>> ra = np.random.uniform(0, 2*np.pi, Npts)
+>>> dec = np.random.uniform(-np.pi/2., np.pi/2, Npts)
+>>> angular_coords = np.vstack((ra, dec)).T
+
+The ``angular_coords`` array is now formatted in a form that can be directly passed, for example, 
+to the `~halotools.mock_observables.angular_tpcf` function as the first positional argument. 
+
+Using the `~halotools.mock_observables.return_xyz_formatted_array` convenience function
+=========================================================================================
+
+When using the `~halotools.mock_observables` package, 
+the above transformation is so commonly encountered that there is a convenience function 
+dedicated to handling it:
+
+>>> from halotools.mock_observables import return_xyz_formatted_array
+>>> pos = return_xyz_formatted_array(x, y, z)
+
+There is no difference between using 
+`~halotools.mock_observables.return_xyz_formatted_array` or `numpy.vstack`. 
+However, the `~halotools.mock_observables.return_xyz_formatted_array` function comes 
+with two additional features that are worthy of special mention. 
+
+Applying redshift-space distortions 
+---------------------------------------
+For some science targets, you may wish to apply redshift-space distortions to your 
+coordinates before computing the observable statistic. 
+For example, RSD has a very significant impact on galaxy group identification, 
+and so most applications using the `~halotools.mock_observables.FoFGroups` feature 
+will want to account for this effect. 
+To do, you can use the ``velocity_distortion_dimension`` keyword argument together 
+with the ``velocity`` keyword storing an array with 
+the peculiar velocity in whatever dimension you want to distort:
+
+>>> velz = np.random.normal(loc=0, scale=100, size=Npts)
+>>> pos_zdist = return_xyz_formatted_array(x, y, z, velocity=velz, velocity_distortion_dimension='z')
+
+Under the distant-observer approximation, 
+the ``pos_zdist`` array includes the effect of redshift-space distortions, 
+so that pos_zdist[:, 0] and pos_zdist[:,1] slices 
+can serve as the directions perpendicular to the line-of-sight, 
+and pos_zdist[:, 2] the direction parallel to the line-of-sight. 
+
+Selecting subsamples 
+-----------------------
+There is an additional feature of the 
+`~halotools.mock_observables.return_xyz_formatted_array` function 
+that allows you to retrieve a specific subsample of your coordinates. 
+Let's see how this works in a realistic example: 
+retrieving the spatial positions of quiescent and star-forming samples 
+in a mock galaxy catalog. 
+
+>>> from halotools.empirical_models import PrebuiltSubhaloModelFactory
+>>> model = PrebuiltSubhaloModelFactory('smhm_binary_sfr')
+>>> model.populate_mock(simname = 'fake')
+
+Our ``model`` now has a ``mock`` object attached to it with a ``galaxy_table`` 
+storing the mock galaxies in the form of an Astropy `~astropy.table.Table`. 
+
+>>> x = model.mock.galaxy_table['x']
+>>> y = model.mock.galaxy_table['y']
+>>> z = model.mock.galaxy_table['z']
+
+>>> red_sample_mask = model.mock.galaxy_table['quiescent'] == True
+>>> red_pos = return_xyz_formatted_array(x, y, z, mask = red_sample_mask)
+>>> blue_pos = return_xyz_formatted_array(x, y, z, mask = ~red_sample_mask)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/halotools/mock_observables/angular_tpcf.py
+++ b/halotools/mock_observables/angular_tpcf.py
@@ -31,7 +31,12 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
     """ 
     Calculate the angular two-point correlation function, :math:`w(\\theta)`.
     
-    Example calls to this function appear in the documentation below. For thorough 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` argument.   
+
+    For thorough 
     documentation of all features, see :ref:`angular_tpcf_usage_tutorial`. 
     
     Parameters 

--- a/halotools/mock_observables/delta_sigma.py
+++ b/halotools/mock_observables/delta_sigma.py
@@ -32,8 +32,12 @@ def delta_sigma(galaxies, particles, rp_bins, pi_max, period,
     integrates the result to get :math:`\\Delta\\Sigma(r_p)`.  See the notes for details 
     about the calculation.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`delta_sigma_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``galaxies`` and ``particles`` arguments.   
+
+    For thorough documentation of all features, see :ref:`delta_sigma_usage_tutorial`. 
     
     Parameters
     ----------

--- a/halotools/mock_observables/groups.py
+++ b/halotools/mock_observables/groups.py
@@ -41,6 +41,9 @@ class FoFGroups(object):
         The first two dimensions (x, y) define the plane for perpendicular distances. 
         The third dimension (z) is used for line-of-sight distances.  This is the 
         "distant observer" approximation.
+        See the :ref:`mock_obs_pos_formatting` documentation page for 
+        instructions on how to transform your coordinate position arrays into the 
+        format accepted by the ``positions`` argument.   
         
         Parameters
         ----------

--- a/halotools/mock_observables/isolation_criteria.py
+++ b/halotools/mock_observables/isolation_criteria.py
@@ -26,7 +26,11 @@ def spherical_isolation(sample1, sample2, r_max, period=None,
     """
     Determine whether a set of points, ``sample1``, has a neighbor in ``sample2`` within 
     a spherical volume.
-    
+
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
     Parameters
     ----------
     sample1 : array_like

--- a/halotools/mock_observables/marked_tpcf.py
+++ b/halotools/mock_observables/marked_tpcf.py
@@ -28,8 +28,12 @@ def marked_tpcf(sample1, rbins, sample2=None,
     """ 
     Calculate the real space marked two-point correlation function, :math:`\\mathcal{M}(r)`.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`marked_tpcf_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
+    For thorough documentation of all features, see :ref:`marked_tpcf_usage_tutorial`. 
     
     Parameters 
     ----------

--- a/halotools/mock_observables/mock_survey.py
+++ b/halotools/mock_observables/mock_survey.py
@@ -22,7 +22,10 @@ __author__ = ['Duncan Campbell']
 def distant_observer_redshift(x, v, period=None, cosmo=None):
     """
     Calculate observed redshifts, :math:`z_{\\rm obs}`, assuming the distant observer approximation.
-    
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``x`` and ``v`` arguments.   
+
     The line-of-sight (LOS) is assumed to be the z-direction.
     
     Parameters

--- a/halotools/mock_observables/nearest_neighbor.py
+++ b/halotools/mock_observables/nearest_neighbor.py
@@ -27,6 +27,10 @@ def nearest_neighbor(sample1, sample2, r_max, period=None, nth_nearest=1,
     """
     Find the nearest neighbor between two sets of points.
     
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
     Parameters
     ----------
     sample1 : array_like

--- a/halotools/mock_observables/pairwise_velocity_stats.py
+++ b/halotools/mock_observables/pairwise_velocity_stats.py
@@ -30,8 +30,12 @@ def mean_radial_velocity_vs_r(sample1, velocities1, rbins,
     """ 
     Calculate the mean pairwise velocity, :math:`\\bar{v}_{12}(r)`.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`pairwise_velocity_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
+    For thorough documentation of all features, see :ref:`pairwise_velocity_usage_tutorial`. 
     
     Parameters
     ----------

--- a/halotools/mock_observables/rp_pi_tpcf.py
+++ b/halotools/mock_observables/rp_pi_tpcf.py
@@ -38,8 +38,11 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
     the plane of the sky, and z is the radial distance coordinate.  This is the 'distant 
     observer' approximation.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`rp_pi_tpcf_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+    For thorough documentation of all features, see :ref:`rp_pi_tpcf_usage_tutorial`. 
     
     Parameters 
     ----------

--- a/halotools/mock_observables/s_mu_tpcf.py
+++ b/halotools/mock_observables/s_mu_tpcf.py
@@ -39,8 +39,12 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,\
     the plane of the sky, and z is the radial distance coordinate.  This is the 'distant 
     observer' approximation.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`s_mu_tpcf_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
+    For thorough documentation of all features, see :ref:`s_mu_tpcf_usage_tutorial`. 
     
     Parameters 
     ----------

--- a/halotools/mock_observables/tpcf.py
+++ b/halotools/mock_observables/tpcf.py
@@ -31,8 +31,12 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
     """ 
     Calculate the real space two-point correlation function, :math:`\\xi(r)`.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`tpcf_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
+    For thorough documentation of all features, see :ref:`tpcf_usage_tutorial`. 
     
     Parameters 
     ----------

--- a/halotools/mock_observables/tpcf_jackknife.py
+++ b/halotools/mock_observables/tpcf_jackknife.py
@@ -38,8 +38,12 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5,5,5],\
     volume.  The spatial samples are defined by splitting the box along each dimension, 
     N times, set by the ``Nsub`` argument.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`tpcf_jackknife_usage_tutorial`.
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+
+    For thorough documentation of all features, see :ref:`tpcf_jackknife_usage_tutorial`.
     
     Parameters
     ----------

--- a/halotools/mock_observables/tpcf_one_two_halo_decomp.py
+++ b/halotools/mock_observables/tpcf_one_two_halo_decomp.py
@@ -39,8 +39,12 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
     This returns the correlation function for galaxies which reside in the same halo, and 
     those that reside in seperate halos, as indicated by a host halo ID. 
     
-    example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`tpcf_one_two_halo_decomp_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+    For thorough documentation of all features, 
+    see :ref:`tpcf_one_two_halo_decomp_usage_tutorial`. 
     
     Parameters 
     ----------

--- a/halotools/mock_observables/void_stats.py
+++ b/halotools/mock_observables/void_stats.py
@@ -29,6 +29,10 @@ def void_prob_func(sample1, rbins, n_ran, period, num_threads=1,
     :math:`P_0(r)` is defined as the probability that randomly placed sphere of size 
     :math:`r` contains zero points.
     
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` argument.   
+
     Parameters
     ----------
     sample1 : array_like
@@ -128,7 +132,11 @@ def underdensity_prob_func(sample1, rbins, n_ran, period, u=0.2, num_threads=1,
     
     :math:`P_U(r)` is defined as the probability that a randomly placed sphere of size 
     :math:`r` encompases a volume with less than a specified density.
-    
+
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` argument.   
+
     Parameters
     ----------
     sample1 : array_like

--- a/halotools/mock_observables/wp.py
+++ b/halotools/mock_observables/wp.py
@@ -40,8 +40,11 @@ def wp(sample1, rp_bins, pi_bins, sample2=None, randoms=None, period=None,\
     dimension is used for parallel distances.  i.e. x,y positions are on the plane of the
     sky, and z is the redshift coordinate. This is the 'distant observer' approximation.
     
-    Example calls to this function appear in the documentation below. For thorough 
-    documentation of all features, see :ref:`wp_usage_tutorial`. 
+    Example calls to this function appear in the documentation below. 
+    See the :ref:`mock_obs_pos_formatting` documentation page for 
+    instructions on how to transform your coordinate position arrays into the 
+    format accepted by the ``sample1`` and ``sample2`` arguments.   
+    For thorough documentation of all features, see :ref:`wp_usage_tutorial`. 
     
     Parameters 
     ----------


### PR DESCRIPTION
This PR adds a new docs tutorial page, plus adds links in the mock_observables function docstrings to this tutorial. 