### PR TITLE
integer arguments for redshift are supported

### DIFF
--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -96,7 +96,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
         with pytest.raises(HalotoolsError) as err:
             halocat = UserSuppliedHaloCatalog(
-                Lbox = 200, particle_mass = 100, redshift = '1.0', 
+                Lbox = 200, particle_mass = 100, redshift = '', 
                 **self.good_halocat_args)
         substr = "The ``redshift`` metadata must be a float."
         assert substr in err.value.message

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -89,7 +89,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
         with pytest.raises(HalotoolsError) as err:
             ptclcat = UserSuppliedPtclCatalog(
-                Lbox = 200, particle_mass = 100, redshift = '1.0', 
+                Lbox = 200, particle_mass = 100, redshift = '', 
                 **self.good_ptclcat_args)
         substr = "The ``redshift`` metadata must be a float."
         assert substr in err.value.message

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -232,10 +232,10 @@ class UserSuppliedHaloCatalog(object):
                 "that are bound by 0 and the input ``Lbox``. \n")
             raise HalotoolsError(msg)
 
-        redshift = metadata_dict['redshift']
+        
         try:
-            assert type(redshift) == float
-        except AssertionError:
+            redshift = float(metadata_dict['redshift'])
+        except:
             msg = ("\nThe ``redshift`` metadata must be a float.\n")
             raise HalotoolsError(msg)
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -214,10 +214,10 @@ class UserSuppliedPtclCatalog(object):
                 "that are bound by 0 and the input ``Lbox``. \n")
             raise HalotoolsError(msg)
 
-        redshift = metadata_dict['redshift']
+        
         try:
-            assert type(redshift) == float
-        except AssertionError:
+            redshift = float(metadata_dict['redshift'])
+        except:
             msg = ("\nThe ``redshift`` metadata must be a float.\n")
             raise HalotoolsError(msg)
 


### PR DESCRIPTION
Previously, there was a hard-coded check that an input redshift argument to a halo catalog had to be a float. This PR relaxes this requirement via duck-typing: if the `redshift` keyword argument can be converted to a float via the python built-in, the argument is permissible. 