### PR TITLE
Fixed corner case of np.digitize to accommodate the new numpy convention

### DIFF
--- a/halotools/utils/table_utils.py
+++ b/halotools/utils/table_utils.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, division, print_function,
 
 __all__ = ['SampleSelector']
 
+from math import ceil
 import numpy as np
 import collections
 from warnings import warn 
@@ -135,7 +136,7 @@ def compute_conditional_percentiles(**kwargs):
             num_prim_haloprop_bins = (lg10_max_prim_haloprop-lg10_min_prim_haloprop)/dlog10_prim_haloprop
             prim_haloprop_bin_boundaries = np.logspace(
                 lg10_min_prim_haloprop, lg10_max_prim_haloprop, 
-                num=num_prim_haloprop_bins)
+                num=ceil(num_prim_haloprop_bins))
 
         # digitize the masses so that we can access them bin-wise
         output = np.digitize(prim_haloprop, prim_haloprop_bin_boundaries)


### PR DESCRIPTION
Numpy's old convention for passing in an empty array for the bins in np.digitize(array, bins) was to return np.zeros(len(array)). The new convention is to raise an exception. This PR fixes the only Halotools call to np.digitize that was susceptible to this change in corner-case behavior. 