### PR TITLE
Now raising informative error message if a python 3.x user tries to install the code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ import glob
 import os
 import sys
 
+if sys.version_info[0] >2:
+    raise SystemError("You are using python 3.x, but currently Halotools is only 2.x compatible.")
+
 import ah_bootstrap
 from setuptools import setup
 


### PR DESCRIPTION
Previously, a mysterious error message was issued if 3.x users attempted `python setup.py install`. Now the python version is checked immediately and an exception is raised if sys.version_info[0] >2