### PR TITLE
Add precompute_RR feature into tpcf

### DIFF
--- a/halotools/mock_observables/test_clustering/test_tpcf.py
+++ b/halotools/mock_observables/test_clustering/test_tpcf.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
 import sys
+from multiprocessing import cpu_count 
 
 from ..tpcf import tpcf
 from ...custom_exceptions import *
@@ -278,4 +279,255 @@ def test_tpcf_cross_consistency_w_auto():
                                           
     assert np.allclose(result1,result1_p), "cross mode and auto mode are not the same"
     assert np.allclose(result2,result2_p), "cross mode and auto mode are not the same"
+
+
+def test_RR_precomputed_exception_handling1():
+
+    sample1 = np.random.random((1000,3))
+    sample2 = np.random.random((100,3))
+    randoms = np.random.random((100,3))
+    period = np.array([1.0,1.0,1.0])
+    rbins = np.linspace(0,0.3,5)
+    rmax = rbins.max()
+
+    RR_precomputed = rmax
+    with pytest.raises(HalotoolsError) as err:
+      result_1 = tpcf(sample1, rbins, sample2 = sample2,
+          randoms=randoms, period = period, 
+          max_sample_size=int(1e4), estimator='Natural', 
+          approx_cell1_size = [rmax, rmax, rmax], 
+          RR_precomputed = RR_precomputed)
+    substr = "``RR_precomputed`` and ``NR_precomputed`` arguments, or neither\n"
+    assert substr in err.value.message
+
+
+def test_RR_precomputed_exception_handling2():
+
+    sample1 = np.random.random((1000,3))
+    sample2 = np.random.random((100,3))
+    randoms = np.random.random((100,3))
+    period = np.array([1.0,1.0,1.0])
+    rbins = np.linspace(0,0.3,5)
+    rmax = rbins.max()
+    
+    RR_precomputed = rbins[:-2]
+    NR_precomputed = randoms.shape[0]
+    with pytest.raises(HalotoolsError) as err:
+        result_1 = tpcf(sample1, rbins, sample2 = sample2,
+            randoms=randoms, period = period, 
+            max_sample_size=int(1e4), estimator='Natural', 
+            approx_cell1_size = [rmax, rmax, rmax], 
+            RR_precomputed = RR_precomputed, NR_precomputed = NR_precomputed)
+    substr = "\nLength of ``RR_precomputed`` must match length of ``rbins``\n"
+    assert substr in err.value.message
+
+
+def test_RR_precomputed_exception_handling3():
+
+    sample1 = np.random.random((1000,3))
+    sample2 = np.random.random((100,3))
+    randoms = np.random.random((100,3))
+    period = np.array([1.0,1.0,1.0])
+    rbins = np.linspace(0,0.3,5)
+    rmax = rbins.max()
+    
+    RR_precomputed = rbins[:-1]
+    NR_precomputed = 5
+    with pytest.raises(HalotoolsError) as err:
+        result_1 = tpcf(sample1, rbins, sample2 = sample2,
+            randoms=randoms, period = period, 
+            max_sample_size=int(1e4), estimator='Natural', 
+            approx_cell1_size = [rmax, rmax, rmax], 
+            RR_precomputed = RR_precomputed, NR_precomputed = NR_precomputed)
+    substr = "the value of NR_precomputed must agree with the number of randoms"
+    assert substr in err.value.message
+
+
+@slow
+def test_RR_precomputed_natural_estimator_auto():
+    """ Strategy here is as follows. First, we adopt the same setup 
+    with randomly generated points as used in the rest of the test suite. 
+    First, we just compute the tpcf in the normal way. 
+    Then we break apart the tpcf innards so that we can 
+    compute RR in the exact same way that it is computed within tpcf. 
+    We will then pass in this RR using the RR_precomputed keyword, 
+    and verify that the tpcf computed in this second way gives 
+    exactly the same results as if we did not pre-compute RR.
+
+    """
+    sample1 = np.random.random((1000,3))
+    sample2 = sample1
+    randoms = np.random.random((100,3))
+    period = np.array([1.0,1.0,1.0])
+    rbins = np.linspace(0,0.3,5)
+    rmax = rbins.max()
+
+    approx_cell1_size = [rmax, rmax, rmax]
+    approx_cell2_size = approx_cell1_size
+    approx_cellran_size = [rmax, rmax, rmax]
+
+    normal_result = tpcf(
+        sample1, rbins, sample2 = sample2, 
+        randoms=randoms, period = period, 
+        max_sample_size=int(1e4), estimator='Natural', 
+        approx_cell1_size=approx_cell1_size, 
+        approx_cellran_size=approx_cellran_size)
+
+
+    # The following quantities are computed inside the 
+    # tpcf namespace. We reproduce them here because they are 
+    # necessary inputs to the _random_counts and _pair_counts 
+    # functions called by tpcf 
+    _sample1_is_sample2 = True
+    PBCs = True
+    num_threads = cpu_count()
+    do_DD, do_DR, do_RR = True, True, True  
+    do_auto, do_cross = True, False      
+
+    from ..tpcf import _random_counts, _pair_counts
+
+    #count data pairs
+    D1D1,D1D2,D2D2 = _pair_counts(
+        sample1, sample2, rbins, period,
+        num_threads, do_auto, do_cross, _sample1_is_sample2,
+        approx_cell1_size, approx_cell2_size)
+
+    #count random pairs
+    D1R, D2R, RR = _random_counts(
+        sample1, sample2, randoms, rbins, period,
+        PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
+        approx_cell1_size, approx_cell2_size, approx_cellran_size)
+
+    N1 = len(sample1)
+    NR = len(randoms)
+
+    factor = N1*N1/(NR*NR)
+    mult = lambda x,y: x*y
+    xi_11 = mult(1.0/factor,D1D1/RR) - 1.0
+
+    # The following assertion implies that the RR 
+    # computed within this testing namespace is the same RR 
+    # as computed in the tpcf namespace
+    assert np.all(xi_11 == normal_result)
+
+    # Now we will pass in the above RR as an argument 
+    # and verify that we get an identical tpcf 
+    result_with_RR_precomputed = tpcf(
+        sample1, rbins, sample2 = sample2, 
+        randoms=randoms, period = period, 
+        max_sample_size=int(1e4), estimator='Natural', 
+        approx_cell1_size=approx_cell1_size, 
+        approx_cellran_size=approx_cellran_size, 
+        RR_precomputed = RR, 
+        NR_precomputed = NR)
+
+    assert np.all(result_with_RR_precomputed == normal_result)
+
+
+@slow
+def test_RR_precomputed_Landy_Szalay_estimator_auto():
+    """ Strategy here is as follows. First, we adopt the same setup 
+    with randomly generated points as used in the rest of the test suite. 
+    First, we just compute the tpcf in the normal way. 
+    Then we break apart the tpcf innards so that we can 
+    compute RR in the exact same way that it is computed within tpcf. 
+    We will then pass in this RR using the RR_precomputed keyword, 
+    and verify that the tpcf computed in this second way gives 
+    exactly the same results as if we did not pre-compute RR.
+
+    """
+    sample1 = np.random.random((1000,3))
+    sample2 = sample1
+    randoms = np.random.random((100,3))
+    period = np.array([1.0,1.0,1.0])
+    rbins = np.linspace(0,0.3,5)
+    rmax = rbins.max()
+
+    approx_cell1_size = [rmax, rmax, rmax]
+    approx_cell2_size = approx_cell1_size
+    approx_cellran_size = [rmax, rmax, rmax]
+
+    normal_result = tpcf(
+        sample1, rbins, sample2 = sample2, 
+        randoms=randoms, period = period, 
+        max_sample_size=int(1e4), estimator='Landy-Szalay', 
+        approx_cell1_size=approx_cell1_size, 
+        approx_cellran_size=approx_cellran_size)
+
+
+    # The following quantities are computed inside the 
+    # tpcf namespace. We reproduce them here because they are 
+    # necessary inputs to the _random_counts and _pair_counts 
+    # functions called by tpcf 
+    _sample1_is_sample2 = True
+    PBCs = True
+    num_threads = cpu_count()
+    do_DD, do_DR, do_RR = True, True, True  
+    do_auto, do_cross = True, False      
+
+    from ..tpcf import _random_counts, _pair_counts
+
+    #count data pairs
+    D1D1,D1D2,D2D2 = _pair_counts(
+        sample1, sample2, rbins, period,
+        num_threads, do_auto, do_cross, _sample1_is_sample2,
+        approx_cell1_size, approx_cell2_size)
+
+    #count random pairs
+    D1R, D2R, RR = _random_counts(
+        sample1, sample2, randoms, rbins, period,
+        PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
+        approx_cell1_size, approx_cell2_size, approx_cellran_size)
+
+    ND1 = len(sample1)
+    ND2 = len(sample2)
+    NR1 = len(randoms)
+    NR2 = len(randoms)
+
+
+    factor1 = ND1*ND2/(NR1*NR2)
+    factor2 = ND1*NR2/(NR1*NR2)
+
+    mult = lambda x,y: x*y
+    xi_11 = mult(1.0/factor1,D1D1/RR) - mult(1.0/factor2,2.0*D1R/RR) + 1.0
+
+    # # The following assertion implies that the RR 
+    # # computed within this testing namespace is the same RR 
+    # # as computed in the tpcf namespace
+    assert np.all(xi_11 == normal_result)
+
+    # Now we will pass in the above RR as an argument 
+    # and verify that we get an identical tpcf 
+    result_with_RR_precomputed = tpcf(
+        sample1, rbins, sample2 = sample2, 
+        randoms=randoms, period = period, 
+        max_sample_size=int(1e4), estimator='Landy-Szalay', 
+        approx_cell1_size=approx_cell1_size, 
+        approx_cellran_size=approx_cellran_size, 
+        RR_precomputed = RR, 
+        NR_precomputed = NR1)
+
+    assert np.all(result_with_RR_precomputed == normal_result)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 

