### PR TITLE
Now requiring halo_rvir > 50 to be safe_for_cache

### DIFF
--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -172,7 +172,8 @@ class HaloTableCacheLogEntry(object):
                 '_verify_has_required_data_columns', 
                 '_verify_all_keys_begin_with_halo', 
                 '_verify_all_positions_inside_box', 
-                '_verify_halo_ids_are_unique')
+                '_verify_halo_ids_are_unique', 
+                '_verify_halo_rvir_mpc_units')
 
             for verification_function in verification_sequence:
                 func = getattr(self, verification_function)
@@ -372,6 +373,28 @@ class HaloTableCacheLogEntry(object):
             num_failures += 1
             msg = str(num_failures) + ". The input file must have '.hdf5' extension.\n\n"
         return msg, num_failures
+
+    def _verify_halo_rvir_mpc_units(self, num_failures):
+        """ Require that all values stored in the halo_rvir column 
+        are less than 50, a crude way to ensure that units are not kpc. 
+        """
+        msg = ''
+
+        try:
+            data = Table.read(self.fname, path='data')
+            try:
+                halo_rvir = data['halo_rvir']
+                assert np.all(halo_rvir < 50)
+            except AssertionError:
+                num_failures += 1
+                msg = (str(num_failures)+". All values of the "
+                    "``halo_rvir`` column\n"
+                    "must be less than 50, crudely ensuring you used Mpc/h units.\n\n"
+                    )
+        except:
+            pass
+
+        return msg, num_failures 
 
     def _verify_hdf5_has_complete_metadata(self, num_failures):
         """

--- a/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
@@ -378,6 +378,31 @@ class TestHaloTableCacheLogEntry(TestCase):
         assert "must contain a unique set of integers" in log_entry._cache_safety_message
 
     @pytest.mark.skipif('not HAS_H5PY')
+    def test_scenario4b(self):
+        num_scenario = 4
+
+        try:
+            os.remove(self.fnames[num_scenario])
+        except:
+            pass
+
+        log_entry = HaloTableCacheLogEntry(**self.get_scenario_kwargs(num_scenario))
+
+        bad_table = deepcopy(self.good_table)
+        bad_table['halo_rvir'] = 0.
+        bad_table['halo_rvir'][0] = 51        
+        bad_table.write(self.fnames[num_scenario], path='data')
+        f = h5py.File(self.fnames[num_scenario])
+        for attr in self.hard_coded_log_attrs:
+            f.attrs[attr] = getattr(log_entry, attr)
+        f.attrs['Lbox'] = 100.
+        f.attrs['particle_mass'] = 1.e8
+        f.close()
+
+        assert log_entry.safe_for_cache == False
+        assert "must be less than 50" in log_entry._cache_safety_message
+
+    @pytest.mark.skipif('not HAS_H5PY')
     def test_passing_scenario(self):
         num_scenario = 4
 


### PR DESCRIPTION
This is a crude way to ensure that halo rvir has not accidentally but put in kpc/h units, which can lead to bugs in satellite position assignment of HOD-style models, as pointed out in #336 . 