### PR TITLE
Improved testing of mock_observables sub-package

### DIFF
--- a/halotools/mock_observables/nearest_neighbor.py
+++ b/halotools/mock_observables/nearest_neighbor.py
@@ -173,7 +173,9 @@ def _nth_matrix_minimum(m, n, axis=None):
     i,j = m.nonzero()
     d = np.array(m[i,j]).flatten()
     
-    if axis is None:
+    if len(i)==0: #no neighbors
+        result = np.zeros(N0, dtype=int)-1
+    elif axis is None:
         sort_inds = np.argsort(d)
         sorted_i = i[sort_inds]
         sorted_j = j[sort_inds]

--- a/halotools/mock_observables/pair_counters/double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pairs.py
@@ -147,6 +147,7 @@ def npairs(data1, data2, rbins, period = None,\
         
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
+    Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
     
     if verbose==True:
         print("volume 1 split {0},{1},{2} times along each dimension,\n"
@@ -154,7 +155,7 @@ def npairs(data1, data2, rbins, period = None,\
               double_tree.num_y1divs,double_tree.num_z1divs,Ncell1))
         print("volume 2 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x2divs,\
-              double_tree.num_y2divs,double_tree.num_z2divs,Ncell1))
+              double_tree.num_y2divs,double_tree.num_z2divs,Ncell2))
     
     #create a function to call with only one argument
     engine = partial(_npairs_engine, 

--- a/halotools/mock_observables/pair_counters/double_tree_per_object_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_per_object_pairs.py
@@ -139,7 +139,7 @@ def per_object_npairs(data1, data2, rbins, period = None,\
 
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
-    Ncell1 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
+    Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
     
     if verbose==True:
         print("volume 1 split {0},{1},{2} times along each dimension,\n"
@@ -147,7 +147,7 @@ def per_object_npairs(data1, data2, rbins, period = None,\
               double_tree.num_y1divs,double_tree.num_z1divs,Ncell1))
         print("volume 2 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x2divs,\
-              double_tree.num_y2divs,double_tree.num_z2divs,Ncell1))
+              double_tree.num_y2divs,double_tree.num_z2divs,Ncell2))
     
     #create a function to call with only one argument
     engine = partial(_per_object_npairs_engine, 

--- a/halotools/mock_observables/pair_counters/marked_cpairs/pairwise_velocity_funcs.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/pairwise_velocity_funcs.pyx
@@ -77,7 +77,8 @@ cdef void relative_radial_velocity_weights(np.float64_t* w1,
        dvz = (w1[5] - w2[5])
        
        #the radial component of the velocity difference
-       result = (xshift*dvx*rx + yshift*dvy*ry + zshift*dvz*rz)/norm
+       #result = (xshift*dvx*rx + yshift*dvy*ry + zshift*dvz*rz)/norm
+       result = (dvx*rx + dvy*ry + dvz*rz)/norm
        
        result1[0] = result #radial velocity
        result2[0] = 0.0 #unused value
@@ -140,8 +141,10 @@ cdef void radial_velocity_weights(np.float64_t* w1,
         result3[0] = 1.0 #number of pairs
     else:        
        #the radial component of the velocities
-       resulta = (xshift*w1[3]*rx + yshift*w1[4]*ry + zshift*w1[5]*rz)/norm
-       resultb = (xshift*w2[3]*rx + yshift*w2[4]*ry + zshift*w2[5]*rz)/norm
+       #resulta = (xshift*w1[3]*rx + yshift*w1[4]*ry + zshift*w1[5]*rz)/norm
+       #resultb = (xshift*w2[3]*rx + yshift*w2[4]*ry + zshift*w2[5]*rz)/norm
+       resulta = (w1[3]*rx + w1[4]*ry + w1[5]*rz)/norm
+       resultb = (w2[3]*rx + w2[4]*ry + w2[5]*rz)/norm
        
        result1[0] = resulta*resultb #radial velocity
        result2[0] = 0.0 #unused value
@@ -213,7 +216,8 @@ cdef void radial_velocity_variance_counter_weights(np.float64_t* w1,
         dvz = (w1[5] - w2[5])
         
         #the radial component of the velocity difference
-        result = (xshift*dvx*rx + yshift*dvy*ry + zshift*dvz*rz)/norm - w1[6]*w2[6]
+        #result = (xshift*dvx*rx + yshift*dvy*ry + zshift*dvz*rz)/norm - w1[6]*w2[6]
+        result = (dvx*rx + dvy*ry + dvz*rz)/norm - w1[6]*w2[6]
         
         result1[0] = result #radial velocity
         result2[0] = result*result #radial velocity squared

--- a/halotools/mock_observables/pair_counters/marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/marked_double_tree_pairs.py
@@ -180,7 +180,7 @@ def _marked_npairs_engine(double_tree, weights1, weights2,
     for icell2, xshift, yshift, zshift in adj_cell_generator:
         
         #set shift array as -1,1,0 depending on direction of/if cell shifted.
-        shift = np.array([xshift,zshift,yshift]).astype(float)
+        shift = np.array([xshift,yshift,zshift]).astype(float)
         
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
@@ -361,7 +361,7 @@ def _xy_z_marked_npairs_engine(double_tree, weights1, weights2,
     for icell2, xshift, yshift, zshift in adj_cell_generator:
         
         #set shift array as -1,1,0 depending on direction of/if cell shifted.
-        shift = np.array([xshift,zshift,yshift]).astype(float)
+        shift = np.array([xshift,yshift,zshift]).astype(float)
         
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
@@ -558,7 +558,7 @@ def _velocity_marked_npairs_engine(double_tree, weights1, weights2,
     for icell2, xshift, yshift, zshift in adj_cell_generator:
         
         #set shift array as -1,1,0 depending on direction of/if cell shifted.
-        shift = np.array([xshift,zshift,yshift]).astype(float)
+        shift = np.array([xshift,yshift,zshift]).astype(float)
         
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
@@ -764,7 +764,7 @@ def _xy_z_velocity_marked_npairs_engine(double_tree, weights1, weights2,
     for icell2, xshift, yshift, zshift in adj_cell_generator:
         
         #set shift array as -1,1,0 depending on direction of/if cell shifted.
-        shift = np.array([xshift,zshift,yshift]).astype(float)
+        shift = np.array([xshift,yshift,zshift]).astype(float)
         
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]

--- a/halotools/mock_observables/pairwise_velocity_stats.py
+++ b/halotools/mock_observables/pairwise_velocity_stats.py
@@ -416,6 +416,7 @@ def radial_pvd_vs_r(sample1, velocities1, rbins, sample2=None,
             else: 
                 D1D2=None
                 N1N2=None
+                S1S2=None
             if do_auto==True:
                 D2D2, S2S2, N2N2 = velocity_marked_npairs(sample2, sample2, rbins,\
                                      weights1=marks2, weights2=marks2,\
@@ -884,6 +885,7 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
             else: 
                 D1D2=None
                 N1N2=None
+                S1S2=None
             if do_auto==True:
                 D2D2, S2S2, N2N2 = xy_z_velocity_marked_npairs(sample2, sample2, rp_bins, pi_bins,\
                                      weights1=marks2, weights2=marks2,\

--- a/halotools/mock_observables/test_clustering/test_marked_tpcf.py
+++ b/halotools/mock_observables/test_clustering/test_marked_tpcf.py
@@ -4,13 +4,13 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
 import sys
-
+from multiprocessing import cpu_count
 from ..marked_tpcf import marked_tpcf
 
 import pytest
 slow = pytest.mark.slow
 
-__all__=['test_marked_tpcf_auto_periodic','test_marked_tpcf_auto_nonperiodic']
+# __all__=['test_marked_tpcf_auto_periodic','test_marked_tpcf_auto_nonperiodic']
 
 #create toy data to test functions
 N_pts = 100
@@ -50,3 +50,40 @@ def test_marked_tpcf_auto_nonperiodic():
                          period=None, num_threads=1, wfunc=wfunc)
     
     assert result.ndim == 1, "More than one correlation function returned erroneously."
+
+def test_marked_tpcf_cross1():
+    """
+    """
+    weights1 = np.random.random(N_pts)
+    weights2 = np.random.random(N_pts)
+    wfunc = 1
+
+    result = marked_tpcf(sample1, rbins, sample2=sample2, 
+        marks1=weights1, marks2=weights2,
+        period=period, num_threads='max', wfunc=wfunc)
+
+def test_marked_tpcf_cross_consistency():
+    """
+    """
+    weights1 = np.random.random(N_pts)
+    weights2 = np.random.random(N_pts)
+    wfunc = 1
+
+    cross_mark1 = marked_tpcf(sample1, rbins, sample2=sample2, 
+        marks1=weights1, marks2=weights2,
+        period=period, num_threads=1, wfunc=wfunc, 
+        do_auto = False, normalize_by = 'number_counts')
+
+    auto1, cross_mark2, auto2 = marked_tpcf(sample1, rbins, sample2=sample2, 
+        marks1=weights1, marks2=weights2,
+        period=period, num_threads=1, wfunc=wfunc, normalize_by = 'number_counts')
+
+    auto1b, auto2b = marked_tpcf(sample1, rbins, sample2=sample2, 
+        marks1=weights1, marks2=weights2,
+        period=period, num_threads=1, wfunc=wfunc, 
+        do_cross = False, normalize_by = 'number_counts')
+
+    assert np.all(cross_mark1 == cross_mark2)
+
+
+

--- a/halotools/mock_observables/tests/cf_helpers.py
+++ b/halotools/mock_observables/tests/cf_helpers.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+import numpy as np 
+from astropy.tests.helper import pytest
+from ...custom_exceptions import HalotoolsError
+
+__all__ = ('generate_locus_of_3d_points', )
+
+def generate_locus_of_3d_points(npts, xc=0.1, yc=0.1, zc=0.1, epsilon=0.001):
+	"""
+	Function returns a tight locus of points inside a 3d box. 
+
+	Parameters 
+	-----------
+	npts : int 
+		Number of desired points 
+
+	xc, yc, zc : float 
+		Midpoint value in all three dimensions 
+
+	epsilon : float 
+		Length of the box enclosing the returned locus of points
+
+	Returns 
+	---------
+	pts : array_like 
+		ndarray with shape (npts, 3) of points tightly localized around 
+		the point (xc, yc, zc)
+	"""
+	x = np.random.uniform(xc - epsilon/2., xc + epsilon/2., npts)
+	y = np.random.uniform(yc - epsilon/2., yc + epsilon/2., npts)
+	z = np.random.uniform(zc - epsilon/2., zc + epsilon/2., npts)
+	return np.vstack([x, y, z]).T
+	# return np.random.uniform(
+	# 	loc - epsilon/2., loc + epsilon/2., npts*3).reshape((npts, 3))
+
+

--- a/halotools/mock_observables/tests/test_distances.py
+++ b/halotools/mock_observables/tests/test_distances.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+import numpy as np 
+from astropy.tests.helper import pytest
+from ...custom_exceptions import HalotoolsError
+
+from ..distances import periodic_3d_distance
+
+__all__ = ['test_distances1']
+
+def test_distances1():
+	x1 = np.random.rand(5)
+	y1 = np.random.rand(5)
+	z1 = np.random.rand(5)
+	x2 = np.random.rand(5)
+	y2 = np.random.rand(5)
+	z2 = np.random.rand(5)
+	Lbox = 1
+	d = periodic_3d_distance(x1, y1, z1, x2, y2, z2, Lbox)

--- a/halotools/mock_observables/tests/test_nearest_neighbor.py
+++ b/halotools/mock_observables/tests/test_nearest_neighbor.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+import numpy as np 
+from astropy.tests.helper import pytest
+
+from .cf_helpers import generate_locus_of_3d_points
+from ..nearest_neighbor import nearest_neighbor
+
+__all__ = ('test_diffusely_distributed_points', 'test_tight_locus')
+
+npts = 100
+
+def test_diffusely_distributed_points():
+    """ Verify that the `~halotools.mock_observables.nearest_neighbor` 
+    function returns a result without raising an exception when passed 
+    two sets of points that evenly sample the full box at random. 
+    """
+    sample1 = np.random.rand(npts, 3)
+    sample2 = np.random.rand(npts, 3)
+    r_max = 0.2
+    nth_nearest = 1
+    nn = nearest_neighbor(sample1, sample2, r_max, 
+        nth_nearest=nth_nearest)
+    nn2 = nearest_neighbor(sample1, sample2, r_max, 
+        nth_nearest=2, period=1.)
+
+
+
+
+def test_tight_locus():
+    """ Verify that the `~halotools.mock_observables.nearest_neighbor` 
+    function returns a result without raising an exception when passed 
+    two distant sets of points, each in a tight locus. 
+    """
+
+    npts1, npts2 = npts, npts
+    sample1 = generate_locus_of_3d_points(npts1, 
+        xc=0.1, yc=0.1, zc=0.1, epsilon=0.01)
+    assert sample1.shape == (npts1, 3)
+    assert np.all(sample1 >= 0.09)
+    assert np.all(sample1 <= 0.11)
+    sample2 = generate_locus_of_3d_points(npts2, 
+        xc=0.9, yc=0.9, zc=0.9, epsilon=0.01)
+
+    r_max = 0.5
+    nn = nearest_neighbor(sample1, sample2, r_max, nth_nearest=1)
+
+
+
+
+
+

--- a/halotools/mock_observables/tests/test_pairwise_velocity_stats.py
+++ b/halotools/mock_observables/tests/test_pairwise_velocity_stats.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+import numpy as np 
+from astropy.tests.helper import pytest
+from ...custom_exceptions import HalotoolsError
+
+from ..pairwise_velocity_stats import *
+from .cf_helpers import generate_locus_of_3d_points
+
+
+@pytest.mark.slow
+def test_mean_radial_velocity_vs_r_auto_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	s1s1a, s1s2a, s2s2a = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s1b, s2s2b = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_cross = False)
+
+	assert np.allclose(s1s1a,s1s1b, rtol=0.001)
+	assert np.allclose(s2s2a,s2s2b, rtol=0.001)
+
+
+@pytest.mark.slow
+def test_mean_radial_velocity_vs_r_cross_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	s1s1a, s1s2a, s2s2a = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s2b = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_auto = False)
+
+	assert np.allclose(s1s2a,s1s2b, rtol=0.001)
+
+@pytest.mark.slow
+def test_radial_pvd_vs_r1():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	rbins = np.linspace(0, 0.3, 10)
+	result1 = radial_pvd_vs_r(sample1, velocities1, rbins)
+	result2 = radial_pvd_vs_r(sample1, velocities1, rbins, 
+		approx_cell1_size = [0.2, 0.2, 0.2])
+	assert np.allclose(result1, result2, rtol=0.0001)
+
+@pytest.mark.slow
+def test_radial_pvd_vs_r_auto_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	s1s1a, s1s2a, s2s2a = radial_pvd_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s1b, s2s2b = radial_pvd_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_cross = False)
+
+	assert np.allclose(s1s1a,s1s1b, rtol=0.001)
+	assert np.allclose(s2s2a,s2s2b, rtol=0.001)
+
+@pytest.mark.slow
+def test_radial_pvd_vs_r_cross_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	s1s1a, s1s2a, s2s2a = radial_pvd_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s2b = radial_pvd_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_auto = False)
+
+	assert np.allclose(s1s2a,s1s2b, rtol=0.001)
+
+@pytest.mark.slow
+def test_mean_los_velocity_vs_rp_auto_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	pi_max = 0.2
+	s1s1a, s1s2a, s2s2a = mean_los_velocity_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s1b, s2s2b = mean_los_velocity_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_cross = False)
+
+	assert np.allclose(s1s1a,s1s1b, rtol=0.001)
+	assert np.allclose(s2s2a,s2s2b, rtol=0.001)
+
+
+@pytest.mark.slow
+def test_mean_los_velocity_vs_rp_cross_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	pi_max = 0.3
+	s1s1a, s1s2a, s2s2a = mean_los_velocity_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s2b = mean_los_velocity_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_auto = False)
+
+	assert np.allclose(s1s2a,s1s2b, rtol=0.001)
+
+
+@pytest.mark.slow
+def test_los_pvd_vs_rp_auto_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	pi_max = 0.2
+	s1s1a, s1s2a, s2s2a = los_pvd_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s1b, s2s2b = los_pvd_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_cross = False)
+
+	assert np.allclose(s1s1a,s1s1b, rtol=0.001)
+	assert np.allclose(s2s2a,s2s2b, rtol=0.001)
+
+@pytest.mark.slow
+def test_los_pvd_vs_rp_cross_consistency():
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = np.random.rand(npts, 3)
+	velocities1 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+	sample2 = np.random.rand(npts, 3)
+	velocities2 = np.random.normal(
+		loc = 0, scale = 100, size=npts*3).reshape((npts, 3))
+
+	rbins = np.linspace(0, 0.3, 10)
+	pi_max = 0.3
+	s1s1a, s1s2a, s2s2a = los_pvd_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2)
+	s1s2b = los_pvd_vs_rp(sample1, velocities1, rbins, pi_max, 
+		sample2 = sample2, velocities2 = velocities2, 
+		do_auto = False)
+
+	assert np.allclose(s1s2a,s1s2b, rtol=0.001)
+
+@pytest.mark.slow
+def test_mean_radial_velocity_vs_r_correctness():
+	""" Create two tight localizations of points, 
+	one at (0.5, 0.5, 0.1), the other at (0.5, 0.5, 0.2). 
+	The first set of points is moving at -50 in the z-direction, 
+	the second set of points is at rest. 
+	Verify that mean_radial_velocity_vs_r returns -50 
+	for the outer bin. 
+	"""
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = generate_locus_of_3d_points(npts, 
+		xc=0.5, yc=0.5, zc=0.1, epsilon = 0.0001)
+	velocities1 = np.zeros(npts*3).reshape(npts, 3)
+	velocities1[:,2] = 50.
+
+	sample2 = generate_locus_of_3d_points(npts, 
+		xc=0.5, yc=0.5, zc=0.25, epsilon = 0.0001)
+	velocities2 = np.zeros(npts*3).reshape(npts, 3)
+
+	rbins = np.array([0, 0.1, 0.3])
+	s1s1, s1s2, s2s2 = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2)
+
+	assert np.allclose(s1s1[0], 0, rtol=0.01)
+	assert np.allclose(s2s2[0], 0, rtol=0.01)
+	assert np.allclose(s1s2[1], -50, rtol=0.01)
+
+@pytest.mark.slow
+def test_mean_radial_velocity_vs_r_correctness_pbc():
+	""" Create two tight localizations of points, 
+	one at (0.5, 0.5, 0.1), the other at (0.5, 0.5, 0.2). 
+	The first set of points is moving at -50 in the z-direction, 
+	the second set of points is at rest. 
+	Verify that mean_radial_velocity_vs_r returns -50 
+	for the outer bin. 
+	Same test as test_mean_radial_velocity_vs_r_correctness, 
+	only here we apply PBC, which should not matter in this case. 
+	"""
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = generate_locus_of_3d_points(npts, 
+		xc=0.5, yc=0.5, zc=0.1, epsilon = 0.0001)
+	velocities1 = np.zeros(npts*3).reshape(npts, 3)
+	velocities1[:,2] = 50.
+
+	sample2 = generate_locus_of_3d_points(npts, 
+		xc=0.5, yc=0.5, zc=0.25, epsilon = 0.0001)
+	velocities2 = np.zeros(npts*3).reshape(npts, 3)
+
+	rbins = np.array([0, 0.1, 0.3])
+	s1s1, s1s2, s2s2 = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2, period=1.)
+
+	assert np.allclose(s1s1[0], 0, rtol=0.01)
+	assert np.allclose(s2s2[0], 0, rtol=0.01)
+	assert np.allclose(s1s2[1], -50, rtol=0.01)
+
+@pytest.mark.slow
+def test_mean_radial_velocity_vs_r_correctness_pbc2():
+	""" Create two tight localizations of points, 
+	one at (0.5, 0.5, 0.05), the other at (0.5, 0.5, 0.9). 
+	The first set of points is moving at -50 in the z-direction, 
+	the second set of points is at rest. 
+	Verify that mean_radial_velocity_vs_r returns -50 
+	for the outer bin. 
+
+	Same test as test_mean_radial_velocity_vs_r_correctness_pbc, 
+	only here the PBC should matter. 
+	"""
+	np.random.seed(43)
+
+	npts = 200
+	sample1 = generate_locus_of_3d_points(npts, 
+		xc=0.5, yc=0.5, zc=0.05, epsilon = 0.0001)
+	velocities1 = np.zeros(npts*3).reshape(npts, 3)
+	velocities1[:,2] = -50.
+
+	sample2 = generate_locus_of_3d_points(npts, 
+		xc=0.5, yc=0.5, zc=0.9, epsilon = 0.0001)
+	velocities2 = np.zeros(npts*3).reshape(npts, 3)
+
+	rbins = np.array([0, 0.1, 0.3])
+	s1s1, s1s2, s2s2 = mean_radial_velocity_vs_r(sample1, velocities1, rbins, 
+		sample2 = sample2, velocities2 = velocities2, period=1.)
+
+	assert np.allclose(s1s1[0], 0, rtol=0.01)
+	assert np.allclose(s2s2[0], 0, rtol=0.01)
+	assert np.allclose(s1s2[1], -50, rtol=0.01)
+