--- a/halotools/mock_observables/tpcf.py
+++ b/halotools/mock_observables/tpcf.py
@@ -23,11 +23,126 @@ __author__ = ['Duncan Campbell']
 
 np.seterr(divide='ignore', invalid='ignore') #ignore divide by zero in e.g. DD/RR
 
+def _random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,\
+                  do_RR, do_DR, _sample1_is_sample2, approx_cell1_size,\
+                  approx_cell2_size , approx_cellran_size):
+    """
+    Count random pairs.  There are two high level branches:
+        1. w/ or wo/ PBCs and randoms.
+        2. PBCs and analytical randoms
+    There are also logical bits to do RR and DR pair counts, as not all estimators
+    need one or the other, and not doing these can save a lot of calculation.
+    
+    Analytical counts are N**2*dv*rho, where dv can is the volume of the spherical 
+    shells, which is the correct volume to use for a continious cubic volume with PBCs
+    """
+    def nball_volume(R,k=3):
+        """
+        Calculate the volume of a n-shpere.
+        This is used for the analytical randoms.
+        """
+        return (np.pi**(k/2.0)/gamma(k/2.0+1.0))*R**k
+    
+    #randoms provided, so calculate random pair counts.
+    if randoms is not None:
+        if do_RR==True:
+            RR = npairs(randoms, randoms, rbins, period=period,
+                        num_threads=num_threads,
+                        approx_cell1_size=approx_cellran_size,
+                        approx_cell2_size=approx_cellran_size)
+            RR = np.diff(RR)
+        else: RR=None
+        if do_DR==True:
+            D1R = npairs(sample1, randoms, rbins, period=period,
+                         num_threads=num_threads,
+                         approx_cell1_size=approx_cell1_size,
+                         approx_cell2_size=approx_cellran_size
+                         )
+            D1R = np.diff(D1R)
+        else: D1R=None
+        if _sample1_is_sample2:
+            D2R = None
+        else:
+            if do_DR==True:
+                D2R = npairs(sample2, randoms, rbins, period=period,
+                             num_threads=num_threads,
+                             approx_cell1_size=approx_cell2_size,
+                             approx_cell2_size=approx_cellran_size)
+                D2R = np.diff(D2R)
+            else: D2R=None
+        
+        return D1R, D2R, RR
+    
+    #PBCs and no randoms--calculate randoms analytically.
+    elif randoms is None:
+        
+        #set the number of randoms equal to the number of points in sample1
+        NR = len(sample1)
+        
+        #do volume calculations
+        v = nball_volume(rbins) #volume of spheres
+        dv = np.diff(v) #volume of shells
+        global_volume = period.prod() #volume of simulation
+        
+        #calculate randoms for sample1
+        N1 = np.shape(sample1)[0] #number of points in sample1
+        rho1 = N1/global_volume #number density of points
+        D1R = (NR)*(dv*rho1) #random counts are N**2*dv*rho
+        
+        #calculate randoms for sample2
+        N2 = np.shape(sample2)[0] #number of points in sample2
+        rho2 = N2/global_volume #number density of points
+        D2R = (NR)*(dv*rho2) #random counts are N**2*dv*rho
+        
+        #calculate the random-random pairs.
+        rhor = (NR**2)/global_volume
+        RR = (dv*rhor)
+        
+        return D1R, D2R, RR
+
+def _pair_counts(sample1, sample2, rbins, 
+    period, num_threads, do_auto, do_cross,
+    _sample1_is_sample2, approx_cell1_size, approx_cell2_size):
+    """
+    Count data-data pairs.
+    """
+    if do_auto==True:
+        D1D1 = npairs(sample1, sample1, rbins, period=period, 
+            num_threads=num_threads,
+            approx_cell1_size=approx_cell1_size,
+            approx_cell2_size=approx_cell1_size)
+        D1D1 = np.diff(D1D1)
+    else:
+        D1D1=None
+        D2D2=None
+    
+    if _sample1_is_sample2:
+        D1D2 = D1D1
+        D2D2 = D1D1
+    else:
+        if do_cross==True:
+            D1D2 = npairs(sample1, sample2, rbins, period=period,
+                num_threads=num_threads,
+                approx_cell1_size=approx_cell1_size,
+                approx_cell2_size=approx_cell2_size)
+            D1D2 = np.diff(D1D2)
+        else: D1D2=None
+        if do_auto==True:
+            D2D2 = npairs(sample2, sample2, rbins, period=period,
+                num_threads=num_threads,
+                approx_cell1_size=approx_cell2_size,
+                approx_cell2_size=approx_cell2_size)
+            D2D2 = np.diff(D2D2)
+        else: D2D2=None
+    
+    return D1D1, D1D2, D2D2
+
 
 def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
