### PR TITLE
Satellite position testing

### DIFF
--- a/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
@@ -8,6 +8,7 @@ from astropy.config.paths import _find_home
 import numpy as np 
 from copy import copy 
 
+from ....mock_observables import periodic_3d_distance
 from ....sim_manager import FakeSim
 from ....sim_manager.fake_sim import FakeSimHalosNearBoundaries
 from ..prebuilt_model_factory import PrebuiltHodModelFactory
@@ -147,4 +148,20 @@ class TestHodMockFactory(TestCase):
 
         halocat = FakeSim()
         model.populate_mock(halocat = halocat)
+
+    @pytest.mark.slow
+    @pytest.mark.skipif('not APH_MACHINE')
+    def test_satellite_positions1(self):
+        model = PrebuiltHodModelFactory('zheng07')
+        model.populate_mock()
+
+        gals = model.mock.galaxy_table 
+        x1 = gals['x']
+        y1 = gals['y']
+        z1 = gals['z']
+        x2 = gals['halo_x']
+        y2 = gals['halo_y']
+        z2 = gals['halo_z']
+        d = periodic_3d_distance(x1, y1, z1, x2, y2, z2, model.mock.Lbox)
+        assert np.all(d <= gals['halo_rvir'])
 

--- a/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
@@ -9,6 +9,8 @@ import numpy as np
 from copy import copy 
 
 from ....mock_observables import periodic_3d_distance
+from ....mock_observables import return_xyz_formatted_array, tpcf_one_two_halo_decomp
+
 from ....sim_manager import FakeSim
 from ....sim_manager.fake_sim import FakeSimHalosNearBoundaries
 from ..prebuilt_model_factory import PrebuiltHodModelFactory
@@ -165,3 +167,20 @@ class TestHodMockFactory(TestCase):
         d = periodic_3d_distance(x1, y1, z1, x2, y2, z2, model.mock.Lbox)
         assert np.all(d <= gals['halo_rvir'])
 
+    @pytest.mark.slow
+    @pytest.mark.skipif('not APH_MACHINE')
+    def test_one_two_halo_decomposition_on_mock(self):
+        """ Enforce that the one-halo term is exactly zero 
+        on sufficiently large scales. 
+        """
+        model = PrebuiltHodModelFactory('zheng07')
+        model.populate_mock()
+
+        gals = model.mock.galaxy_table 
+        pos = return_xyz_formatted_array(gals['x'], gals['y'], gals['z'])
+        halo_hostid = model.mock.galaxy_table['halo_id']
+
+        rbins = np.logspace(-1, 1.5, 15)
+        xi_1h, xi_2h = tpcf_one_two_halo_decomp(pos, halo_hostid, rbins,
+            period = model.mock.Lbox, num_threads='max')
+        assert xi_1h[-1] == -1

--- a/halotools/mock_observables/__init__.py
+++ b/halotools/mock_observables/__init__.py
@@ -20,3 +20,4 @@ from .isolation_criteria import *
 from .nearest_neighbor import *
 from .void_stats import *
 from .catalog_analysis_helpers import *
+from .distances import *

--- a/halotools/mock_observables/distances.py
+++ b/halotools/mock_observables/distances.py
@@ -1,0 +1,35 @@
+""" Module containing pure python distance functions. 
+""" 
+import numpy as np 
+
+__all__ = ('periodic_3d_distance', )
+
+def periodic_3d_distance(x1, y1, z1, x2, y2, z2, Lbox):
+    """
+    Function computes the distance between two sets of coordinates 
+    with the same number of points, accounting for PBCs. 
+
+    Parameters 
+    ------------
+    x1, y1, z1 : array_like 
+        Length-Npts arrays storing Cartesian coordinates 
+
+    x2, y2, z2 : array_like 
+        Length-Npts arrays storing Cartesian coordinates 
+
+    Lbox : float 
+        Box length defining the periodic boundary conditions 
+
+    Returns 
+    --------
+    r : array_like 
+        Length-Npts array storing the 3d distance between the input 
+        points, accounting for box periodicity. 
+    """
+    dx = np.fabs(x1 - x2)
+    dx = np.fmin(dx, Lbox - dx)
+    dy = np.fabs(y1 - y2)
+    dy = np.fmin(dy, Lbox - dy)
+    dz = np.fabs(z1 - z2)
+    dz = np.fmin(dz, Lbox - dz)
+    return np.sqrt(dx*dx+dy*dy+dz*dz)


### PR DESCRIPTION
This PR adds a new non-trivial test of the correctness of satellite positions during mock population. In particular, it is now manually checked that populating a full-scale mock with 'zheng07' into the default simulation results in satellite positions that lie within rvir of their host halo. Previously, this test was only performed at the unit-testing level. This new test is an integration test. 