### PR TITLE
Changed default convention of custom_spline. Now default is k=1.

### DIFF
--- a/halotools/empirical_models/assembias_models/heaviside_assembias.py
+++ b/halotools/empirical_models/assembias_models/heaviside_assembias.py
@@ -276,12 +276,12 @@ class HeavisideAssembias(object):
 
         elif self._loginterp is True:
             spline_function = model_helpers.custom_spline(
-                np.log10(self._split_abscissa), self._split_ordinates)
+                np.log10(self._split_abscissa), self._split_ordinates, k=3)
             result = spline_function(np.log10(prim_haloprop))
         else:
             model_abscissa = self._split_abscissa
             spline_function = model_helpers.custom_spline(
-                self._split_abscissa, self._split_ordinates)
+                self._split_abscissa, self._split_ordinates, k=3)
             result = spline_function(prim_haloprop)
 
         return result
@@ -308,7 +308,7 @@ class HeavisideAssembias(object):
         model_ordinates = (self.param_dict[self._get_assembias_param_dict_key(ipar)] 
             for ipar in range(len(self._assembias_strength_abscissa)))
         spline_function = model_helpers.custom_spline(
-            self._assembias_strength_abscissa, list(model_ordinates))
+            self._assembias_strength_abscissa, list(model_ordinates), k=3)
 
         if self._loginterp is True:
             result = spline_function(np.log10(prim_haloprop))

--- a/halotools/empirical_models/model_helpers.py
+++ b/halotools/empirical_models/model_helpers.py
@@ -240,7 +240,8 @@ def custom_spline(table_abscissa, table_ordinates, **kwargs):
         ordinate values defining the interpolation 
 
     k : int, optional
-        Degree of the desired spline interpolation
+        Degree of the desired spline interpolation. 
+        Default is 1. 
 
     Returns 
     -------
@@ -270,7 +271,7 @@ def custom_spline(table_abscissa, table_ordinates, **kwargs):
     if 'k' in kwargs:
         k = np.min([custom_len(table_abscissa)-1, kwargs['k'], max_scipy_spline_degree])
     else:
-        k = np.min([custom_len(table_abscissa)-1, max_scipy_spline_degree])
+        k = 1
 
     if k<0:
         raise HalotoolsError("Spline degree must be non-negative")

--- a/halotools/empirical_models/phase_space_models/monte_carlo_helpers.py
+++ b/halotools/empirical_models/phase_space_models/monte_carlo_helpers.py
@@ -147,12 +147,12 @@ class MonteCarloGalProf(object):
             for ii, items in enumerate(product(*profile_params_list)):
                 table_ordinates = self.cumulative_mass_PDF(radius_array,*items)
                 log_table_ordinates = np.log10(table_ordinates)
-                funcobj = custom_spline(log_table_ordinates, self.logradius_array, k=4)
+                funcobj = custom_spline(log_table_ordinates, self.logradius_array, k=3)
                 func_table.append(funcobj)
 
                 velocity_table_ordinates = self.dimensionless_radial_velocity_dispersion(
                     radius_array, *items)
-                velocity_funcobj = custom_spline(self.logradius_array, velocity_table_ordinates)
+                velocity_funcobj = custom_spline(self.logradius_array, velocity_table_ordinates, k=3)
                 velocity_func_table.append(velocity_funcobj)
                 # Print a message for the expected runtime of the table build
                 if ii == 9:

--- a/halotools/empirical_models/phase_space_models/tests/test_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/tests/test_phase_space.py
@@ -187,15 +187,6 @@ class TestNFWPhaseSpace(TestCase):
         assert np.all(norm10a < 2*r)
      
         t = Table({'c': self.c15})
-        # with pytest.raises(HalotoolsError) as exc:
-        #     x, y, z = self.nfw.mc_halo_centric_pos(
-        #     halo_radius=halo_radius, profile_params=[self.c10], seed=43, table = t)
-        # t['host_centric_distance'] = 0.
-        # x, y, z = self.nfw.mc_halo_centric_pos(
-        #     halo_radius=halo_radius, profile_params=[self.c10], seed=43, table = t)
-        # norm = t['host_centric_distance']
-        # assert np.all(norm > 0)
-        # assert np.all(norm < halo_radius)
 
     def test_mc_pos(self):
         """ Method used to test `~halotools.empirical_models.NFWPhaseSpace.mc_halo_centric_pos`. 


### PR DESCRIPTION
This is the appropriate convention for simple linear interpolation through the abscissa, which is the most common usage of this wrapper. Suggestion due to @yyao. 