-         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
-         max_sample_size=int(1e6), approx_cell1_size = None,
-         approx_cell2_size = None, approx_cellran_size = None):
+    do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
+    max_sample_size=int(1e6), approx_cell1_size = None,
+    approx_cell2_size = None, approx_cellran_size = None, 
+    RR_precomputed = None, NR_precomputed = None):
     """ 
     Calculate the real space two-point correlation function, :math:`\\xi(r)`.
     
@@ -95,7 +210,21 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
     approx_cellran_size : array_like, optional 
         Analogous to ``approx_cell1_size``, but for randoms.  See comments for 
         ``approx_cell1_size`` for details. 
-    
+
+    RR_precomputed : array_like, optional 
+        Array storing the number of previously calculated RR-counts. 
+        Must have the same length as *len(rbins)*. 
+        If the ``RR_precomputed`` argument is provided, 
+        you must also provide the ``NR_precomputed`` argument. 
+        Default is None. 
+
+    NR_precomputed : int, optional 
+        Number of points in the random sample used to calculate 
+        ``RR_precomputed``.  
+        If the ``NR_precomputed`` argument is provided, 
+        you must also provide the ``RR_precomputed`` argument. 
+        Default is None. 
+
     Returns 
     -------
     correlation_function(s) : numpy.array
@@ -168,134 +297,27 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
     """
     
     #check input arguments using clustering helper functions
