### PR TITLE
Resolve DownloadManager bug for windows users

### DIFF
--- a/halotools/sim_manager/download_manager.py
+++ b/halotools/sim_manager/download_manager.py
@@ -857,13 +857,13 @@ class DownloadManager(object):
         for a in soup.find_all('a', href=True):
             dirpath = posixpath.dirname(urlparse.urlparse(a['href']).path)
             if dirpath and dirpath[0] != '/':
-                simloclist.append(os.path.join(baseurl, dirpath))
+                simloclist.append(baseurl + '/' + dirpath)
 
         catlist = []
         for simloc in simloclist:
             soup = BeautifulSoup(requests.get(simloc).text)
             for a in soup.find_all('a'):
-                catlist.append(os.path.join(simloc, a['href']))
+                catlist.append(simloc + '/' + a['href'])
 
         file_pattern = version_name
         all_ptcl_tables = fnmatch.filter(catlist, '*'+file_pattern + '*.hdf5')
@@ -934,7 +934,7 @@ class DownloadManager(object):
         for a in soup.find_all('a', href=True):
             dirpath = posixpath.dirname(urlparse.urlparse(a['href']).path)
             if dirpath and dirpath[0] != '/':
-                simloclist.append(os.path.join(baseurl, dirpath))
+                simloclist.append(baseurl + '/' + dirpath)
 
         halocatloclist = []
         for simloc in simloclist:
@@ -942,13 +942,13 @@ class DownloadManager(object):
             for a in soup.find_all('a', href=True):
                 dirpath = posixpath.dirname(urlparse.urlparse(a['href']).path)
                 if dirpath and dirpath[0] != '/':
-                    halocatloclist.append(os.path.join(simloc, dirpath))
+                    halocatloclist.append(simloc + '/' + dirpath)
 
         catlist = []
         for halocatdir in halocatloclist:
             soup = BeautifulSoup(requests.get(halocatdir).text)
             for a in soup.find_all('a'):
-                catlist.append(os.path.join(halocatdir, a['href']))
+                catlist.append(halocatdir + '/' + a['href'])
 
         file_pattern = version_name + '.hdf5'
         all_halocats = fnmatch.filter(catlist, '*'+file_pattern)


### PR DESCRIPTION
Bug pointed out by @a-kravtsov. When running `scripts/download_initial_halocat.py`, the DownloadManager does not detect the default halo catalog on the Yale server when being run from a windows machine. There is at least one reason why this behavior should be expected. The Yale server is unix, and so the correct paths to the halo catalogs should be names like "url/dirname/basename.hdf5". However, when the `_processed_halo_tables_available_for_download` of the `DownloadManager` builds the absolute paths using `BeautifulSoup`, the paths are generated using os.path.join(dirname, basename). When run from a windows machine, this will create a path with a name like "url\dirname\basename.hdf5", which will not match any path on the Yale server, and so the `_processed_halo_tables_available_for_download` will return an empty list, triggering a HalotoolsError by the `scripts/download_initial_halocat.py`. 

This PR addresses this bug by hard-coding the path joins to be unix-like, so that the paths will match the Yale Server paths regardless of the platform from which the DownloadManager was run. I do not expect to ever store the halo catalogs on a windows machine, so there should be no harm in this hard-coding. 