### PR TITLE
MANIFEST.in update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 *.cpp
 
 # Other generated files
+MANIFEST
 */version.py
 */cython_version.py
 htmlcov

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,18 +1,24 @@
 include README.rst
+include CHANGES.rst
 
 include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
 
+recursive-include *.pyx *.pxd *.c *.cpp *.h
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
 
-exclude *.pyc *.o
-prune docs/_build
 prune build
+prune docs/_build
+prune docs/api
+
 
 recursive-include astropy_helpers *
 exclude astropy_helpers/.git
 exclude astropy_helpers/.gitignore
+
+
+global-exclude *.pyc *.o

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include CHANGES.rst
 
 include ez_setup.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,9 +16,25 @@ prune docs/_build
 prune docs/api
 
 
-recursive-include astropy_helpers *
-exclude astropy_helpers/.git
-exclude astropy_helpers/.gitignore
+# the next few stanzas are for astropy_helpers.  It's derived from the
+# astropy_helpers/MANIFEST.in, but requires additional includes for the actual
+# package directory and egg-info.
+
+include astropy_helpers/README.rst
+include astropy_helpers/CHANGES.rst
+include astropy_helpers/LICENSE.rst
+recursive-include astropy_helpers/licenses *
+
+include astropy_helpers/ez_setup.py
+include astropy_helpers/ah_bootstrap.py
+
+recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h
+recursive-include astropy_helpers/astropy_helpers.egg-info *
+# include the sphinx stuff with "*" because there are css/html/rst/etc.
+recursive-include astropy_helpers/astropy_helpers/sphinx *
+
+prune astropy_helpers/build
+prune astropy_helpers/astropy_helpers/tests
 
 
 global-exclude *.pyc *.o


### PR DESCRIPTION
this update the halotools MANIFEST.in to actually include all the files that halotools is supposed to have.

@aphearin - if you don't know about ``MANIFEST.in``, it's a file that basically tells release commands like ``sdist`` what to put in the tarball.  Confusingly, though, any source files that are included in the setup script are *automatically* included.  But that misses things like .h files, .c files that aren't explicitly compiled as python modules, etc.  So this update should account for that (as well as being *less* heavy handed in what gets included in astropy_helpers - see the second commit).

While I said earlier to @aphearin that maybe this shouldn't get merged, I now think it should be prior to release regardless.  But there's possibly a separate problem that perhaps should be resolved (will file an issue on this shortly).