### PR TITLE
Simplify API for users declaring their own halo mass completeness cut

### DIFF
--- a/halotools/empirical_models/factories/tests/test_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_model_factory.py
@@ -7,7 +7,7 @@ from astropy.tests.helper import pytest
 import numpy as np 
 from copy import copy 
 
-from ...factories import HodModelFactory
+from ...factories import HodModelFactory, PrebuiltHodModelFactory
 
 from ....sim_manager import FakeSim
 from ....custom_exceptions import HalotoolsError
@@ -28,6 +28,71 @@ class TestHodModelFactory(TestCase):
             model = HodModelFactory()
         substr = "You did not pass any model features to the factory"
         assert substr in err.value.message
+
+    def test_populate_mock1(self):
+        model = PrebuiltHodModelFactory('zheng07')
+        halocat = FakeSim()
+        model.populate_mock(halocat = halocat)
+        model.populate_mock(halocat = halocat)
+        model.populate_mock(simname = halocat.simname, 
+            redshift = halocat.redshift, 
+            halo_finder = halocat.halo_finder, 
+            version_name = halocat.version_name)
+
+        with pytest.raises(HalotoolsError) as err:
+            model.populate_mock(simname = 'bolshoi')
+        substr = "Inconsistency between the simname already bound to the existing mock"
+        assert substr in err.value.message
+
+        with pytest.raises(HalotoolsError) as err:
+            model.populate_mock(simname = halocat.simname, redshift = 4.)
+        substr = "Inconsistency between the redshift already bound to the existing mock"
+        assert substr in err.value.message
+
+        with pytest.raises(HalotoolsError) as err:
+            model.populate_mock(simname = halocat.simname, 
+                redshift = halocat.redshift, 
+                halo_finder = 'Jose Canseco')
+        substr = "Inconsistency between the halo-finder "
+        assert substr in err.value.message
+
+        with pytest.raises(HalotoolsError) as err:
+            model.populate_mock(simname = halocat.simname, 
+                redshift = halocat.redshift, 
+                halo_finder = halocat.halo_finder, 
+                version_name = 'mo biscuit')
+        substr = "Inconsistency between the version_name "
+        assert substr in err.value.message
+
+        halocat_redshift2 = FakeSim(redshift = 2.)
+        with pytest.raises(HalotoolsError) as err:
+            model.populate_mock(halocat = halocat_redshift2)
+        substr = "Inconsistency between the redshift already bound to the existing mock"
+        assert substr in err.value.message
+
+    def test_Num_ptcl_requirement(self):
+        """ Demonstrate that passing in varying values for 
+        Num_ptcl_requirement results in the proper behavior. 
+        """
+        model = PrebuiltHodModelFactory('zheng07')
+        halocat = FakeSim()
+        actual_mvir_min = halocat.halo_table['halo_mvir'].min()
+
+        model.populate_mock(halocat = halocat)
+        default_mvir_min = model.mock.particle_mass*model.mock.Num_ptcl_requirement
+        # verify that the cut was applied
+        assert np.all(model.mock.halo_table['halo_mvir'] > default_mvir_min)
+        # verify that the cut was non-trivial
+        assert np.any(halocat.halo_table['halo_mvir'] < default_mvir_min)
+
+        del model.mock 
+        model.populate_mock(halocat = halocat, Num_ptcl_requirement = 0.)
+        assert model.mock.Num_ptcl_requirement == 0.
+        assert np.any(model.mock.halo_table['halo_mvir'] < default_mvir_min)
+
+
+
+
 
     def tearDown(self):
         pass

--- a/halotools/sim_manager/fake_sim.py
+++ b/halotools/sim_manager/fake_sim.py
@@ -50,9 +50,20 @@ class FakeSim(UserSuppliedHaloCatalog):
 		"""
 		Lbox = 250.0
 		particle_mass = 1.e8
-		self.simname = 'fake'
-		self.halo_finder = 'fake'
-		self.version_name = 'dummy_version'
+		try:
+			self.simname = kwargs['simname']
+		except KeyError:
+			self.simname = 'fake'
+		try:
+			self.halo_finder = kwargs['halo_finder']
+		except KeyError:
+			self.halo_finder = 'fake'
+		try:
+			self.version_name = kwargs['version_name']
+		except KeyError:
+			self.version_name = 'dummy_version'
+		self.redshift = redshift
+
 
 		self.seed = seed
 		np.random.seed(self.seed)


### PR DESCRIPTION
As pointed out by @nickhand, there were several awkward aspects of how the halo completeness cuts were applied during HOD mock generation. This PR addresses this by allowing the user to declare two arguments that may be passed either to the `HodMockFactory` constructor, or equivalently to the `populate_mock` function:

1. Num_ptcl_requirement 
2. halo_mass_column_key

These two arguments together permit the user to make more customizable initial halo completeness cuts with a simpler and more transparent interface. 

This PR also prompted a much-needed syntax cleanup for the `populate_mock` method, which had become very cluttered with nested control flow. 

@nickhand - since you discovered this awkwardness and will be using this feature in short order, would you mind providing some feedback on this implementation? I will wait to merge this PR until you've had a chance to weigh in. 

Also, fyi, I added in a dedicated test to demonstrate that application of this feature is handled correctly: see `TestHodModelFactory.test_Num_ptcl_requirement`

