### PR TITLE
Performance enhancements of mock_observables

### DIFF
--- a/halotools/mock_observables/pair_counters/cpairs/cpairs.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/cpairs.pyx
@@ -1402,7 +1402,7 @@ def s_mu_npairs_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
 #### binning functions ####
 ###########################
 
-cdef inline radial_binning(np.int_t* counts, np.float64_t* bins,\
+cdef inline void radial_binning(np.int_t* counts, np.float64_t* bins,\
                            np.float64_t d, np.int_t k):
     """
     real space radial binning function
@@ -1414,7 +1414,7 @@ cdef inline radial_binning(np.int_t* counts, np.float64_t* bins,\
         if k<0: break
 
 
-cdef inline radial_wbinning(np.float64_t* counts, np.float64_t* bins,\
+cdef inline void radial_wbinning(np.float64_t* counts, np.float64_t* bins,\
                             np.float64_t d, np.int_t k,\
                             np.float64_t w1, np.float64_t w2):
     """
@@ -1427,7 +1427,7 @@ cdef inline radial_wbinning(np.float64_t* counts, np.float64_t* bins,\
         if k<0: break
 
 
-cdef inline radial_jbinning(np.float64_t* counts, np.float64_t* bins,\
+cdef inline void radial_jbinning(np.float64_t* counts, np.float64_t* bins,\
                             np.float64_t d,\
                             np.int_t nbins_minus_one,\
                             np.int_t N_samples,\
@@ -1448,7 +1448,7 @@ cdef inline radial_jbinning(np.float64_t* counts, np.float64_t* bins,\
             if k<0: break
 
 
-cdef inline xy_z_binning(np.int_t* counts, np.float64_t* rp_bins,\
+cdef inline void xy_z_binning(np.int_t* counts, np.float64_t* rp_bins,\
                          np.float64_t* pi_bins, np.float64_t d_perp,\
                          np.float64_t d_para, np.int_t k,\
                          np.int_t npi_bins_minus_one):
@@ -1469,7 +1469,7 @@ cdef inline xy_z_binning(np.int_t* counts, np.float64_t* rp_bins,\
         if k<0: break
 
 
-cdef inline xy_z_wbinning(np.float64_t* counts, np.float64_t* rp_bins,\
+cdef inline void xy_z_wbinning(np.float64_t* counts, np.float64_t* rp_bins,\
                           np.float64_t* pi_bins, np.float64_t d_perp,\
                           np.float64_t d_para, np.int_t k,\
                           np.int_t npi_bins_minus_one, np.float64_t w1, np.float64_t w2):
@@ -1490,7 +1490,7 @@ cdef inline xy_z_wbinning(np.float64_t* counts, np.float64_t* rp_bins,\
         if k<0: break
 
 
-cdef inline xy_z_jbinning(np.float64_t* counts, np.float64_t* rp_bins,\
+cdef inline void xy_z_jbinning(np.float64_t* counts, np.float64_t* rp_bins,\
                           np.float64_t* pi_bins, np.float64_t d_perp,\
                           np.float64_t d_para,\
                           np.int_t nrp_bins_minus_one,\

--- a/halotools/mock_observables/pair_counters/cpairs/per_object_cpairs.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/per_object_cpairs.pyx
@@ -114,7 +114,7 @@ def per_object_npairs_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
     return outer_counts
 
 
-cdef inline radial_binning(np.int_t* counts, np.float64_t* bins,\
+cdef inline void radial_binning(np.int_t* counts, np.float64_t* bins,\
                            np.float64_t d, np.int_t k):
     """
     real space radial binning function

--- a/halotools/mock_observables/pair_counters/cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/cpairs/setup_package.py
@@ -16,7 +16,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = []
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pair_counters/double_tree_pair_matrix.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pair_matrix.py
@@ -197,7 +197,6 @@ def _pair_matrix_engine(double_tree, r_max, period, PBCs, icell1):
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
             
-    adj_cell_counter = 0
     for icell2, xshift, yshift, zshift in adj_cell_generator:
                 
         #extract the points in the cell
@@ -411,9 +410,7 @@ def _xy_z_pair_matrix_engine(double_tree, rp_max, pi_max, period, PBCs, icell1):
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
     
-    adj_cell_counter = 0
     for icell2, xshift, yshift, zshift in adj_cell_generator:
-        adj_cell_counter +=1
         
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
@@ -715,7 +712,6 @@ def _conditional_pair_matrix_engine(double_tree, weights1, weights2, r_max, peri
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
             
-    adj_cell_counter = 0
     for icell2, xshift, yshift, zshift in adj_cell_generator:
                 
         #extract the points in the cell
@@ -1035,9 +1031,7 @@ def _conditional_xy_z_pair_matrix_engine(double_tree, weights1, weights2, rp_max
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
     
-    adj_cell_counter = 0
     for icell2, xshift, yshift, zshift in adj_cell_generator:
-        adj_cell_counter +=1
         
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]

--- a/halotools/mock_observables/pair_counters/marked_cpairs/marked_cpairs.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/marked_cpairs.pyx
@@ -587,7 +587,7 @@ def xy_z_velocity_marked_npairs_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1
 #### binning functions ####
 ###########################
 
-cdef inline radial_wbinning(np.float64_t* counts, np.float64_t* bins,\
+cdef inline void radial_wbinning(np.float64_t* counts, np.float64_t* bins,\
                             np.float64_t d, np.int_t k,\
                             np.float64_t* w1, np.float64_t* w2, f_type wfunc,\
                             np.float64_t* shift):
@@ -602,7 +602,7 @@ cdef inline radial_wbinning(np.float64_t* counts, np.float64_t* bins,\
         if k<0: break
 
 
-cdef inline radial_velocity_wbinning(np.float64_t* counts1,\
+cdef inline void radial_velocity_wbinning(np.float64_t* counts1,\
                                      np.float64_t* counts2,\
                                      np.float64_t* counts3,\
                                      np.float64_t* bins, np.float64_t d, np.int_t k,\
@@ -622,7 +622,7 @@ cdef inline radial_velocity_wbinning(np.float64_t* counts1,\
         if k<0: break
 
 
-cdef inline xy_z_wbinning(np.float64_t* counts,
+cdef inline void xy_z_wbinning(np.float64_t* counts,
                           np.float64_t* rp_bins,
                           np.float64_t* pi_bins,
                           np.float64_t d_perp,
@@ -651,7 +651,7 @@ cdef inline xy_z_wbinning(np.float64_t* counts,
         if k<0: break
 
 
-cdef inline xy_z_velocity_wbinning(np.float64_t* counts1,
+cdef inline void xy_z_velocity_wbinning(np.float64_t* counts1,
                                    np.float64_t* counts2,
                                    np.float64_t* counts3,
                                    np.float64_t* rp_bins,

--- a/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
@@ -14,7 +14,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = []
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
@@ -57,6 +57,22 @@ def test_marked_npairs_periodic():
     
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
 
+def test_marked_npairs_parallelization():
+    """
+    Function tests marked_npairs with periodic boundary conditions.
+    """
+    
+    rbins = np.array([0.0,0.1,0.2,0.3])
+    
+    serial_result = marked_npairs(random_sample, random_sample, 
+        rbins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
+
+    parallel_result = marked_npairs(random_sample, random_sample, 
+        rbins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1, 
+        num_threads = 'max')
+    
+    assert np.allclose(serial_result,parallel_result,rtol=1e-09), "pair counts are incorrect"
+
 
 def test_marked_npairs_nonperiodic():
     """
@@ -88,10 +104,24 @@ def test_xy_z_marked_npairs_periodic():
     test_result = pure_python_xy_z_weighted_pairs(random_sample, random_sample, rp_bins, pi_bins,
         period=period, weights1=ran_weights1, weights2=ran_weights1)
     
-    print(test_result)
-    print(result)
-    
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
+
+def test_xy_z_marked_npairs_parallelization():
+    """
+    Function tests xy_z_marked_npairs with periodic boundary conditions.
+    """
+    
+    rp_bins = np.array([0.0,0.1,0.2,0.3])
+    pi_bins = np.array([0.0,0.1,0.2,0.3])
+    
+    serial_result = xy_z_marked_npairs(random_sample, random_sample, 
+        rp_bins, pi_bins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
+
+    parallel_result = xy_z_marked_npairs(random_sample, random_sample, 
+        rp_bins, pi_bins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1, 
+        num_threads = 'max')
+            
+    assert np.allclose(serial_result,parallel_result,rtol=1e-09), "pair counts are incorrect"
 
 
 def test_xy_z_marked_npairs_nonperiodic():


### PR DESCRIPTION
Modest enhancements to performance of the mock_observables sub-package. Special thanks to @rainwoodman. 

@duncandc - have a look at https://github.com/aphearin/halotools/commit/3d2164275c5dc5d456a984019d08b95ad2bcb57d. This is a very minor change to how pool.map is used that is worth being aware of. Doing things the old way, there is communication between processes for every element of xrange(Ncell1). Doing things this new way, there is only one communication per chunk. It's a very minor change, but performance scales much better with the number of cores. Nothing for you to do, just pointing this out since you might be using this pattern again in the future. 

Note to @rainwoodman - this PR does not include your own Pool. I'd like to experiment with that more before merging. 