### PR TITLE
fix manifest to include source files *in the halotools* dir

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,7 +5,7 @@ include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
 
-recursive-include *.pyx *.pxd *.c *.cpp *.h
+recursive-include halotools *.pyx *.pxd *.c *.cpp *.h
 recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *


### PR DESCRIPTION
There was a mistake in #443 - I added the ``MANIFEST.in`` line to include all the Cython source files but neglected to specify *where* (it should have been the halotools source dir, and in what's in master I think it instead looks for ``*.pxd *.c *.cpp *.h`` in any directory named ``*.pyx``.  But of course that's nothing.)