### PR TITLE
Improve error handling of mock population

### DIFF
--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -40,7 +40,8 @@ unavailable_haloprop_msg = ("Your model requires that the ``%s`` key appear in t
     "but this column is not available in the catalog you attempted to populate.\n")
 
 missing_halo_upid_msg = ("All HOD-style models populate host halos with mock galaxies.\n"
-    "The way Halotools distinguishes host halos from subhalos is via the ``halo_upid`` column.\n"
+    "The way Halotools distinguishes host halos from subhalos is via the ``halo_upid`` column,\n"
+    "with halo_upid = -1 for host halos and !=-1 for subhalos.\n"
     "The halo catalog you passed to the HodMockFactory does not have the ``halo_upid`` column.\n")
 
 class HodMockFactory(MockFactory):

--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -36,6 +36,12 @@ from ...custom_exceptions import *
 __all__ = ['HodMockFactory']
 __author__ = ['Andrew Hearin']
 
+unavailable_haloprop_msg = ("Your model requires that the ``%s`` key appear in the halo catalog,\n"
+    "but this column is not available in the catalog you attempted to populate.\n")
+
+missing_halo_upid_msg = ("All HOD-style models populate host halos with mock galaxies.\n"
+    "The way Halotools distinguishes host halos from subhalos is via the ``halo_upid`` column.\n"
+    "The halo catalog you passed to the HodMockFactory does not have the ``halo_upid`` column.\n")
 
 class HodMockFactory(MockFactory):
     """ Class responsible for populating a simulation with a 
@@ -113,6 +119,11 @@ class HodMockFactory(MockFactory):
             Default is set in `~halotools.empirical_models.model_defaults`. 
 
         """
+        try:
+            assert 'halo_upid' in halocat.halo_table.keys()
+        except AssertionError:
+            raise HalotoolsError(missing_halo_upid_msg)
+
         ################ Make cuts on halo catalog ################
         # Select host halos only, since this is an HOD-style model
         halo_table = SampleSelector.host_halo_selection(table = halocat.halo_table)
@@ -135,7 +146,10 @@ class HodMockFactory(MockFactory):
 
         self._orig_halo_table = Table()
         for key in self.additional_haloprops:
-            self._orig_halo_table[key] = halo_table[key][:]
+            try:
+                self._orig_halo_table[key] = halo_table[key][:]
+            except KeyError:
+                raise HalotoolsError(unavailable_haloprop_msg % key)
 
         self.model.build_lookup_tables()
 

--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -19,6 +19,9 @@ from ...custom_exceptions import *
 __all__ = ['SubhaloMockFactory']
 __author__ = ['Andrew Hearin']
 
+unavailable_haloprop_msg = ("Your model requires that the ``%s`` key appear in the halo catalog,\n"
+    "but this column is not available in the catalog you attempted to populate.\n")
+
 
 class SubhaloMockFactory(MockFactory):
     """ Class responsible for populating a simulation with a 
@@ -82,7 +85,10 @@ class SubhaloMockFactory(MockFactory):
 
         self.halo_table = Table()
         for key in self.additional_haloprops:
-            self.halo_table[key] = halo_table[key]
+            try:
+                self.halo_table[key] = halo_table[key]
+            except KeyError:
+                raise HalotoolsError(unavailable_haloprop_msg % key)
 
 
     def precompute_galprops(self):

--- a/halotools/empirical_models/factories/tests/test_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_model_factory.py
@@ -90,7 +90,25 @@ class TestHodModelFactory(TestCase):
         assert model.mock.Num_ptcl_requirement == 0.
         assert np.any(model.mock.halo_table['halo_mvir'] < default_mvir_min)
 
+    def test_unavailable_haloprop(self):
+        halocat = FakeSim()
+        m = PrebuiltHodModelFactory('zheng07')
+        m._haloprop_list.append("Jose Canseco")
+        with pytest.raises(HalotoolsError) as err:
+            m.populate_mock(halocat = halocat)
+        substr = "this column is not available in the catalog you attempted to populate"
+        assert substr in err.value.message
+        assert "``Jose Canseco``" in err.value.message
 
+    def test_unavailable_upid(self):
+        halocat = FakeSim()
+        del halocat.halo_table['halo_upid']
+        m = PrebuiltHodModelFactory('zheng07')
+
+        with pytest.raises(HalotoolsError) as err:
+            m.populate_mock(halocat = halocat)
+        substr = "does not have the ``halo_upid`` column."
+        assert substr in err.value.message
 
 
 

--- a/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
@@ -10,7 +10,7 @@ from copy import copy
 from ...smhm_models import Behroozi10SmHm, Moster13SmHm
 from ...component_model_templates import BinaryGalpropInterpolModel
 
-from ...factories import SubhaloModelFactory
+from ...factories import SubhaloModelFactory, PrebuiltSubhaloModelFactory
 from ...composite_models.smhm_models.behroozi10 import behroozi10_model_dictionary
 
 
@@ -151,6 +151,16 @@ class TestSubhaloModelFactory(TestCase):
             model = SubhaloModelFactory()
         substr = "You did not pass any model features to the factory"
         assert substr in err.value.message
+
+    def test_unavailable_haloprop(self):
+        halocat = FakeSim()
+        m = PrebuiltSubhaloModelFactory('behroozi10')
+        m._haloprop_list.append("Jose Canseco")
+        with pytest.raises(HalotoolsError) as err:
+            m.populate_mock(halocat = halocat)
+        substr = "this column is not available in the catalog you attempted to populate"
+        assert substr in err.value.message
+        assert "``Jose Canseco``" in err.value.message
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Now catching exceptions for attempts to populate a simulation that does not have a required halo property. Also, attempts to use and HOD-style model to populate a halo catalog without the `halo_upid` column are now also caught. 

This PR resolves #312 and #362. 