--- a/halotools/mock_observables/tests/test_void_stats.py
+++ b/halotools/mock_observables/tests/test_void_stats.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+import numpy as np 
+from astropy.tests.helper import pytest
+from ...custom_exceptions import HalotoolsError
+
+from ..void_stats import *
+from .cf_helpers import generate_locus_of_3d_points
+
+def test_vpf1():
+    """ Verify that the VPF raises no exceptions 
+    for several reasonable choices of rbins. 
+
+    period = [1, 1, 1]
+    """
+
+    Npts = 100
+    Lbox = 1
+    period = np.array([Lbox,Lbox,Lbox])
+    sample1 = np.random.random((Npts, 3))
+    n_ran = 100
+
+    rbins = np.logspace(-2,-1,20)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+
+    rbins = np.linspace(0.1, 0.3, 10)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+
+def test_vpf2():
+    """ Verify that the VPF raises no exceptions 
+    for several reasonable choices of rbins. 
+
+    period = None
+    """
+
+    Npts = 100
+    Lbox = 1
+    period = None
+    sample1 = np.random.random((Npts, 3))
+    n_ran = 100
+
+    rbins = np.logspace(-2,-1,20)
+    vpf = void_prob_func(sample1, rbins, n_ran, period)
+
+@pytest.mark.slow
+def test_vpf3():
+    """ Verify that the VPF returns consistent results 
+    regardless of the value of approx_cell1_size. 
+    """
+    np.random.seed(43)
+
+    Npts = 1000
+    Lbox = 1
+    period = Lbox
+    sample1 = np.random.random((Npts, 3))
+    n_ran = 1000
+
+    rbins = np.logspace(-2,-1,5)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+    vpf2 = void_prob_func(sample1, rbins, n_ran=n_ran, period=period, 
+        approx_cell1_size = [0.2, 0.2, 0.2])
+    assert np.allclose(vpf, vpf2, rtol = 0.1)
+
+def test_upf1():
+    """ Verify that the UPF raises no exceptions 
+    for several reasonable choices of rbins. 
+    """
+
+    Npts = 100
+    Lbox = 1
+    period = np.array([Lbox,Lbox,Lbox])
+    sample1 = np.random.random((Npts, 3))
+    n_ran = 100
+
+    rbins = np.logspace(-2,-1,20)
+    upf = underdensity_prob_func(sample1, rbins, 
+        n_ran=n_ran, period=period)
+
+    rbins = np.linspace(0.1, 0.3, 10)
+    upf = underdensity_prob_func(sample1, rbins, 
+        n_ran=n_ran, period=period)
+
+@pytest.mark.slow
+def test_upf2():
+    """ Verify that the UPF behaves properly when changing the 
+    density threshold criterion. 
+    """
+    
+    Npts = 1000
+    Lbox = 1
+    period = np.array([Lbox,Lbox,Lbox])
+    sample1 = np.random.random((Npts, 3))
+    random_sphere_centers = np.random.random((Npts, 3))
+
+
+    rbins = np.logspace(-1.5,-1,5)
+    upf = underdensity_prob_func(sample1, rbins, 
+        random_sphere_centers=random_sphere_centers, period=period, u=0.5)
+    upf2 = underdensity_prob_func(sample1, rbins, 
+        random_sphere_centers=random_sphere_centers, period=period, u=0.00001)
+    print(upf)
+    print(upf2)
+    assert np.all(upf >= upf2)  
+
+@pytest.mark.slow
+def test_upf3():
+    """ Verify that the UPF converges to the VPF in the 
+    limit of vanishing density threshold.  
+    """
+
+    Npts = 1000
+    Lbox = 1
+    period = np.array([Lbox,Lbox,Lbox])
+    sample1 = np.random.random((Npts, 3))
+    random_sphere_centers = np.random.random((Npts, 3))
+
+    rbins = np.logspace(-2, -0.5, 5)
+
+    upf = underdensity_prob_func(sample1, rbins, 
+        random_sphere_centers=random_sphere_centers, period=period, u=0)
+    upf2 = underdensity_prob_func(sample1, rbins, 
+        random_sphere_centers=random_sphere_centers, period=period, u=0.001)
+    vpf = void_prob_func(sample1, rbins, 
+        random_sphere_centers=random_sphere_centers, period=period)
+    assert np.all(upf == vpf)
+    assert np.all(upf2 >= vpf)
+
+@pytest.mark.slow
+def test_upf4():
+    """ Verify that the UPF and VPF raise no exceptions 
+    when operating on a tight locus of points.   
+    """
+
+    Npts = 1000
+    Lbox = 1
+    period = np.array([Lbox,Lbox,Lbox])
+    sample1 = generate_locus_of_3d_points(Npts)
+    n_ran = 1000
+
+    rbins = np.logspace(-1.5,-1,5)
+    upf = underdensity_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+
+

