### PR TITLE
Update helpers and bootstrap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,8 @@ else:
     import __builtin__ as builtins
 builtins._ASTROPY_SETUP_ = True
 
-from astropy_helpers.setup_helpers import (
-    register_commands, adjust_compiler, get_debug_option, get_package_info)
+from astropy_helpers.setup_helpers import (register_commands, get_debug_option,
+                                           get_package_info)
 from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
@@ -58,10 +58,6 @@ if not RELEASE:
 # invoking any other functionality from distutils since it can potentially
 # modify distutils' behavior.
 cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
-
-# Adjust the compiler in case the default on this platform is to use a
-# broken one.
-adjust_compiler(PACKAGENAME)
 
 # Freeze build information in version.py
 generate_version_py(PACKAGENAME, VERSION, RELEASE,


### PR DESCRIPTION
This updates the bundeled astropy helpers to the latest helpers version, and also copies over the `ah_boostrap.py` from that to the root of halotools.

This should get rid of the deprecation warning from setuptools as well as anything else that might have been fixed in `ah_bootstrap` in the meantime.