-    function_args = [sample1, rbins, sample2, randoms, period, do_auto, do_cross,\
-                     estimator, num_threads, max_sample_size, approx_cell1_size,\
-                     approx_cell2_size, approx_cellran_size]
+    function_args = (sample1, rbins, sample2, randoms, period, 
+        do_auto, do_cross, estimator, num_threads, max_sample_size, 
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, 
+        RR_precomputed, NR_precomputed)
     
     #pass arguments in, and get out processed arguments, plus some control flow variables
-    sample1, rbins, sample2, randoms, period, do_auto, do_cross, num_threads,\
-    _sample1_is_sample2, PBCs = _tpcf_process_args(*function_args)
+    (sample1, rbins, sample2, randoms, period, 
+        do_auto, do_cross, num_threads,
+        _sample1_is_sample2, PBCs, 
+        RR_precomputed, NR_precomputed) = _tpcf_process_args(*function_args)
     
     #Below we define functions to count data-data pairs and random pairs.
     #After that, we get to work. The pair counting functions here actually call outside
     #pair counters that are highly optimized. Beware that the control flow inside 
     #these functions here can look a bit complicated, but don't des-pair!
     
-    def random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,\
-                      do_RR, do_DR, _sample1_is_sample2, approx_cell1_size,\
-                      approx_cell2_size , approx_cellran_size):
-        """
-        Count random pairs.  There are two high level branches:
-            1. w/ or wo/ PBCs and randoms.
-            2. PBCs and analytical randoms
-        There are also logical bits to do RR and DR pair counts, as not all estimators
-        need one or the other, and not doing these can save a lot of calculation.
-        
-        Analytical counts are N**2*dv*rho, where dv can is the volume of the spherical 
-        shells, which is the correct volume to use for a continious cubic volume with PBCs
-        """
-        def nball_volume(R,k=3):
-            """
-            Calculate the volume of a n-shpere.
-            This is used for the analytical randoms.
-            """
-            return (np.pi**(k/2.0)/gamma(k/2.0+1.0))*R**k
-        
-        #randoms provided, so calculate random pair counts.
-        if randoms is not None:
-            if do_RR==True:
-                RR = npairs(randoms, randoms, rbins, period=period,
-                            num_threads=num_threads,
-                            approx_cell1_size=approx_cellran_size,
-                            approx_cell2_size=approx_cellran_size)
-                RR = np.diff(RR)
-            else: RR=None
-            if do_DR==True:
-                D1R = npairs(sample1, randoms, rbins, period=period,
-                             num_threads=num_threads,
-                             approx_cell1_size=approx_cell1_size,
-                             approx_cell2_size=approx_cellran_size
-                             )
-                D1R = np.diff(D1R)
-            else: D1R=None
-            if _sample1_is_sample2:
-                D2R = None
-            else:
-                if do_DR==True:
-                    D2R = npairs(sample2, randoms, rbins, period=period,
-                                 num_threads=num_threads,
-                                 approx_cell1_size=approx_cell2_size,
-                                 approx_cell2_size=approx_cellran_size)
-                    D2R = np.diff(D2R)
-                else: D2R=None
-            
-            return D1R, D2R, RR
-        
-        #PBCs and no randoms--calculate randoms analytically.
-        elif randoms is None:
-            
-            #set the number of randoms equal to the number of points in sample1
-            NR = len(sample1)
-            
-            #do volume calculations
-            v = nball_volume(rbins) #volume of spheres
-            dv = np.diff(v) #volume of shells
-            global_volume = period.prod() #volume of simulation
-            
-            #calculate randoms for sample1
-            N1 = np.shape(sample1)[0] #number of points in sample1
-            rho1 = N1/global_volume #number density of points
-            D1R = (NR)*(dv*rho1) #random counts are N**2*dv*rho
-            
-            #calculate randoms for sample2
-            N2 = np.shape(sample2)[0] #number of points in sample2
-            rho2 = N2/global_volume #number density of points
-            D2R = (NR)*(dv*rho2) #random counts are N**2*dv*rho
-            
-            #calculate the random-random pairs.
-            rhor = (NR**2)/global_volume
-            RR = (dv*rhor)
-            
-            return D1R, D2R, RR
-    
-    def pair_counts(sample1, sample2, rbins, period, N_thread, do_auto, do_cross,\
-                    _sample1_is_sample2, approx_cell1_size, approx_cell2_size):
-        """
-        Count data-data pairs.
-        """
-        if do_auto==True:
-            D1D1 = npairs(sample1, sample1, rbins, period=period, num_threads=num_threads,
-                          approx_cell1_size=approx_cell1_size,
-                          approx_cell2_size=approx_cell1_size)
-            D1D1 = np.diff(D1D1)
-        else:
-            D1D1=None
-            D2D2=None
-        
-        if _sample1_is_sample2:
-            D1D2 = D1D1
-            D2D2 = D1D1
-        else:
-            if do_cross==True:
-                D1D2 = npairs(sample1, sample2, rbins, period=period,
-                              num_threads=num_threads,
-                              approx_cell1_size=approx_cell1_size,
-                              approx_cell2_size=approx_cell2_size)
-                D1D2 = np.diff(D1D2)
-            else: D1D2=None
-            if do_auto==True:
-                D2D2 = npairs(sample2, sample2, rbins, period=period,
-                              num_threads=num_threads,
-                              approx_cell1_size=approx_cell2_size,
-                              approx_cell2_size=approx_cell2_size)
-                D2D2 = np.diff(D2D2)
-            else: D2D2=None
-        
-        return D1D1, D1D2, D2D2
     
     # What needs to be done?
     do_DD, do_DR, do_RR = _TP_estimator_requirements(estimator)