--- a/halotools/mock_observables/void_stats_helpers.py
+++ b/halotools/mock_observables/void_stats_helpers.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+"""
+Helper functions used to process the arguments passed 
+to functions in the void_stats module. 
+"""
+import numpy as np 
+from ..utils.array_utils import convert_to_ndarray, array_is_monotonic
+from ..custom_exceptions import *
+
+__all__ = ('_void_prob_func_process_args', 
+    '_underdensity_prob_func_process_args')
+
+def _void_prob_func_process_args(sample1, rbins, 
+    n_ran, random_sphere_centers, period, num_threads,
+    approx_cell1_size, approx_cellran_size):
+    """
+    """
+    sample1 = convert_to_ndarray(sample1)
+
+    rbins = convert_to_ndarray(rbins)
+    try:
+        assert rbins.ndim == 1
+        assert len(rbins) > 1
+        assert np.min(rbins) > 0
+        if len(rbins) > 2:
+            assert array_is_monotonic(rbins, strict = True) == 1
+    except AssertionError:
+        msg = ("\n Input ``rbins`` must be a monotonically increasing \n"
+               "1-D array with at least two entries. All entries must be strictly positive.")
+        raise HalotoolsError(msg)
+
+    if period is None:
+        xmin, xmax = np.min(sample1), np.max(sample1)
+        ymin, ymax = np.min(sample1), np.max(sample1)
+        zmin, zmax = np.min(sample1), np.max(sample1)
+    else:
+        period = convert_to_ndarray(period)
+        if len(period) == 1:
+            period = np.array([period, period, period])
+        elif len(period) == 3:
+            pass
+        else:
+            msg = ("\nInput ``period`` must either be a float or length-3 sequence")
+            raise HalotoolsError(msg)
+        xmin, xmax = 0., float(period[0])
+        ymin, ymax = 0., float(period[1])
+        zmin, zmax = 0., float(period[2])
+
+    if (n_ran is None):
+        if (random_sphere_centers is None):
+            msg = ("You must pass either ``n_ran`` or ``random_sphere_centers``")
+            raise HalotoolsError(msg)
+        else:
+            random_sphere_centers = convert_to_ndarray(random_sphere_centers)
+            try:
+                assert random_sphere_centers.shape[1] == 3
+            except AssertionError:
+                msg = ("Your input ``random_sphere_centers`` must have shape (Nspheres, 3)")
+                raise HalotoolsError(msg)
+        n_ran = float(random_sphere_centers.shape[0])
+    else:
+        if random_sphere_centers is not None:
+            msg = ("If passing in ``random_sphere_centers``, do not also pass in ``n_ran``.")
+            raise HalotoolsError(msg)
+        else:
+            xran = np.random.uniform(xmin, xmax, n_ran)
+            yran = np.random.uniform(ymin, ymax, n_ran)
+            zran = np.random.uniform(zmin, zmax, n_ran)
+            random_sphere_centers = np.vstack([xran, yran, zran]).T
+
+    return (sample1, rbins, n_ran, random_sphere_centers, 
+        period, num_threads, approx_cell1_size, approx_cellran_size)
+
+def _underdensity_prob_func_process_args(sample1, rbins, 
+    n_ran, random_sphere_centers, period, 
+    sample_volume, u, num_threads,
+    approx_cell1_size, approx_cellran_size):
+    """
+    """
+    sample1 = convert_to_ndarray(sample1)
+
+    rbins = convert_to_ndarray(rbins)
+    try:
+        assert rbins.ndim == 1
+        assert len(rbins) > 1
+        assert np.min(rbins) > 0
+        if len(rbins) > 2:
+            assert array_is_monotonic(rbins, strict = True) == 1
+    except AssertionError:
+        msg = ("\n Input ``rbins`` must be a monotonically increasing \n"
+               "1-D array with at least two entries. All entries must be strictly positive.")
+        raise HalotoolsError(msg)
+
+    if period is None:
+        xmin, xmax = np.min(sample1), np.max(sample1)
+        ymin, ymax = np.min(sample1), np.max(sample1)
+        zmin, zmax = np.min(sample1), np.max(sample1)
+        if sample_volume is None:
+            msg = ("If period is None, you must pass in ``sample_volume``.")
+            raise HalotoolsError(msg)
+        else:
+            sample_volume = float(sample_volume)
+    else:
+        period = convert_to_ndarray(period)
+        if len(period) == 1:
+            period = np.array([period, period, period])
+        elif len(period) == 3:
+            pass
+        else:
+            msg = ("\nInput ``period`` must either be a float or length-3 sequence")
+            raise HalotoolsError(msg)
+        xmin, xmax = 0., float(period[0])
+        ymin, ymax = 0., float(period[1])
+        zmin, zmax = 0., float(period[2])
+        if sample_volume is None:
+            sample_volume = period.prod()
+        else:
+            msg = ("If period is not None, do not pass in sample_volume")
+            raise HalotoolsError(msg)
+
+    if (n_ran is None):
+        if (random_sphere_centers is None):
+            msg = ("You must pass either ``n_ran`` or ``random_sphere_centers``")
+            raise HalotoolsError(msg)
+        else:
+            random_sphere_centers = convert_to_ndarray(random_sphere_centers)
+            try:
+                assert random_sphere_centers.shape[1] == 3
+            except AssertionError:
+                msg = ("Your input ``random_sphere_centers`` must have shape (Nspheres, 3)")
+                raise HalotoolsError(msg)
+        n_ran = float(random_sphere_centers.shape[0])
+    else:
+        if random_sphere_centers is not None:
+            msg = ("If passing in ``random_sphere_centers``, do not also pass in ``n_ran``.")
+            raise HalotoolsError(msg)
+        else:
+            xran = np.random.uniform(xmin, xmax, n_ran)
+            yran = np.random.uniform(ymin, ymax, n_ran)
+            zran = np.random.uniform(zmin, zmax, n_ran)
+            random_sphere_centers = np.vstack([xran, yran, zran]).T
+
+    u = float(u)
+
+    return (sample1, rbins, n_ran, random_sphere_centers, period, 
+        sample_volume, u, num_threads, approx_cell1_size, approx_cellran_size)
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Many new unit-tests added and associated bug-fixes. The functions that are changed are:

1. nearest_neighbors
2. pairwise velocity statistics
3. void statistics

In almost all cases, the bug fixes just addressed edge cases that previously raised uninformative error messages, e.g., if there was no nearest neighbor within a given search radius, the code used to raise a mysterious error message, now it no longer raises an exception. 

The only exception is with the pairwise velocity statistics. In this function, the periodic boundary conditions were not being handled correctly. The source of the bug has to do with the fact that the signs of the velocity was being flipped in an inconsistent way with the fact that the points were being pre-shifted by the pair-counting engine; this bug has been fixed. Note that this bug does not pertain to any other function in mock_observables. 