### PR TITLE
HodModelFactory gal_types is now a list, not a set

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -543,7 +543,7 @@ class HodModelFactory(ModelFactory):
         _gal_type_list = []
         for component_model in self.model_dictionary.values():
             _gal_type_list.append(component_model.gal_type)
-        self.gal_types = set(list(_gal_type_list))
+        self.gal_types = list(set(_gal_type_list))
 
 
     def set_primary_behaviors(self):


### PR DESCRIPTION
This was accidental due to an unintentionally reversed order set(list(_gal_type_list)) rather than the list(set(_gal_type_list)). There were no consequences to this error, but this could have led to buggy behavior in future attempts to access, for example, self.gal_types[index]. 