### PR TITLE
Improved error handling of subhalo and hod model factories

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -256,6 +256,9 @@ class HodModelFactory(ModelFactory):
             Dictionary of any possible remaining keyword arguments passed to the `__init__` constructor 
             that are not part of the composite model dictionary, e.g., ``model_feature_calling_sequence``. 
         """
+        if len(kwargs) == 0:
+            msg = ("You did not pass any model features to the factory")
+            raise HalotoolsError(msg)
 
         if 'baseline_model_instance' in kwargs:
             baseline_model_dictionary = kwargs['baseline_model_instance'].model_dictionary

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -261,6 +261,9 @@ class SubhaloModelFactory(ModelFactory):
         ---------
         :ref:`subhalo_model_factory_parsing_kwargs`
         """
+        if len(kwargs) == 0:
+            msg = ("You did not pass any model features to the factory")
+            raise HalotoolsError(msg)
 
         if 'baseline_model_instance' in kwargs:
             baseline_model_dictionary = kwargs['baseline_model_instance'].model_dictionary

--- a/halotools/empirical_models/factories/tests/test_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_model_factory.py
@@ -23,5 +23,11 @@ class TestHodModelFactory(TestCase):
         """
         pass
 
+    def test_empty_arguments(self):
+        with pytest.raises(HalotoolsError) as err:
+            model = HodModelFactory()
+        substr = "You did not pass any model features to the factory"
+        assert substr in err.value.message
+
     def tearDown(self):
         pass

--- a/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
@@ -146,7 +146,11 @@ class TestSubhaloModelFactory(TestCase):
         assert hasattr(model1, 'mock')
         assert 'stellar_mass' in model1.mock.galaxy_table.keys()
 
-
+    def test_empty_arguments(self):
+        with pytest.raises(HalotoolsError) as err:
+            model = SubhaloModelFactory()
+        substr = "You did not pass any model features to the factory"
+        assert substr in err.value.message
 
     def tearDown(self):
         pass


### PR DESCRIPTION
An attempt to call either of the model factories with no arguments as if there were a default choice now raises an exception. 

This PR resolves #207 