### PR TITLE
Large scale density

### DIFF
--- a/halotools/mock_observables/large_scale_density.py
+++ b/halotools/mock_observables/large_scale_density.py
@@ -17,8 +17,9 @@ from .large_scale_density_helpers import *
 ##########################################################################################
 
 
-__all__=['large_scale_density_spherical_volume']
-__author__ = ['Andrew Hearin', 'Duncan Campbell']
+__all__ = ('large_scale_density_spherical_volume', 
+    'large_scale_density_spherical_annulus')
+__author__ = ['Andrew Hearin']
 
 np.seterr(divide='ignore', invalid='ignore') #ignore divide by zero in e.g. DD/RR
 
@@ -105,6 +106,98 @@ def large_scale_density_spherical_volume(sample, tracers, radius,
     result = _[:,0]
 
     environment_volume = (4/3.)*np.pi*radius**3
+    number_density = result/environment_volume
+
+    if norm_by_mean_density is True:
+        mean_rho = tracers.shape[0]/sample_volume
+        return number_density/mean_rho
+    else:
+        return number_density
+
+
+def large_scale_density_spherical_annulus(sample, tracers, inner_radius, outer_radius, 
+    period=None, sample_volume = None, num_threads=1, approx_cell1_size=None, 
+    norm_by_mean_density = False):
+    """
+    Calculate the mean density of the input ``sample`` 
+    from an input set of tracer particles. 
+
+    Around each point in the input ``sample``, a sphere of the input ``radius`` 
+    is placed and the number of points in the input ``tracers`` is counted, 
+    optionally accounting for box periodicity. 
+    The `large_scale_density_spherical_volume` returns the mean number density 
+    of tracer particles in each such sphere, optionally normalizing this result 
+    by the global mean number density of tracer particles in the entire sample volume. 
+
+    Parameters 
+    ------------
+    sample : array_like 
+        Npts x 3 numpy array containing 3-D positions of points.
+        See `~halotools.mock_observables.return_xyz_formatted_array` for 
+        a convenience function that can be used to transform a set of x, y, z 
+        1d arrays into the required form. 
+
+    tracers : array_like 
+        Npts x 3 numpy array containing 3-D positions of tracers.
+
+    inner_radius, outer_radius : float, float
+        Radii of the annulus used to define the volume inside which the 
+        number density of tracers is calculated. 
+
+    period : array_like, optional 
+        length 3 array defining axis-aligned periodic boundary conditions. If only
+        one number, Lbox, is specified, period is assumed to be np.array([Lbox]*3).
+        If set to None, PBCs are set to infinity, in which case ``sample_volume`` 
+        must be specified. 
+
+    sample_volume : float, optional 
+        If period is set to None, you must specify the effective volume of the sample. 
+
+    num_threads : int, optional
+        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        available cores.  num_threads=0 is the default.
+    
+    approx_cell1_size : array_like, optional 
+        Length-3 array serving as a guess for the optimal manner by which 
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
+        will apportion the ``sample1`` points into subvolumes of the simulation box. 
+        The optimum choice unavoidably depends on the specs of your machine. 
+        Default choice is to use *max(rbins)* in each dimension, 
+        which will return reasonable result performance for most use-cases. 
+        Performance can vary sensitively with this parameter, so it is highly 
+        recommended that you experiment with this parameter when carrying out  
+        performance-critical calculations. 
+
+    norm_by_mean_density : bool, optional 
+        If set to True, the returned number density will be normalized by 
+        the global number density of tracer particles averaged across the 
+        entire ``sample_volume``. Default is False. 
+
+    Returns 
+    --------
+    number_density : array_like 
+        Length-Npts array of number densities
+
+    Examples 
+    ---------
+    >>> npts1, npts2 = 100, 200
+    >>> sample = np.random.random((npts1, 3))
+    >>> tracers = np.random.random((npts2, 3))
+    >>> inner_radius, outer_radius = 0.1, 0.2
+    >>> result = large_scale_density_spherical_annulus(sample, tracers, inner_radius, outer_radius, period=1)
+
+    """
+    sample, tracers, rbins, period, sample_volume, num_threads, approx_cell1_size = (
+        _large_scale_density_spherical_annulus_process_args(
+            sample, tracers, inner_radius, outer_radius, 
+            period, sample_volume, num_threads, approx_cell1_size)
+        )
+
+    _ = per_object_npairs(sample, tracers, rbins, period = period,
+        num_threads = num_threads, approx_cell1_size = approx_cell1_size)
+    result = np.diff(_, axis=1)
+
+    environment_volume = (4/3.)*np.pi*(outer_radius**3 - inner_radius**3)
     number_density = result/environment_volume
 
     if norm_by_mean_density is True:

--- a/halotools/mock_observables/large_scale_density.py
+++ b/halotools/mock_observables/large_scale_density.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+
+"""
+functions to measure large-scale density
+"""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+####import modules########################################################################
+import numpy as np
+from .pair_counters.double_tree_per_object_pairs import *
+from ..custom_exceptions import *
+from warnings import warn
+
+from ..utils import convert_to_ndarray
+from .large_scale_density_helpers import *
+##########################################################################################
+
+
+__all__=['large_scale_density_spherical_volume']
+__author__ = ['Andrew Hearin', 'Duncan Campbell']
+
+np.seterr(divide='ignore', invalid='ignore') #ignore divide by zero in e.g. DD/RR
+
+
+def large_scale_density_spherical_volume(sample, tracers, radius, 
+    period=None, sample_volume = None, num_threads=1, approx_cell1_size=None, 
+    norm_by_mean_density = False):
+    """
+    Calculate the mean density of the input ``sample`` 
+    from an input set of tracer particles. 
+
+    Around each point in the input ``sample``, a sphere of the input ``radius`` 
+    is placed and the number of points in the input ``tracers`` is counted, 
+    optionally accounting for box periodicity. 
+    The `large_scale_density_spherical_volume` returns the mean number density 
+    of tracer particles in each such sphere, optionally normalizing this result 
+    by the global mean number density of tracer particles in the entire sample volume. 
+
+    Parameters 
+    ------------
+    sample : array_like 
+        Npts x 3 numpy array containing 3-D positions of points.
+        See `~halotools.mock_observables.return_xyz_formatted_array` for 
+        a convenience function that can be used to transform a set of x, y, z 
+        1d arrays into the required form. 
+
+    tracers : array_like 
+        Npts x 3 numpy array containing 3-D positions of tracers.
+
+    radius : float 
+        Radius of the sphere used to define the volume inside which the 
+        number density of tracers is calculated. 
+
+    period : array_like, optional 
+        length 3 array defining axis-aligned periodic boundary conditions. If only
+        one number, Lbox, is specified, period is assumed to be np.array([Lbox]*3).
+        If set to None, PBCs are set to infinity, in which case ``sample_volume`` 
+        must be specified. 
+
+    sample_volume : float, optional 
+        If period is set to None, you must specify the effective volume of the sample. 
+
+    num_threads : int, optional
+        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        available cores.  num_threads=0 is the default.
+    
+    approx_cell1_size : array_like, optional 
+        Length-3 array serving as a guess for the optimal manner by which 
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
+        will apportion the ``sample1`` points into subvolumes of the simulation box. 
+        The optimum choice unavoidably depends on the specs of your machine. 
+        Default choice is to use *max(rbins)* in each dimension, 
+        which will return reasonable result performance for most use-cases. 
+        Performance can vary sensitively with this parameter, so it is highly 
+        recommended that you experiment with this parameter when carrying out  
+        performance-critical calculations. 
+
+    norm_by_mean_density : bool, optional 
+        If set to True, the returned number density will be normalized by 
+        the global number density of tracer particles averaged across the 
+        entire ``sample_volume``. Default is False. 
+
+    Returns 
+    --------
+    number_density : array_like 
+        Length-Npts array of number densities
+
+    Examples 
+    ---------
+    >>> npts1, npts2 = 100, 200
+    >>> sample = np.random.random((npts1, 3))
+    >>> tracers = np.random.random((npts2, 3))
+    >>> radius = 0.1
+    >>> result = large_scale_density_spherical_volume(sample, tracers, radius, period=1)
+
+    """
+    sample, tracers, rbins, period, sample_volume, num_threads, approx_cell1_size = (
+        _large_scale_density_spherical_volume_process_args(
+            sample, tracers, radius, period, sample_volume, num_threads, approx_cell1_size)
+        )
+
+    _ = per_object_npairs(sample, tracers, rbins, period = period,
+        num_threads = num_threads, approx_cell1_size = approx_cell1_size)
+    result = _[:,0]
+
+    environment_volume = (4/3.)*np.pi*radius**3
+    number_density = result/environment_volume
+
+    if norm_by_mean_density is True:
+        mean_rho = tracers.shape[0]/sample_volume
+        return number_density/mean_rho
+    else:
+        return number_density
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/halotools/mock_observables/large_scale_density_helpers.py
+++ b/halotools/mock_observables/large_scale_density_helpers.py
@@ -8,7 +8,8 @@ import numpy as np
 from ..utils.array_utils import convert_to_ndarray, array_is_monotonic
 from ..custom_exceptions import *
 
-__all__ = ('_large_scale_density_spherical_volume_process_args', )
+__all__ = ('_large_scale_density_spherical_volume_process_args', 
+    '_large_scale_density_spherical_annulus_process_args')
 
 
 def _large_scale_density_spherical_volume_process_args(
@@ -44,6 +45,43 @@ def _large_scale_density_spherical_volume_process_args(
 
     return sample, tracers, rbins, period, sample_volume, num_threads, approx_cell1_size
 
+def _large_scale_density_spherical_annulus_process_args(
+    sample, tracers, inner_radius, outer_radius, 
+    period, sample_volume, num_threads, approx_cell1_size):
+    """
+    """
+    sample = convert_to_ndarray(sample)
+    tracers = convert_to_ndarray(tracers)
+
+    try:
+        assert outer_radius > inner_radius
+    except AssertionError:
+        msg = ("Input ``outer_radius`` must be larger than input ``inner_radius``")
+        raise HalotoolsError(msg)
+    rbins = np.array([inner_radius, outer_radius])
+
+    if period is None:
+        if sample_volume is None:
+            msg = ("If period is None, you must pass in ``sample_volume``.")
+            raise HalotoolsError(msg)
+        else:
+            sample_volume = float(sample_volume)
+    else:
+        period = convert_to_ndarray(period)
+        if len(period) == 1:
+            period = np.array([period, period, period])
+        elif len(period) == 3:
+            pass
+        else:
+            msg = ("\nInput ``period`` must either be a float or length-3 sequence")
+            raise HalotoolsError(msg)
+        if sample_volume is None:
+            sample_volume = period.prod()
+        else:
+            msg = ("If period is not None, do not pass in sample_volume")
+            raise HalotoolsError(msg)
+
+    return sample, tracers, rbins, period, sample_volume, num_threads, approx_cell1_size
 
 
 

--- a/halotools/mock_observables/large_scale_density_helpers.py
+++ b/halotools/mock_observables/large_scale_density_helpers.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+"""
+Helper functions used to process the arguments passed 
+to functions in the void_stats module. 
+"""
+import numpy as np 
+from ..utils.array_utils import convert_to_ndarray, array_is_monotonic
+from ..custom_exceptions import *
+
+__all__ = ('_large_scale_density_spherical_volume_process_args', )
+
+
+def _large_scale_density_spherical_volume_process_args(
+    sample, tracers, radius, period, sample_volume, num_threads, approx_cell1_size):
+    """
+    """
+    sample = convert_to_ndarray(sample)
+    tracers = convert_to_ndarray(tracers)
+    _ = convert_to_ndarray(radius, dt=float)
+    rbins = np.append(_, _[0]+0.0001)
+
+
+    if period is None:
+        if sample_volume is None:
+            msg = ("If period is None, you must pass in ``sample_volume``.")
+            raise HalotoolsError(msg)
+        else:
+            sample_volume = float(sample_volume)
+    else:
+        period = convert_to_ndarray(period)
+        if len(period) == 1:
+            period = np.array([period, period, period])
+        elif len(period) == 3:
+            pass
+        else:
+            msg = ("\nInput ``period`` must either be a float or length-3 sequence")
+            raise HalotoolsError(msg)
+        if sample_volume is None:
+            sample_volume = period.prod()
+        else:
+            msg = ("If period is not None, do not pass in sample_volume")
+            raise HalotoolsError(msg)
+
+    return sample, tracers, rbins, period, sample_volume, num_threads, approx_cell1_size
+
+
+
+
+

--- a/halotools/mock_observables/tests/test_large_scale_density.py
+++ b/halotools/mock_observables/tests/test_large_scale_density.py
@@ -65,4 +65,75 @@ def test_large_scale_density_spherical_volume2():
 	correct_answer = 200/environment_volume/mean_density
 	assert np.allclose(result, correct_answer, rtol=0.001)
 
+def test_large_scale_density_spherical_annulus_exception_handling():
+	"""
+	"""
+	npts1, npts2 = 100, 200
+	sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
+	tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+	inner_radius, outer_radius = 0.1, 0.2
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_annulus(
+			sample, tracers, inner_radius, outer_radius)
+	substr = "If period is None, you must pass in ``sample_volume``."
+	assert substr in err.value.message
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_annulus(
+			sample, tracers, inner_radius, outer_radius, period=[1,1])
+	substr = "Input ``period`` must either be a float or length-3 sequence"
+	assert substr in err.value.message
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_annulus(
+			sample, tracers, inner_radius, outer_radius, period=1, sample_volume=0.4)
+	substr = "If period is not None, do not pass in sample_volume"
+	assert substr in err.value.message
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_annulus(
+			sample, tracers, 0.5, outer_radius, period=1, sample_volume=0.4)
+	substr = "Input ``outer_radius`` must be larger than input ``inner_radius``"
+	assert substr in err.value.message
+
+def test_large_scale_density_spherical_annulus1():
+	"""
+	"""
+	npts1, npts2 = 100, 200
+	sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
+	tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+	inner_radius, outer_radius = 0.04, 0.1
+	result = large_scale_density_spherical_annulus(
+		sample, tracers, inner_radius, outer_radius, period=1)
+
+	environment_volume = (4/3.)*np.pi*(outer_radius**3 - inner_radius**3)
+	correct_answer = 200/environment_volume
+	assert np.allclose(result, correct_answer, rtol=0.001)
+
+def test_large_scale_density_spherical_annulus2():
+	"""
+	"""
+	npts1, npts2 = 100, 200
+	sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
+	tracers = generate_locus_of_3d_points(npts2, xc=0.95, yc=0.1, zc=0.1)
+	inner_radius, outer_radius = 0.1, 0.2
+	result = large_scale_density_spherical_annulus(
+		sample, tracers, inner_radius, outer_radius, 
+		period=[1,1,1], norm_by_mean_density=True)
+
+	environment_volume = (4/3.)*np.pi*(outer_radius**3 - inner_radius**3)
+	mean_density = float(npts2)
+	correct_answer = 200/environment_volume/mean_density
+	assert np.allclose(result, correct_answer, rtol=0.001)
+
+
+
+
+
+
+
+
+
+
 

--- a/halotools/mock_observables/tests/test_large_scale_density.py
+++ b/halotools/mock_observables/tests/test_large_scale_density.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+from __future__ import (absolute_import, division, print_function)
+import numpy as np 
+from astropy.tests.helper import pytest
+from ...custom_exceptions import HalotoolsError
+
+from ..large_scale_density import *
+from .cf_helpers import generate_locus_of_3d_points
+
+__all__ = ('test_large_scale_density_spherical_volume1', )
+
+def test_large_scale_density_spherical_volume_exception_handling():
+	"""
+	"""
+	npts1, npts2 = 100, 200
+	sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
+	tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+	radius = 0.1
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_volume(
+			sample, tracers, radius)
+	substr = "If period is None, you must pass in ``sample_volume``."
+	assert substr in err.value.message
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_volume(
+			sample, tracers, radius, period=[1,1])
+	substr = "Input ``period`` must either be a float or length-3 sequence"
+	assert substr in err.value.message
+
+	with pytest.raises(HalotoolsError) as err:
+		result = large_scale_density_spherical_volume(
+			sample, tracers, radius, period=1, sample_volume=0.4)
+	substr = "If period is not None, do not pass in sample_volume"
+	assert substr in err.value.message
+
+def test_large_scale_density_spherical_volume1():
+	"""
+	"""
+	npts1, npts2 = 100, 200
+	sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
+	tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+	radius = 0.1
+	result = large_scale_density_spherical_volume(
+		sample, tracers, radius, period=1)
+
+	environment_volume = (4/3.)*np.pi*radius**3
+	correct_answer = 200/environment_volume
+	assert np.allclose(result, correct_answer, rtol=0.001)
+
+
+def test_large_scale_density_spherical_volume2():
+	"""
+	"""
+	npts1, npts2 = 100, 200
+	sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
+	tracers = generate_locus_of_3d_points(npts2, xc=0.95, yc=0.1, zc=0.1)
+	radius = 0.2
+	result = large_scale_density_spherical_volume(
+		sample, tracers, radius, period=[1,1,1], norm_by_mean_density=True)
+	mean_density = float(npts2)
+
+	environment_volume = (4/3.)*np.pi*radius**3
+	correct_answer = 200/environment_volume/mean_density
+	assert np.allclose(result, correct_answer, rtol=0.001)
+
+

--- a/halotools/mock_observables/tests/test_void_stats.py
+++ b/halotools/mock_observables/tests/test_void_stats.py
@@ -7,6 +7,9 @@ from ...custom_exceptions import HalotoolsError
 from ..void_stats import *
 from .cf_helpers import generate_locus_of_3d_points
 
+__all__ = ('test_vpf1', 'test_vpf2', 'test_vpf3', 'test_upf1', 
+    'test_upf2', 'test_upf3', 'test_upf4')
+
 def test_vpf1():
     """ Verify that the VPF raises no exceptions 
     for several reasonable choices of rbins. 

--- a/halotools/mock_observables/void_stats.py
+++ b/halotools/mock_observables/void_stats.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """
-funcitons to measure void statistics
+functions to measure void statistics
 """
 
 from __future__ import (absolute_import, division, print_function,
@@ -42,7 +42,10 @@ def void_prob_func(sample1, rbins, n_ran=None, random_sphere_centers=None,
     ----------
     sample1 : array_like
         Npts x 3 numpy array containing 3-D positions of points.
-    
+        See `~halotools.mock_observables.return_xyz_formatted_array` for 
+        a convenience function that can be used to transform a set of x, y, z 
+        1d arrays into the required form. 
+
     rbins : float
         size of spheres to search for neighbors
     
@@ -132,9 +135,6 @@ def void_prob_func(sample1, rbins, n_ran=None, random_sphere_centers=None,
                               approx_cell1_size = approx_cell1_size,\
                               approx_cell2_size = approx_cellran_size)
 
-    # mask = (result > 1)
-    # result = np.sum(mask, axis=0)
-    # return (n_ran - result)/n_ran
     num_empty_spheres = np.array(
         [sum(result[:,i] == 0) for i in xrange(result.shape[1])])
     return num_empty_spheres/n_ran
@@ -160,7 +160,10 @@ def underdensity_prob_func(sample1, rbins, n_ran=None,
     ----------
     sample1 : array_like
         Npts x 3 numpy array containing 3-D positions of points.
-    
+        See `~halotools.mock_observables.return_xyz_formatted_array` for 
+        a convenience function that can be used to transform a set of x, y, z 
+        1d arrays into the required form. 
+
     rbins : float
         size of spheres to search for neighbors
     


### PR DESCRIPTION
This PR addresses #236. There are two new functions introduced here: `large_scale_density_spherical_volume` and `large_scale_density_spherical_annulus`, both of which use `per_object_npairs`. 

Large-scale density estimations based on cylinders will have to wait for an implementation of `per_object_xy_z_npairs` in the `v0.2` release. 

CC @duncandc 