### PR TITLE
Slight modification to halo_id integer dtype testing

### DIFF
--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -336,7 +336,7 @@ class HaloTableCacheLogEntry(object):
             data = Table.read(self.fname, path='data')
             try:
                 halo_id = data['halo_id'].data
-                assert np.all(halo_id == halo_id.astype(int))
+                assert halo_id.dtype.str[1] in ('i','u')
                 assert len(halo_id) == len(set(halo_id))
             except AssertionError:
                 num_failures += 1


### PR DESCRIPTION
This PR attempts to resolve a remaining issue with windows compatibility, #385. The default halo catalog on windows machines fails the `_verify_halo_ids_are_unique` test in `safe_for_cache`, as pointed out by @a-kravtsov. This is most likely because the `halo_id` column stores long integers, and when these are type cast into a python `int`, some of the values get changed. The fix implemented here is to compare the `dtype.str` and ensure that it's an `i` or `u` data type. 