### PR TITLE
Removed hard-coding of integer type checking during _safe_for_cache execution

### DIFF
--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -335,18 +335,14 @@ class HaloTableCacheLogEntry(object):
         try:
             data = Table.read(self.fname, path='data')
             try:
-                halo_id = data['halo_id']
-                assert halo_id.dtype == np.int
+                halo_id = data['halo_id'].data
+                assert np.all(halo_id == halo_id.astype(int))
                 assert len(halo_id) == len(set(halo_id))
             except AssertionError:
                 num_failures += 1
                 msg = (str(num_failures)+". The ``halo_id`` column "
                     "must contain a unique set of integers.\n\n"
                     )
-                if halo_id.dtype != np.int:
-                    msg = msg[:-1]
-                    msg += ("Your ``halo_id`` has the incorrect data type.\n"
-                        "Should be ``np.int``, instead got " + str(halo_id.dtype) + "\n\n")
         except:
             pass
 

--- a/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
@@ -365,6 +365,7 @@ class TestHaloTableCacheLogEntry(TestCase):
         bad_table = deepcopy(self.good_table)
         del bad_table['halo_id']
         bad_table['halo_id'] = np.arange(len(bad_table), dtype = float)
+        bad_table['halo_id'][0] = 0.1
         bad_table.write(self.fnames[num_scenario], path='data')
         f = h5py.File(self.fnames[num_scenario])
         for attr in self.hard_coded_log_attrs:
@@ -374,7 +375,7 @@ class TestHaloTableCacheLogEntry(TestCase):
         f.close()
 
         assert log_entry.safe_for_cache == False
-        assert "Your ``halo_id`` has the incorrect data type." in log_entry._cache_safety_message
+        assert "must contain a unique set of integers" in log_entry._cache_safety_message
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_passing_scenario(self):


### PR DESCRIPTION
The `_verify_halo_ids_are_unique` method of the `halo_table_cache_log_entry` module had an unnecessary hard-coded test of integer typing that causes perfectly good halo catalogs to appear as if they are incorrectly typed on a windows platform. 

Bug pointed out by @a-kravtsov