### PR TITLE
Removed needless unit test of convert_to_ndarray

### DIFF
--- a/halotools/utils/tests/test_array_utils.py
+++ b/halotools/utils/tests/test_array_utils.py
@@ -188,9 +188,4 @@ def test_convert_to_ndarray15():
     v = np.array([])
     varr = array_utils.convert_to_ndarray(v) 
 
-def test_convert_to_ndarray15():
-    """
-    """
-    t = Table(np.array([]))
-    tarr = array_utils.convert_to_ndarray(t) 
 


### PR DESCRIPTION
As pointed out by @andrew-zentner , test_convert_to_ndarray15 fails for out-of-date versions of astropy, and it is an utterly irrelevant test. 