-    
+    if RR_precomputed is not None: do_RR = False
+
     # How many points are there (for normalization purposes)?
     N1 = len(sample1)
     N2 = len(sample2)
@@ -304,17 +326,20 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
     else:
         #set the number of randoms equal to the number of points in sample1
         #this is arbitrarily set, but must remain consistent!
-        NR = N1
-    
+        if NR_precomputed is not None:
+            NR = NR_precomputed
+        else:
+            NR = N1
+
     #count data pairs
-    D1D1,D1D2,D2D2 = pair_counts(sample1, sample2, rbins, period,
-                                 num_threads, do_auto, do_cross, _sample1_is_sample2,
-                                 approx_cell1_size, approx_cell2_size)
+    D1D1,D1D2,D2D2 = _pair_counts(sample1, sample2, rbins, period,
+        num_threads, do_auto, do_cross, _sample1_is_sample2,
+        approx_cell1_size, approx_cell2_size)
     #count random pairs
-    D1R, D2R, RR = random_counts(sample1, sample2, randoms, rbins, period,
-                                    PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
-                                    approx_cell1_size, approx_cell2_size,
-                                    approx_cellran_size)
+    D1R, D2R, RR = _random_counts(sample1, sample2, randoms, rbins, 
+        period, PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
+        approx_cell1_size, approx_cell2_size, approx_cellran_size)
+    if RR_precomputed is not None: RR = RR_precomputed
     
     #check to see if any of the random counts contain 0 pairs.
     if D1R is not None:


### PR DESCRIPTION
This PR introduces an additional feature to the tpcf function: you can now optionally pass in a set of pre-computed random pairs. This feature is useful for MCMC applications populating multiple simulation volumes, as is currently being done by @mjvakili and @changhoonhahn. 