### PR TITLE
Enforce PBCs for velocities of satellites that scatter out of the box

### DIFF
--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -209,15 +209,26 @@ class HodMockFactory(MockFactory):
             func(table = self.galaxy_table[gal_type_slice])
                 
         if self.enforce_PBC is True:
-            self.galaxy_table['x'] = model_helpers.enforce_periodicity_of_box(
-                self.galaxy_table['x'], self.Lbox, 
-                check_multiple_box_lengths = self._testing_mode)
-            self.galaxy_table['y'] = model_helpers.enforce_periodicity_of_box(
-                self.galaxy_table['y'], self.Lbox, 
-                check_multiple_box_lengths = self._testing_mode)
-            self.galaxy_table['z'] = model_helpers.enforce_periodicity_of_box(
-                self.galaxy_table['z'], self.Lbox, 
-                check_multiple_box_lengths = self._testing_mode)
+            self.galaxy_table['x'], self.galaxy_table['vx'] = (
+                model_helpers.enforce_periodicity_of_box(
+                    self.galaxy_table['x'], self.Lbox, 
+                    velocity = self.galaxy_table['vx'], 
+                    check_multiple_box_lengths = self._testing_mode)
+                )
+
+            self.galaxy_table['y'], self.galaxy_table['vy'] = (
+                model_helpers.enforce_periodicity_of_box(
+                    self.galaxy_table['y'], self.Lbox, 
+                    velocity = self.galaxy_table['vy'], 
+                    check_multiple_box_lengths = self._testing_mode)
+                )
+
+            self.galaxy_table['z'], self.galaxy_table['vz'] = (
+                model_helpers.enforce_periodicity_of_box(
+                    self.galaxy_table['z'], self.Lbox, 
+                    velocity = self.galaxy_table['vz'], 
+                    check_multiple_box_lengths = self._testing_mode)
+                )
 
         if hasattr(self.model, 'galaxy_selection_func'):
             mask = self.model.galaxy_selection_func(self.galaxy_table)

--- a/halotools/empirical_models/model_helpers.py
+++ b/halotools/empirical_models/model_helpers.py
@@ -112,7 +112,7 @@ def polynomial_from_table(table_abscissa,table_ordinates,input_abscissa):
     return output_ordinates
 
 def enforce_periodicity_of_box(coords, box_length, 
-    check_multiple_box_lengths = False):
+    check_multiple_box_lengths = False, **kwargs):
     """ Function used to apply periodic boundary conditions 
     of the simulation, so that mock galaxies all lie in the range [0, Lbox].
 
@@ -124,6 +124,11 @@ def enforce_periodicity_of_box(coords, box_length,
         
     box_length : float
         the size of simulation box (currently hard-coded to be Mpc/h units)
+
+    velocity : array_like, optional 
+        velocity in the same dimension as the input coords. 
+        For all coords outside the box, the corresponding velocities 
+        will receive a sign flip. 
 
     check_multiple_box_lengths : bool, optional 
         If True, an exception will be raised if the points span a range 
@@ -147,7 +152,14 @@ def enforce_periodicity_of_box(coords, box_length,
             msg = ("\nThere is at least one input point with a coordinate greater than 2*Lbox\n")
             raise HalotoolsError(msg)
 
-    return coords % box_length
+    try:
+        velocity = kwargs['velocity']
+        outbox = ((coords > box_length) | (coords < 0))
+        newcoords = coords % box_length 
+        new_velocity = np.where(outbox, -velocity, velocity)
+        return newcoords, new_velocity
+    except:
+        return coords % box_length
 
 
 def piecewise_heaviside(bin_midpoints, bin_width, values_inside_bins, value_outside_bins, abscissa):

--- a/halotools/empirical_models/tests/test_model_helpers.py
+++ b/halotools/empirical_models/tests/test_model_helpers.py
@@ -51,6 +51,23 @@ class TestModelHelpers(TestCase):
         newcoords = occuhelp.enforce_periodicity_of_box(x, box_length, 
             check_multiple_box_lengths = True)
 
+    def test_velocity_flip(self):
+        box_length = 250
+        Npts = 1e4
+
+        x = np.linspace(-0.5*box_length, 1.5*box_length, Npts)
+        vx = np.ones(Npts)
+
+        newcoords, newvel = occuhelp.enforce_periodicity_of_box(
+            x, box_length, velocity = vx)
+
+        inbox = ( (x >= 0) & (x <= box_length) )
+        assert np.all(newvel[inbox] == 1.0)
+        assert np.all(newvel[~inbox] == -1.0)
+
+
+
+
 
 
 


### PR DESCRIPTION
Accomplished by adding velocity-flip feature to enforce_periodicity_of_box function in model_helpers