### PR TITLE
Making py3 compatible aph edits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
 
@@ -49,6 +48,10 @@ matrix:
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
+
+        # Python3.3 is a bit old, thus conda doesn't have all version dependencies
+        - python: 3.3
+          env: CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
         # Try Astropy development version
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.7
     - 3.4
     - 3.5
 
@@ -39,6 +38,8 @@ env:
 
 matrix:
     include:
+        - python: 2.7
+          env: SETUP_CMD='egg_info'
 
         # Do a coverage test in Python 2.
         - python: 2.7
@@ -49,9 +50,10 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
-        # Python3.3 is a bit old, thus conda doesn't have all version dependencies
+        # Python3.3 is a bit old, thus conda doesn't have all version dependencies including newer numpies
         - python: 3.3
-          env: CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
+          env: NUMPY_VERSION=1.9
+               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
         # Try Astropy development version
         - python: 2.7
@@ -66,11 +68,6 @@ matrix:
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
-
-    allow_failures:
-        - python: 3.3
-        - python: 3.4
-        - python: 3.5
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development
-        - python: 3.4
+        - python: 3.5
           env: ASTROPY_VERSION=development
 
         # Try numpy 1.10 - might want to switch this so that 1.10 is *default* and 1.9 is checked here down the road

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
@@ -59,9 +59,9 @@ matrix:
         - python: 3.5
           env: ASTROPY_VERSION=development
 
-        # Try numpy 1.10 - might want to switch this so that 1.10 is *default* and 1.9 is checked here down the road
+        # Try older numpy version
         - python: 2.7
-          env: NUMPY_VERSION=1.10
+          env: NUMPY_VERSION=1.9
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.2 (unreleased)
 ----------------
 
-- No changes yet
+- Halotools is now Python 3.x compatible
 
 0.1 (2016-03-13)
 ----------------

--- a/docs/source_notes/convert_tutorials.py
+++ b/docs/source_notes/convert_tutorials.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 from os import system
-from subprocess import PIPE,Popen
+from subprocess import PIPE, Popen
 import fileinput
+
 
 def file_prepend_line(filename, line_to_prepend):
     f = fileinput.input(filename, inplace=1)
     for xline in f:
         if f.isfirstline():
-            print line_to_prepend.rstrip('\r\n') + '\n' + xline,
+            print(line_to_prepend.rstrip('\r\n') + '\n' + xline,)
         else:
-            print xline,
+            print(xline,)
+
 
 def get_asterisks_line(header):
     asterisks=''
@@ -19,34 +22,35 @@ def get_asterisks_line(header):
         asterisks+='*'
     return asterisks
 
+
 def test_ipynb(fname, enforce_pass=True):
-    """Function to use in a test suite to 
-    verify that an IPython Notebook 
+    """Function to use in a test suite to
+    verify that an IPython Notebook
     executes without raising an exception.
-    
-    The method is to convert the Notebook to a python script, 
-    and then assert that the script does not raise an exception 
-    when run as an executable. Useful for 
-    incorporating IPython Notebooks into documentation. 
 
-    Parameters 
+    The method is to convert the Notebook to a python script,
+    and then assert that the script does not raise an exception
+    when run as an executable. Useful for
+    incorporating IPython Notebooks into documentation.
+
+    Parameters
     ----------
-    fname : string 
-        Name of IPython Notebook being tested. 
+    fname : string
+        Name of IPython Notebook being tested.
 
-    Notes 
+    Notes
     -----
-    Requires pandoc to be installed so that 
-    the Notebook can be converted to an executable python script. 
+    Requires pandoc to be installed so that
+    the Notebook can be converted to an executable python script.
 
-    Do not include the file extension in fname. 
-    If '.ipynb' is accidentally included, the function will strip 
-    the extension and otherwise behave properly. 
+    Do not include the file extension in fname.
+    If '.ipynb' is accidentally included, the function will strip
+    the extension and otherwise behave properly.
 
-    Credit to Padriac Cunningham for the idea to spawn a subprocess 
-    to handle the exception handling in an external script. 
+    Credit to Padriac Cunningham for the idea to spawn a subprocess
+    to handle the exception handling in an external script.
 
-    """ 
+    """
 
     if fname[-6:]=='.ipynb':
         fname = fname[0:-6]
@@ -56,17 +60,17 @@ def test_ipynb(fname, enforce_pass=True):
     conversion_string = "ipython nbconvert --to python "+fname
     c=system(conversion_string)
 
-#   Use subprocess.Popen to spawn a subprocess 
+#   Use subprocess.Popen to spawn a subprocess
 #   that executes the tutorial script
     s = Popen(["python" ,fname+".py"],stderr=PIPE)
-#   After the following line, 
-#   err will be an empty string if the program runs without 
+#   After the following line,
+#   err will be an empty string if the program runs without
 #   raising any exceptions
-    _, err = s.communicate()  
+    _, err = s.communicate()
     if enforce_pass is True:
         assert err==''
 
-    # The script version of the .ipynb file 
+    # The script version of the .ipynb file
     # is no longer necessary, so delete it
     system("rm -rf "+fname+".py")
 
@@ -112,7 +116,7 @@ def main():
             print(failure+".ipynb\n")
         print("\n")
 
-            
+
 ########################################################
 
 

--- a/halotools/_astropy_init.py
+++ b/halotools/_astropy_init.py
@@ -10,7 +10,7 @@ except NameError:
     if version_info[0] >= 3:
         import builtins
     else:
-        import __builtin__ as builtins
+        import builtins as builtins
     builtins._ASTROPY_SETUP_ = False
 
 try:

--- a/halotools/_astropy_init.py
+++ b/halotools/_astropy_init.py
@@ -10,7 +10,7 @@ except NameError:
     if version_info[0] >= 3:
         import builtins
     else:
-        import builtins as builtins
+        import __builtin__ as builtins
     builtins._ASTROPY_SETUP_ = False
 
 try:

--- a/halotools/custom_exceptions.py
+++ b/halotools/custom_exceptions.py
@@ -4,21 +4,21 @@ Classes for all Halotools-specific exceptions.
 """
 
 __all__ = ('HalotoolsError', 'HalotoolsCacheError', 
-	'HalotoolsIOError', 'UnsupportedSimError', 'CatalogTypeError', 
-	'HalotoolsModelInputError', 'HalotoolsArgumentError')
+        'HalotoolsIOError', 'UnsupportedSimError', 'CatalogTypeError', 
+        'HalotoolsModelInputError', 'HalotoolsArgumentError')
 
 
 class HalotoolsError(Exception):
-	""" Base class of all Halotools-specific exceptions. 
-	"""
-	def __init__(self, message):
-		super(HalotoolsError, self).__init__(message)
+    """ Base class of all Halotools-specific exceptions. 
+    """
+    def __init__(self, message):
+        super(HalotoolsError, self).__init__(message)
 
 class InvalidCacheLogEntry(Exception):
-	""" Base class of all Halotools-specific exceptions. 
-	"""
-	def __init__(self, message):
-		super(InvalidCacheLogEntry, self).__init__(message)
+    """ Base class of all Halotools-specific exceptions. 
+    """
+    def __init__(self, message):
+        super(InvalidCacheLogEntry, self).__init__(message)
 
 
 ########################################
@@ -26,76 +26,76 @@ class InvalidCacheLogEntry(Exception):
 
 
 class HalotoolsCacheError(HalotoolsError):
-	""" Custom exception used to indicate that there has been an incorrect attempt to load data from the cache directory into memory. 
-	"""
-	def __init__(self, message):
-		super(HalotoolsCacheError, self).__init__(message)
+    """ Custom exception used to indicate that there has been an incorrect attempt to load data from the cache directory into memory. 
+    """
+    def __init__(self, message):
+        super(HalotoolsCacheError, self).__init__(message)
 
 class HalotoolsIOError(HalotoolsError):
-	""" Catch-all custom exception for incorrect Halotools-specific I/O. 
-	"""
-	def __init__(self, message):
-		super(HalotoolsIOError, self).__init__(message)
+    """ Catch-all custom exception for incorrect Halotools-specific I/O. 
+    """
+    def __init__(self, message):
+        super(HalotoolsIOError, self).__init__(message)
 
 
 class UnsupportedSimError(HalotoolsCacheError):
-	""" Custom exception that is raised when there is an attempt to load a halo catalog into memory that is not recogized by Halotools. 
-	"""
-	def __init__(self, simname):
+    """ Custom exception that is raised when there is an attempt to load a halo catalog into memory that is not recogized by Halotools. 
+    """
+    def __init__(self, simname):
 
-		message = ("\nThe input simname " + simname + " is not recognized by Halotools.\n")
+        message = ("\nThe input simname " + simname + " is not recognized by Halotools.\n")
 
-		super(UnsupportedSimError, self).__init__(message)
+        super(UnsupportedSimError, self).__init__(message)
 
 
 class CatalogTypeError(HalotoolsCacheError):
-	""" Custom exception that is raised when an unrecognized type of data catalog is attempted to be loaded into memory. 
-	"""
-	def __init__(self, catalog_type):
+    """ Custom exception that is raised when an unrecognized type of data catalog is attempted to be loaded into memory. 
+    """
+    def __init__(self, catalog_type):
 
-		message = "\nInput catalog_type = ``"+catalog_type+"``\n Must be either 'raw_halos', 'halos', or 'particles'.\n"
-		
-		super(CatalogTypeError, self).__init__(message)
+        message = "\nInput catalog_type = ``"+catalog_type+"``\n Must be either 'raw_halos', 'halos', or 'particles'.\n"
+
+        super(CatalogTypeError, self).__init__(message)
 
 
 ########################################
 
 class HalotoolsModelInputError(HalotoolsError):
-	""" Catch-all custom exception for when a model object method was called without the correct arguments.
-	"""
-	def __init__(self, function_name):
-		message = ("\nMust pass one of the following keyword arguments to %s:\n"
-                "``halo_table`` or  ``prim_haloprop``" % function_name)
-		super(HalotoolsModelInputError, self).__init__(message)
+    """ Catch-all custom exception for when a model object method was called without the correct arguments.
+    """
+    def __init__(self, function_name):
+        message = ("\nMust pass one of the following keyword arguments to %s:\n"
+        "``halo_table`` or  ``prim_haloprop``" % function_name)
+        super(HalotoolsModelInputError, self).__init__(message)
 
 class HalotoolsArgumentError(HalotoolsError):
-	""" Catch-all custom exception for instantiating a Halotools-defined class without passing the correct arguments to the constructor.
-	"""
-	def __init__(self, function_name, required_input_list):
-		"""
-		Parameters 
-		-----------
-		function_name : string 
+    """ Catch-all custom exception for instantiating a Halotools-defined class without passing the correct arguments to the constructor.
+    """
+    def __init__(self, function_name, required_input_list):
+        """
+        Parameters 
+        -----------
+        function_name : string 
 
-		required_input_list : list 
-			List of strings 
-		"""
-		message = "\nMust pass each of the following keyword arguments to " + function_name + ":\n"
-		for required_input in required_input_list:
-			message = message + required_input + ', '
-		message = message[:-2]
-		super(HalotoolsArgumentError, self).__init__(message)
+        required_input_list : list 
+                List of strings 
+        """
+        message = "\nMust pass each of the following keyword arguments to " + function_name + ":\n"
+        for required_input in required_input_list:
+            message = message + required_input + ', '
+        message = message[:-2]
+        super(HalotoolsArgumentError, self).__init__(message)
 
 class AmurricaError(HalotoolsError):
-	""" Built-in mechanism to prevent ridiculous spelling-choice contributions to the repository. 
-	"""
+    """ Built-in mechanism to prevent ridiculous spelling-choice contributions to the repository. 
+    """
 
-	def __init__(self, basename, linenum, correct_spelling, offending_spelling):
-		message = ("\nOn line number "+str(linenum)+" of the source code file ``"+basename+"``,\n"
-			"you have incorrectly spelled the word ``"+correct_spelling+"`` "
-			"as ``"+offending_spelling+"``.\n"
-			"Contributions to Halotools that support King George are strictly forbidden.\n")
-		super(AmurricaError, self).__init__(message)
+    def __init__(self, basename, linenum, correct_spelling, offending_spelling):
+        message = ("\nOn line number "+str(linenum)+" of the source code file ``"+basename+"``,\n"
+                "you have incorrectly spelled the word ``"+correct_spelling+"`` "
+                "as ``"+offending_spelling+"``.\n"
+                "Contributions to Halotools that support King George are strictly forbidden.\n")
+        super(AmurricaError, self).__init__(message)
 
 
 

--- a/halotools/empirical_models/assembias_models/heaviside_assembias.py
+++ b/halotools/empirical_models/assembias_models/heaviside_assembias.py
@@ -18,6 +18,7 @@ from .. import model_defaults, model_helpers
 from ...utils.array_utils import custom_len, convert_to_ndarray
 from ...custom_exceptions import HalotoolsError
 from ...utils.table_utils import compute_conditional_percentiles
+import collections
 
 class HeavisideAssembias(object):
     """ Class used as an orthogonal mix-in to introduce step function-style 
@@ -159,12 +160,12 @@ class HeavisideAssembias(object):
         if 'splitting_model' in kwargs:
             self.splitting_model = kwargs['splitting_model']
             func = getattr(self.splitting_model, kwargs['splitting_method_name'])
-            if callable(func):
+            if isinstance(func, collections.Callable):
                 self._input_split_func = func
             else:
                 raise HalotoolsError("Input ``splitting_model`` must have a callable function "
                     "named ``%s``" % kwargs['splitting_method_name'])
-        elif 'split_abscissa' in kwargs.keys():
+        elif 'split_abscissa' in list(kwargs.keys()):
             if custom_len(kwargs['split_abscissa']) != custom_len(split):
                 raise HalotoolsError("``split`` and ``split_abscissa`` must have the same length")
             self._split_abscissa = kwargs['split_abscissa']
@@ -471,7 +472,7 @@ class HeavisideAssembias(object):
                     type1_mask = table[halo_type_key][no_edge_mask] == halo_type1_val
 
                 # the value of sec_haloprop_percentile is already stored as a column of the table
-                elif self.sec_haloprop_key + '_percentile' in table.keys():
+                elif self.sec_haloprop_key + '_percentile' in list(table.keys()):
                     no_edge_percentiles = table[self.sec_haloprop_key + '_percentile'][no_edge_mask]
                     type1_mask = no_edge_percentiles > no_edge_split
                 else:

--- a/halotools/empirical_models/component_model_templates/binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/binary_galprop_models.py
@@ -62,10 +62,10 @@ class BinaryGalpropModel(object):
 
         self.prim_haloprop_key = prim_haloprop_key
 
-        if 'sec_haloprop_key' in kwargs.keys():
+        if 'sec_haloprop_key' in list(kwargs.keys()):
             self.sec_haloprop_key = kwargs['sec_haloprop_key']
 
-        if 'new_haloprop_func_dict' in kwargs.keys():
+        if 'new_haloprop_func_dict' in list(kwargs.keys()):
             self.new_haloprop_func_dict = kwargs['new_haloprop_func_dict']
 
         # Enforce the requirement that sub-classes have been configured properly
@@ -241,7 +241,7 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
             pass
 
         if self._interpol_method=='spline':
-            if 'input_spline_degree' in kwargs.keys():
+            if 'input_spline_degree' in list(kwargs.keys()):
                 self._input_spine_degree = kwargs['input_spline_degree']
             else:
                 self._input_spline_degree = 3
@@ -306,9 +306,9 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
 
         """
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             prim_haloprop = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             prim_haloprop = kwargs['prim_haloprop']
         else:
             raise KeyError("Must pass one of the following keyword arguments to mean_occupation:\n"

--- a/halotools/empirical_models/component_model_templates/prim_galprop_model.py
+++ b/halotools/empirical_models/component_model_templates/prim_galprop_model.py
@@ -96,7 +96,7 @@ class PrimGalpropModel(object):
         if 'redshift' in kwargs:
             self.redshift = float(max(0, kwargs['redshift']))
 
-        if 'new_haloprop_func_dict' in kwargs.keys():
+        if 'new_haloprop_func_dict' in list(kwargs.keys()):
             self.new_haloprop_func_dict = kwargs['new_haloprop_func_dict']
 
         self.scatter_model = scatter_model(
@@ -133,7 +133,7 @@ class PrimGalpropModel(object):
         of the scatter model, and then call the `mean_scatter` method of 
         the scatter model. 
         """
-        for key in self.scatter_model.param_dict.keys():
+        for key in list(self.scatter_model.param_dict.keys()):
             self.scatter_model.param_dict[key] = self.param_dict[key]
 
         return self.scatter_model.mean_scatter(**kwargs)
@@ -143,7 +143,7 @@ class PrimGalpropModel(object):
         of the scatter model, and then call the `scatter_realization` method of 
         the scatter model. 
         """
-        for key in self.scatter_model.param_dict.keys():
+        for key in list(self.scatter_model.param_dict.keys()):
             self.scatter_model.param_dict[key] = self.param_dict[key]
 
         return self.scatter_model.scatter_realization(**kwargs)
@@ -160,7 +160,7 @@ class PrimGalpropModel(object):
 
         scatter_param_dict = self.scatter_model.param_dict
 
-        for key, value in scatter_param_dict.iteritems():
+        for key, value in scatter_param_dict.items():
             self.param_dict[key] = value
 
     def _mc_galprop(self, include_scatter = True, **kwargs):
@@ -193,7 +193,7 @@ class PrimGalpropModel(object):
         """
 
         # Interpret the inputs to determine the appropriate redshift
-        if 'redshift' not in kwargs.keys():
+        if 'redshift' not in list(kwargs.keys()):
             if hasattr(self, 'redshift'):
                 kwargs['redshift'] = self.redshift
             else:

--- a/halotools/empirical_models/component_model_templates/scatter_models.py
+++ b/halotools/empirical_models/component_model_templates/scatter_models.py
@@ -72,7 +72,7 @@ class LogNormalScatterModel(object):
         default_scatter = model_defaults.default_smhm_scatter
         self.prim_haloprop_key = prim_haloprop_key
 
-        if ('scatter_abscissa' in kwargs.keys()) and ('scatter_ordinates' in kwargs.keys()):
+        if ('scatter_abscissa' in list(kwargs.keys())) and ('scatter_ordinates' in list(kwargs.keys())):
             self.abscissa = convert_to_ndarray(kwargs['scatter_abscissa'])
             self.ordinates = convert_to_ndarray(kwargs['scatter_ordinates'])
         else:
@@ -104,9 +104,9 @@ class LogNormalScatterModel(object):
             at the input table. 
         """
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             raise KeyError("Must pass one of the following keyword arguments to mean_occupation:\n"

--- a/halotools/empirical_models/component_model_templates/tests/test_binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/tests/test_binary_galprop_models.py
@@ -65,7 +65,7 @@ class TestBinaryGalpropInterpolModel(TestCase):
                 galprop_abscissa = [12, 12], galprop_ordinates = [0.5, 0.9], 
                 prim_haloprop_key = 'vpeak_host', gal_type = 'sats')
         substr = "Your input ``galprop_abscissa`` cannot have any repeated values"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_ordinates_check(self):
         with pytest.raises(HalotoolsError) as err:
@@ -73,7 +73,7 @@ class TestBinaryGalpropInterpolModel(TestCase):
                 galprop_abscissa = [12, 13], galprop_ordinates = [0.5, 1.9], 
                 prim_haloprop_key = 'vpeak_host', gal_type = 'sats')
         substr = "All values of the input ``galprop_ordinates`` must be between 0 and 1, inclusive."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     def test_galprop_ordinates_consistency(self):
@@ -82,7 +82,7 @@ class TestBinaryGalpropInterpolModel(TestCase):
                 galprop_abscissa = [12, 13], galprop_ordinates = [0.5, 0.7, 0.9], 
                 prim_haloprop_key = 'vpeak_host', gal_type = 'sats')
         substr = "Input ``galprop_abscissa`` and ``galprop_ordinates`` must have the same length"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
 

--- a/halotools/empirical_models/composite_models/hod_models/tests/test_tinker13.py
+++ b/halotools/empirical_models/composite_models/hod_models/tests/test_tinker13.py
@@ -26,22 +26,22 @@ else:
 __all__ = ('TestTinker13', )
 
 class TestTinker13(TestCase):
-	
-	def test_tinker13_default(self):
-		model = PrebuiltHodModelFactory('tinker13')
 
-	def test_tinker13_abscissa(self):
-		model = PrebuiltHodModelFactory('tinker13', 
-			quiescent_fraction_abscissa = [1e12, 1e13, 1e14, 1e15], 
-			quiescent_fraction_ordinates = [0.25, 0.5, 0.75, 0.9])
+    def test_tinker13_default(self):
+        model = PrebuiltHodModelFactory('tinker13')
 
-	@pytest.mark.slow
-	def test_tinker13_populate1(self):
-		model = PrebuiltHodModelFactory('tinker13')
-		fake_sim = FakeSim()
-		model.populate_mock(fake_sim)
+    def test_tinker13_abscissa(self):
+        model = PrebuiltHodModelFactory('tinker13', 
+                quiescent_fraction_abscissa = [1e12, 1e13, 1e14, 1e15], 
+                quiescent_fraction_ordinates = [0.25, 0.5, 0.75, 0.9])
 
-	
+    @pytest.mark.slow
+    def test_tinker13_populate1(self):
+        model = PrebuiltHodModelFactory('tinker13')
+        fake_sim = FakeSim()
+        model.populate_mock(fake_sim)
+
+
 
 
 

--- a/halotools/empirical_models/composite_models/hod_models/tests/test_tinker13.py
+++ b/halotools/empirical_models/composite_models/hod_models/tests/test_tinker13.py
@@ -16,7 +16,7 @@ from .....custom_exceptions import *
 # returned values depend on the configuration 
 # of my personal cache directory files
 from astropy.config.paths import _find_home 
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -30,42 +30,42 @@ __all__ = ('TestHearin15', )
 
 class TestHearin15(TestCase):
 
-	def setup_class(self):
-		pass
+    def setup_class(self):
+        pass
 
-	def test_Hearin15(self):
+    def test_Hearin15(self):
 
-		model = PrebuiltHodModelFactory('hearin15')
-		halocat = FakeSim()
-		model.populate_mock(halocat)
+        model = PrebuiltHodModelFactory('hearin15')
+        halocat = FakeSim()
+        model.populate_mock(halocat)
 
-	def test_Leauthaud11(self):
+    def test_Leauthaud11(self):
 
-		model = PrebuiltHodModelFactory('leauthaud11')
-		halocat = FakeSim()
-		model.populate_mock(halocat)
+        model = PrebuiltHodModelFactory('leauthaud11')
+        halocat = FakeSim()
+        model.populate_mock(halocat)
 
-	def test_Leauthaud11b(self):
+    def test_Leauthaud11b(self):
 
-		model = PrebuiltHodModelFactory('leauthaud11') 
-		halocat = FakeSim(redshift = 2.)
-		# Test that an attempt to repopulate with a different halocat raises an exception
-		with pytest.raises(HalotoolsError) as exc:
-			model.populate_mock(halocat) #default redshift != 2
+        model = PrebuiltHodModelFactory('leauthaud11') 
+        halocat = FakeSim(redshift = 2.)
+        # Test that an attempt to repopulate with a different halocat raises an exception
+        with pytest.raises(HalotoolsError) as exc:
+            model.populate_mock(halocat) #default redshift != 2
 
-	def test_Leauthaud11c(self):
+    def test_Leauthaud11c(self):
 
-		model_highz = PrebuiltHodModelFactory('leauthaud11', redshift = 2.)
-		halocat = FakeSim(redshift = 2.)
-		model_highz.populate_mock(halocat)
+        model_highz = PrebuiltHodModelFactory('leauthaud11', redshift = 2.)
+        halocat = FakeSim(redshift = 2.)
+        model_highz.populate_mock(halocat)
 
-	@pytest.mark.skipif('not APH_MACHINE')
-	@pytest.mark.slow
-	def test_hearin15_fullpop(self):
-		halocat = CachedHaloCatalog(simname = 'bolshoi', redshift = 0)
-		model = PrebuiltHodModelFactory('hearin15', threshold = 11)
-		model.populate_mock(halocat)
-		del model
+    @pytest.mark.skipif('not APH_MACHINE')
+    @pytest.mark.slow
+    def test_hearin15_fullpop(self):
+        halocat = CachedHaloCatalog(simname = 'bolshoi', redshift = 0)
+        model = PrebuiltHodModelFactory('hearin15', threshold = 11)
+        model.populate_mock(halocat)
+        del model
 
 
 

--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -18,7 +18,7 @@ from ....custom_exceptions import *
 # returned values depend on the configuration 
 # of my personal cache directory files
 from astropy.config.paths import _find_home 
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -123,7 +123,7 @@ class HodMockFactory(MockFactory):
 
         """
         try:
-            assert 'halo_upid' in halocat.halo_table.keys()
+            assert 'halo_upid' in list(halocat.halo_table.keys())
         except AssertionError:
             raise HalotoolsError(missing_halo_upid_msg)
 
@@ -141,7 +141,7 @@ class HodMockFactory(MockFactory):
         ### Create new columns of the halo catalog, if applicable
         try:
             d = self.model.new_haloprop_func_dict
-            for new_haloprop_key, new_haloprop_func in d.iteritems():
+            for new_haloprop_key, new_haloprop_func in d.items():
                 halo_table[new_haloprop_key] = new_haloprop_func(table = halo_table)
                 self.additional_haloprops.append(new_haloprop_key)
         except AttributeError:
@@ -358,7 +358,7 @@ class HodMockFactory(MockFactory):
             galprops_assigned_to_halo_table_by_func = occupation_func._galprop_dtypes_to_allocate.names
             self.additional_haloprops.extend(galprops_assigned_to_halo_table_by_func)
             
-        self.Ngals = np.sum(self._total_abundance.values())
+        self.Ngals = np.sum(list(self._total_abundance.values()))
 
         # Allocate memory for all additional halo properties, 
         # including profile parameters of the halos such as 'conc_NFWmodel'

--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -298,7 +298,7 @@ class HodModelFactory(ModelFactory):
                 supplementary_kwargs['model_feature_calling_sequence'] = None
 
             new_model_dictionary = copy(baseline_model_dictionary)
-            for key, value in input_model_dictionary.iteritems():
+            for key, value in input_model_dictionary.items():
                 new_model_dictionary[key] = value
             return new_model_dictionary, supplementary_kwargs
 
@@ -361,7 +361,7 @@ class HodModelFactory(ModelFactory):
             model_feature_calling_sequence = list(supplementary_kwargs['model_feature_calling_sequence'])
             for model_feature in model_feature_calling_sequence:
                 try:
-                    assert model_feature in self._input_model_dictionary.keys()
+                    assert model_feature in list(self._input_model_dictionary.keys())
                 except AssertionError:
                     msg = ("\nYour input ``model_feature_calling_sequence`` has a ``%s`` element\n"
                     "that does not appear in the keyword arguments you passed to the HodModelFactory.\n"
@@ -550,7 +550,7 @@ class HodModelFactory(ModelFactory):
         model components with explicit dependence on the central population. 
         """
         _gal_type_list = []
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
             _gal_type_list.append(component_model.gal_type)
         self.gal_types = list(set(_gal_type_list))
 
@@ -571,7 +571,7 @@ class HodModelFactory(ModelFactory):
         `set_primary_behaviors` just creates a symbolic link to those external behaviors. 
         """
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
             gal_type = component_model.gal_type
             feature_name = component_model.feature_name
 
@@ -654,7 +654,7 @@ class HodModelFactory(ModelFactory):
         the phase space component models. 
         """
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
             if hasattr(component_model, 'build_lookup_tables'):
                 component_model.build_lookup_tables()
 
@@ -697,7 +697,7 @@ class HodModelFactory(ModelFactory):
             "simply attach a _suppress_repeated_param_warning attribute \n"
             "to any of your component models and set this variable to ``True``.\n")
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             if not hasattr(component_model, 'param_dict'):
                 component_model.param_dict = {}
@@ -707,7 +707,7 @@ class HodModelFactory(ModelFactory):
                     if suppress_warning is False:
                         warn(msg % key)
 
-            for key, value in component_model.param_dict.iteritems():
+            for key, value in component_model.param_dict.items():
                 self.param_dict[key] = value
 
         self._init_param_dict = copy(self.param_dict)
@@ -727,7 +727,7 @@ class HodModelFactory(ModelFactory):
         """ 
         """
 
-        zlist = list(model.redshift for model in self.model_dictionary.values() 
+        zlist = list(model.redshift for model in list(self.model_dictionary.values()) 
             if hasattr(model, 'redshift'))
 
         if len(set(zlist)) == 0:
@@ -736,7 +736,7 @@ class HodModelFactory(ModelFactory):
             self.redshift = float(zlist[0])
         else:
             msg = ("Inconsistency between the redshifts of the component models:\n\n")
-            for model in self.model_dictionary.values():
+            for model in list(self.model_dictionary.values()):
                 gal_type = model.gal_type
                 clname = model.__class__.__name__
                 if hasattr(model, 'redshift'):
@@ -757,7 +757,7 @@ class HodModelFactory(ModelFactory):
         a corresponding column storing the halo property inherited by the mock galaxy. 
         """
         haloprop_list = []
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             if hasattr(component_model, 'prim_haloprop_key'):
                 haloprop_list.append(component_model.prim_haloprop_key)
@@ -773,7 +773,7 @@ class HodModelFactory(ModelFactory):
         """
         prof_param_keys = []
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
             if hasattr(component_model, 'prof_param_keys'):
                 prof_param_keys.extend(component_model.prof_param_keys)
 
@@ -783,7 +783,7 @@ class HodModelFactory(ModelFactory):
         """
         """
         pub_list = []
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             if hasattr(component_model, 'publications'):
                 pub_list.extend(component_model.publications)
@@ -804,7 +804,7 @@ class HodModelFactory(ModelFactory):
         :ref:`galprop_dtypes_to_allocate_mechanism` 
         """
         dtype_list = []
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             # Column dtypes to add to mock galaxy_table
             if hasattr(component_model, '_galprop_dtypes_to_allocate'):
@@ -823,7 +823,7 @@ class HodModelFactory(ModelFactory):
         """
         new_haloprop_func_dict = {}
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
             feature_name, gal_type = component_model.feature_name, component_model.gal_type
 
             # Haloprop function dictionaries
@@ -832,8 +832,8 @@ class HodModelFactory(ModelFactory):
                     set(component_model.new_haloprop_func_dict))
                 if dict_intersection == set():
                     new_haloprop_func_dict = dict(
-                        new_haloprop_func_dict.items() + 
-                        component_model.new_haloprop_func_dict.items()
+                        list(new_haloprop_func_dict.items()) + 
+                        list(component_model.new_haloprop_func_dict.items())
                         )
                 else:
                     example_repeated_element = list(dict_intersection)[0]
@@ -862,7 +862,7 @@ class HodModelFactory(ModelFactory):
         """
         self._suppress_repeated_param_warning = False
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             if hasattr(component_model, '_suppress_repeated_param_warning'):
                 self._suppress_repeated_param_warning += component_model._suppress_repeated_param_warning
@@ -889,7 +889,7 @@ class HodModelFactory(ModelFactory):
         even if these lists were forgotten or irrelevant to that particular component. 
         """
 
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             # Ensure that all methods in the calling sequence are inherited
             try:
@@ -966,7 +966,7 @@ class HodModelFactory(ModelFactory):
             "which determines which methods of the component model are inherited by the composite model.\n"
             "The former must be a subset of the latter. However, for ``gal_type`` = %s,\n"
             "the following method was not inherited:\n%s")
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
 
             mock_generation_methods = set(component_model._mock_generation_calling_sequence)
             inherited_methods = set(component_model._methods_to_inherit)

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -68,7 +68,7 @@ class MockFactory(object):
         except KeyError:
             msg = ("\n``halocat`` and ``model`` are required ``MockFactory`` arguments\n")
             raise HalotoolsError(msg)
-        for key in halocat.__dict__.keys():
+        for key in list(halocat.__dict__.keys()):
             setattr(self, key, halocat.__dict__[key])
 
         try:

--- a/halotools/empirical_models/factories/mock_helpers.py
+++ b/halotools/empirical_models/factories/mock_helpers.py
@@ -35,7 +35,7 @@ def three_dim_pos_bundle(table, key1, key2, key3,
         Default is False. 
 
     """
-    if 'mask' in kwargs.keys():
+    if 'mask' in list(kwargs.keys()):
         mask = kwargs['mask']
         x, y, z = table[key1][mask], table[key2][mask], table[key3][mask]
         if return_complement is True:

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -63,7 +63,7 @@ def _test_mock_consistency(mock,
         raise HalotoolsError(inconsistent_halo_finder_error_msg % (mock.halo_finder,halo_finder ))
     if version_name != mock.version_name:
         raise HalotoolsError(inconsistent_version_name_error_msg % (mock.version_name,version_name ))
-    print("version_name = %s" % version_name)
+    print(("version_name = %s" % version_name))
 
 @six.add_metaclass(ABCMeta)
 class ModelFactory(object):
@@ -276,7 +276,7 @@ class ModelFactory(object):
         def decorated_func(*args, **kwargs):
 
             # Update the param_dict as necessary
-            for key in self.param_dict.keys():
+            for key in list(self.param_dict.keys()):
                 if key in component_model.param_dict:
                     component_model.param_dict[key] = self.param_dict[key]
 
@@ -462,7 +462,7 @@ class ModelFactory(object):
         else:
             rbins = model_defaults.default_rbins
 
-        if 'include_crosscorr' in kwargs.keys():
+        if 'include_crosscorr' in list(kwargs.keys()):
             include_crosscorr = kwargs['include_crosscorr']
         else:
             include_crosscorr = False
@@ -676,7 +676,7 @@ class ModelFactory(object):
         else:
             rbins = model_defaults.default_rbins
 
-        if 'include_complement' in kwargs.keys():
+        if 'include_complement' in list(kwargs.keys()):
             include_complement = kwargs['include_complement']
         else:
             include_complement = False

--- a/halotools/empirical_models/factories/prebuilt_model_factory.py
+++ b/halotools/empirical_models/factories/prebuilt_model_factory.py
@@ -95,9 +95,9 @@ class PrebuiltSubhaloModelFactory(SubhaloModelFactory):
             )
 
         super_class_kwargs = {}
-        for key, value in input_model_dictionary.iteritems():
+        for key, value in input_model_dictionary.items():
             super_class_kwargs[key] = value
-        for key, value in supplementary_kwargs.iteritems():
+        for key, value in supplementary_kwargs.items():
             super_class_kwargs[key] = value
 
         SubhaloModelFactory.__init__(self, **super_class_kwargs)
@@ -215,9 +215,9 @@ class PrebuiltHodModelFactory(HodModelFactory):
             )
 
         super_class_kwargs = {}
-        for key, value in input_model_dictionary.iteritems():
+        for key, value in input_model_dictionary.items():
             super_class_kwargs[key] = value
-        for key, value in supplementary_kwargs.iteritems():
+        for key, value in supplementary_kwargs.items():
             super_class_kwargs[key] = value
 
         HodModelFactory.__init__(self, **super_class_kwargs)

--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -72,17 +72,17 @@ class SubhaloMockFactory(MockFactory):
         """
         halo_table = halocat.halo_table
 
-        if ( ('halo_hostid' not in self.additional_haloprops) & ('halo_hostid' in halo_table.keys()) ):
+        if ( ('halo_hostid' not in self.additional_haloprops) & ('halo_hostid' in list(halo_table.keys())) ):
             self.additional_haloprops.append('halo_hostid')
 
         if ( ('halo_mvir_host_halo' not in self.additional_haloprops) & 
-            ('halo_mvir_host_halo' in halo_table.keys()) ):
+            ('halo_mvir_host_halo' in list(halo_table.keys())) ):
             self.additional_haloprops.append('halo_mvir_host_halo')
 
         ### Create new columns of the halo catalog, if applicable
         try:
             d = self.model.new_haloprop_func_dict
-            for new_haloprop_key, new_haloprop_func in d.iteritems():
+            for new_haloprop_key, new_haloprop_func in d.items():
                 halo_table[new_haloprop_key] = new_haloprop_func(table = halo_table)
                 self.additional_haloprops.append(new_haloprop_key)
         except AttributeError:
@@ -128,7 +128,7 @@ class SubhaloMockFactory(MockFactory):
         # Component models may explicitly distinguish between certain types of halos, 
         # e.g., subhalos vs. host halos. Since this assignment is not dynamic, 
         # it can be pre-computed. 
-        for feature, component_model in self.model.model_dictionary.iteritems():
+        for feature, component_model in self.model.model_dictionary.items():
 
             try:
                 f = component_model.gal_type_func

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -295,7 +295,7 @@ class SubhaloModelFactory(ModelFactory):
                 supplementary_kwargs['model_feature_calling_sequence'] = None
 
             new_model_dictionary = copy(baseline_model_dictionary)
-            for key, value in input_model_dictionary.iteritems():
+            for key, value in input_model_dictionary.items():
                 new_model_dictionary[key] = value
             return new_model_dictionary, supplementary_kwargs
 
@@ -333,7 +333,7 @@ class SubhaloModelFactory(ModelFactory):
         msg_conclusion = ("See the `~halotools.empirical_models.SubhaloModelFactory` "
             "docstring for further details.\n")
 
-        for feature_key, component_model in candidate_model_dictionary.iteritems():
+        for feature_key, component_model in candidate_model_dictionary.items():
             cl = component_model.__class__
             clname = cl.__name__
 
@@ -377,7 +377,7 @@ class SubhaloModelFactory(ModelFactory):
             model_feature_calling_sequence = list(supplementary_kwargs['model_feature_calling_sequence'])
             for model_feature in model_feature_calling_sequence:
                 try:
-                    assert model_feature in self._input_model_dictionary.keys()
+                    assert model_feature in list(self._input_model_dictionary.keys())
                 except AssertionError:
                     msg = ("\nYour input ``model_feature_calling_sequence`` has a ``%s`` element\n"
                     "that does not appear in the keyword arguments you passed to the SubhaloModelFactory.\n"
@@ -446,7 +446,7 @@ class SubhaloModelFactory(ModelFactory):
         _attrs_repetition_check = []
 
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             # Ensure that all methods in the calling sequence are inherited
             try:
@@ -477,7 +477,7 @@ class SubhaloModelFactory(ModelFactory):
             "in more than one component model.\n You should rename this method in one of your "
             "component models to disambiguate.\n")
         repeated_method_list = ([methodname for methodname, count in 
-            collections.Counter(_method_repetition_check).items() if count > 1]
+            list(collections.Counter(_method_repetition_check).items()) if count > 1]
             )
         if repeated_method_list != []:
             example_repeated_methodname = repeated_method_list[0]
@@ -490,7 +490,7 @@ class SubhaloModelFactory(ModelFactory):
             "Only ignore this message if you are confident "
             "that this will not result in unintended behavior\n")
         repeated_attr_list = ([attr for attr, count in 
-            collections.Counter(_attrs_repetition_check).items() if count > 1]
+            list(collections.Counter(_attrs_repetition_check).items()) if count > 1]
             )
         if repeated_attr_list != []:
             example_repeated_attr = repeated_attr_list[0]
@@ -517,7 +517,7 @@ class SubhaloModelFactory(ModelFactory):
         """
 
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             for methodname in component_model._methods_to_inherit:
                 new_method_name = methodname
@@ -599,7 +599,7 @@ class SubhaloModelFactory(ModelFactory):
             "component models to disambiguate.\n")
 
         # The model dictionary is an OrderedDict that is already appropriately structured
-        feature_sequence = self.model_dictionary.keys()
+        feature_sequence = list(self.model_dictionary.keys())
 
         ###############
         # Loop over feature_sequence and successively append each component model's
@@ -627,7 +627,7 @@ class SubhaloModelFactory(ModelFactory):
         """ 
         """
 
-        zlist = list(model.redshift for model in self.model_dictionary.values() 
+        zlist = list(model.redshift for model in list(self.model_dictionary.values()) 
             if hasattr(model, 'redshift'))
 
         if len(set(zlist)) == 0:
@@ -636,7 +636,7 @@ class SubhaloModelFactory(ModelFactory):
             self.redshift = float(zlist[0])
         else:
             msg = ("Inconsistency between the redshifts of the component models:\n\n")
-            for modelname, model in self.model_dictionary.iteritems():
+            for modelname, model in self.model_dictionary.items():
                 clname = model.__class__.__name__
                 if hasattr(model, 'redshift'):
                     zs = str(model.redshift)
@@ -655,7 +655,7 @@ class SubhaloModelFactory(ModelFactory):
         """
         haloprop_list = []
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             if hasattr(component_model, 'prim_haloprop_key'):
                 haloprop_list.append(component_model.prim_haloprop_key)
@@ -671,11 +671,11 @@ class SubhaloModelFactory(ModelFactory):
         """
         pub_list = []
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             try:
                 pubs = component_model.publications 
-                if type(pubs) in [str, unicode]:
+                if type(pubs) in [str, str]:
                     pub_list.append(pubs)
                 elif type(pubs) is list:
                     pub_list.extend(pubs)
@@ -700,7 +700,7 @@ class SubhaloModelFactory(ModelFactory):
         """
         new_haloprop_func_dict = {}
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             # Haloprop function dictionaries
             if hasattr(component_model, 'new_haloprop_func_dict'):
@@ -708,8 +708,8 @@ class SubhaloModelFactory(ModelFactory):
                     set(component_model.new_haloprop_func_dict))
                 if dict_intersection == set():
                     new_haloprop_func_dict = dict(
-                        new_haloprop_func_dict.items() + 
-                        component_model.new_haloprop_func_dict.items()
+                        list(new_haloprop_func_dict.items()) + 
+                        list(component_model.new_haloprop_func_dict.items())
                         )
                 else:
                     example_repeated_element = list(dict_intersection)[0]
@@ -738,7 +738,7 @@ class SubhaloModelFactory(ModelFactory):
         """
         self._suppress_repeated_param_warning = False
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             if hasattr(component_model, '_suppress_repeated_param_warning'):
                 self._suppress_repeated_param_warning += component_model._suppress_repeated_param_warning
@@ -783,7 +783,7 @@ class SubhaloModelFactory(ModelFactory):
             "to any of your component models and set this variable to ``True``.\n")
 
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             if not hasattr(component_model, 'param_dict'):
                 component_model.param_dict = {}
@@ -795,7 +795,7 @@ class SubhaloModelFactory(ModelFactory):
                     if suppress_warning is False:
                         warn(msg % key)
 
-            for key, value in component_model.param_dict.iteritems():
+            for key, value in component_model.param_dict.items():
                 self.param_dict[key] = value
 
         self._init_param_dict = copy(self.param_dict)
@@ -815,7 +815,7 @@ class SubhaloModelFactory(ModelFactory):
         """
         dtype_list = []
         # Loop over all component features in the composite model
-        for feature, component_model in self.model_dictionary.iteritems():
+        for feature, component_model in self.model_dictionary.items():
 
             # Column dtypes to add to mock galaxy_table
             if hasattr(component_model, '_galprop_dtypes_to_allocate'):
@@ -915,7 +915,7 @@ class SubhaloModelFactory(ModelFactory):
     def _test_dictionary_consistency(self):
         """
         """
-        for component_model in self.model_dictionary.values():
+        for component_model in list(self.model_dictionary.values()):
             try:
                 assert hasattr(component_model, '_methods_to_inherit')
                 for methodname in component_model._methods_to_inherit:

--- a/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
@@ -17,7 +17,7 @@ from ....sim_manager.fake_sim import FakeSimHalosNearBoundaries
 from ..prebuilt_model_factory import PrebuiltHodModelFactory
 from ....custom_exceptions import HalotoolsError
 
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
@@ -48,24 +48,24 @@ class TestHodMockFactory(TestCase):
     def test_mock_population_mask(self):
         start = time()
 
-    	model = PrebuiltHodModelFactory('zheng07')
+        model = PrebuiltHodModelFactory('zheng07')
 
-    	f100x = lambda t: t['halo_x'] > 100
-    	f150z = lambda t: t['halo_z'] > 150
+        f100x = lambda t: t['halo_x'] > 100
+        f150z = lambda t: t['halo_z'] > 150
 
         halocat = FakeSim()
-    	model.populate_mock(halocat, masking_function = f100x)
-    	assert np.all(model.mock.galaxy_table['halo_x'] > 100)
-    	model.populate_mock(halocat)
-    	assert np.any(model.mock.galaxy_table['halo_x'] < 100)
-    	model.populate_mock(halocat, masking_function = f100x)
-    	assert np.all(model.mock.galaxy_table['halo_x'] > 100)
+        model.populate_mock(halocat, masking_function = f100x)
+        assert np.all(model.mock.galaxy_table['halo_x'] > 100)
+        model.populate_mock(halocat)
+        assert np.any(model.mock.galaxy_table['halo_x'] < 100)
+        model.populate_mock(halocat, masking_function = f100x)
+        assert np.all(model.mock.galaxy_table['halo_x'] > 100)
 
-    	model.populate_mock(halocat, masking_function = f150z)
-    	assert np.all(model.mock.galaxy_table['halo_z'] > 150)
-    	assert np.any(model.mock.galaxy_table['halo_x'] < 100)
-    	model.populate_mock(halocat)
-    	assert np.any(model.mock.galaxy_table['halo_z'] < 150)
+        model.populate_mock(halocat, masking_function = f150z)
+        assert np.all(model.mock.galaxy_table['halo_z'] > 150)
+        assert np.any(model.mock.galaxy_table['halo_x'] < 100)
+        model.populate_mock(halocat)
+        assert np.any(model.mock.galaxy_table['halo_z'] < 150)
 
         runtime = time() - start
 
@@ -91,7 +91,7 @@ class TestHodMockFactory(TestCase):
         model = PrebuiltHodModelFactory('zheng07')
         halocat = FakeSim()
         model.populate_mock(halocat)
-        
+
         cenmask = model.mock.galaxy_table['gal_type'] == 'centrals'
         cens = model.mock.galaxy_table[cenmask]
         assert np.all(cens['halo_x'] == cens['x'])

--- a/halotools/empirical_models/factories/tests/test_hod_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_model_factory.py
@@ -27,7 +27,7 @@ class TestHodModelFactory(TestCase):
         with pytest.raises(HalotoolsError) as err:
             model = HodModelFactory()
         substr = "You did not pass any model features to the factory"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_populate_mock1(self):
         model = PrebuiltHodModelFactory('zheng07')
@@ -62,8 +62,8 @@ class TestHodModelFactory(TestCase):
         with pytest.raises(HalotoolsError) as err:
             m.populate_mock(halocat = halocat)
         substr = "this column is not available in the catalog you attempted to populate"
-        assert substr in err.value.message
-        assert "``Jose Canseco``" in err.value.message
+        assert substr in err.value.args[0]
+        assert "``Jose Canseco``" in err.value.args[0]
 
     def test_unavailable_upid(self):
         halocat = FakeSim()
@@ -73,7 +73,7 @@ class TestHodModelFactory(TestCase):
         with pytest.raises(HalotoolsError) as err:
             m.populate_mock(halocat = halocat)
         substr = "does not have the ``halo_upid`` column."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
 

--- a/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
@@ -48,7 +48,7 @@ class TestPrebuiltSubhaloModelFactory(TestCase):
             with pytest.raises(HalotoolsError) as err:
                 model2.populate_mock(halocat)
             substr = "Inconsistency between the model redshift"
-            assert substr in err.value.message
+            assert substr in err.value.args[0]
             halocat = FakeSim(redshift = 2.)
             model2.populate_mock(halocat)
 

--- a/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
@@ -151,7 +151,7 @@ class TestSubhaloModelFactory(TestCase):
         with pytest.raises(HalotoolsError) as err:
             model = SubhaloModelFactory()
         substr = "You did not pass any model features to the factory"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_unavailable_haloprop(self):
         halocat = FakeSim()
@@ -160,8 +160,8 @@ class TestSubhaloModelFactory(TestCase):
         with pytest.raises(HalotoolsError) as err:
             m.populate_mock(halocat)
         substr = "this column is not available in the catalog you attempted to populate"
-        assert substr in err.value.message
-        assert "``Jose Canseco``" in err.value.message
+        assert substr in err.value.args[0]
+        assert "``Jose Canseco``" in err.value.args[0]
 
     def tearDown(self):
         pass

--- a/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_subhalo_model_factory.py
@@ -145,7 +145,7 @@ class TestSubhaloModelFactory(TestCase):
         halocat = FakeSim()
         model1.populate_mock(halocat)
         assert hasattr(model1, 'mock')
-        assert 'stellar_mass' in model1.mock.galaxy_table.keys()
+        assert 'stellar_mass' in list(model1.mock.galaxy_table.keys())
 
     def test_empty_arguments(self):
         with pytest.raises(HalotoolsError) as err:

--- a/halotools/empirical_models/model_helpers.py
+++ b/halotools/empirical_models/model_helpers.py
@@ -314,7 +314,7 @@ def call_func_table(func_table, abscissa, func_indices):
     func_indices = convert_to_ndarray(func_indices)
     
     func_argsort = func_indices.argsort()
-    func_ranges = list(np.searchsorted(func_indices[func_argsort], range(len(func_table))))
+    func_ranges = list(np.searchsorted(func_indices[func_argsort], list(range(len(func_table)))))
     func_ranges.append(None)
     out = np.zeros_like(abscissa)
     for f, start, end in zip(func_table, func_ranges, func_ranges[1:]):
@@ -347,7 +347,7 @@ def bind_required_kwargs(required_kwargs, obj, **kwargs):
     as attribute with the same name as the keyword. 
     """
     for key in required_kwargs:
-        if key in kwargs.keys():
+        if key in list(kwargs.keys()):
             setattr(obj, key, kwargs[key])
         else:
             class_name = obj.__class__.__name__

--- a/halotools/empirical_models/occupation_models/leauthaud11_components.py
+++ b/halotools/empirical_models/occupation_models/leauthaud11_components.py
@@ -77,7 +77,7 @@ class Leauthaud11Cens(OccupationComponent):
         self.smhm_model = Behroozi10SmHm(
             prim_haloprop_key = prim_haloprop_key, **kwargs)
 
-        for key, value in self.smhm_model.param_dict.iteritems():
+        for key, value in self.smhm_model.param_dict.items():
             self.param_dict[key] = value
 
         self._methods_to_inherit = (
@@ -128,8 +128,8 @@ class Leauthaud11Cens(OccupationComponent):
         -----
         Assumes constant scatter in the stellar-to-halo-mass relation. 
         """
-        for key, value in self.param_dict.iteritems():
-            if key in self.smhm_model.param_dict.keys():
+        for key, value in self.param_dict.items():
+            if key in list(self.smhm_model.param_dict.keys()):
                 self.smhm_model.param_dict[key] = value 
 
         logmstar = np.log10(self.smhm_model.mean_stellar_mass(
@@ -161,7 +161,7 @@ class Leauthaud11Cens(OccupationComponent):
             Array containing stellar masses living in the input table. 
         """
 
-        for key, value in self.param_dict.iteritems():
+        for key, value in self.param_dict.items():
             if key in self.smhm_model.param_dict:
                 self.smhm_model.param_dict[key] = value 
         return self.smhm_model.mean_stellar_mass(redshift = self.redshift, **kwargs)
@@ -180,7 +180,7 @@ class Leauthaud11Cens(OccupationComponent):
         log_halo_mass : array_like 
             Array containing 10-base logarithm of halo mass in h=1 solar mass units. 
         """
-        for key, value in self.param_dict.iteritems():
+        for key, value in self.param_dict.items():
             if key in self.smhm_model.param_dict:
                 self.smhm_model.param_dict[key] = value 
         return self.smhm_model.mean_log_halo_mass(log_stellar_mass, 
@@ -268,9 +268,9 @@ class Leauthaud11Sats(OccupationComponent):
         Assumes constant scatter in the stellar-to-halo-mass relation. 
         """
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             function_name = "Leauthaud11Sats.mean_occupation"
@@ -301,7 +301,7 @@ class Leauthaud11Sats(OccupationComponent):
         self.param_dict['betacut'] = -0.13
         self.param_dict['betasat'] = 0.859
 
-        for key, value in self.central_occupation_model.param_dict.iteritems():
+        for key, value in self.central_occupation_model.param_dict.items():
             self.param_dict[key] = value
 
         self._update_satellite_params()
@@ -311,7 +311,7 @@ class Leauthaud11Sats(OccupationComponent):
         """ Private method to update the model parameters. 
 
         """
-        for key, value in self.param_dict.iteritems():
+        for key, value in self.param_dict.items():
             if key in self.central_occupation_model.param_dict:
                 self.central_occupation_model.param_dict[key] = value
 

--- a/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
+++ b/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
@@ -38,7 +38,7 @@ class TestOccupationComponent(TestCase):
 		with pytest.raises(KeyError) as err:
 			model = MyOccupationComponent()
 		substr = 'gal_type'
-		assert substr in err.value.message
+		assert substr in err.value.args[0]
 
 	def test_required_kwargs2(self):
 
@@ -50,7 +50,7 @@ class TestOccupationComponent(TestCase):
 		with pytest.raises(KeyError) as err:
 			model = MyOccupationComponent()
 		substr = 'threshold'
-		assert substr in err.value.message
+		assert substr in err.value.args[0]
 
 	def test_required_kwargs3(self):
 
@@ -64,7 +64,7 @@ class TestOccupationComponent(TestCase):
 		with pytest.raises(KeyError) as err:
 			model = MyOccupationComponent()
 		substr = 'upper_occupation_bound'
-		assert substr in err.value.message
+		assert substr in err.value.args[0]
 
 	def test_required_methods1(self):
 
@@ -77,7 +77,7 @@ class TestOccupationComponent(TestCase):
 		with pytest.raises(SyntaxError) as err:
 			model = MyOccupationComponent()
 		substr = 'implement a method named mean_occupation'
-		assert substr in err.value.message
+		assert substr in err.value.args[0]
 
 	def test_required_methods2(self):
 
@@ -109,7 +109,7 @@ class TestOccupationComponent(TestCase):
 		with pytest.raises(HalotoolsError) as err:
 			_ = model.mc_occupation(prim_haloprop = 1e10)
 		substr = "write your own ``mc_occupation`` method that overrides the method "
-		assert substr in err.value.message
+		assert substr in err.value.args[0]
 
 	@pytest.mark.slow
 	def test_nonstandard_upper_occupation_bound2(self):

--- a/halotools/empirical_models/occupation_models/tests/test_zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/tests/test_zheng07_components.py
@@ -201,7 +201,7 @@ class TestZheng07Cens(TestCase):
         with pytest.raises(HalotoolsError) as err:
             _ = self.default_model.mean_occupation(x = 4)
         substr = "You must pass either a ``table`` or ``prim_haloprop`` argument" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_get_published_parameters1(self):
         d1 = self.default_model.get_published_parameters(self.default_model.threshold)
@@ -211,7 +211,7 @@ class TestZheng07Cens(TestCase):
             d2 = self.default_model.get_published_parameters(self.default_model.threshold, 
                 publication='Parejko13')
         substr = "For Zheng07Cens, only supported best-fit models are currently Zheng et al. 2007"
-        assert substr == err.value.message
+        assert substr == err.value.args[0]
 
     def test_get_published_parameters3(self):
         with warnings.catch_warnings(record=True) as w:
@@ -412,7 +412,7 @@ class TestZheng07Sats(TestCase):
         with pytest.raises(HalotoolsError) as err:
             _ = self.default_model.mean_occupation(x = 4)
         substr = "You must pass either a ``table`` or ``prim_haloprop`` argument" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_get_published_parameters1(self):
         d1 = self.default_model.get_published_parameters(self.default_model.threshold)
@@ -422,7 +422,7 @@ class TestZheng07Sats(TestCase):
             d2 = self.default_model.get_published_parameters(self.default_model.threshold, 
                 publication='Parejko13')
         substr = "For Zheng07Sats, only supported best-fit models are currently Zheng et al. 2007"
-        assert substr == err.value.message
+        assert substr == err.value.args[0]
 
     def test_get_published_parameters3(self):
         with warnings.catch_warnings(record=True) as w:

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -114,7 +114,7 @@ class Tinker13Cens(OccupationComponent):
         """
         """
         self.param_dict = {}
-        for key, value in self.smhm_model.param_dict.iteritems():
+        for key, value in self.smhm_model.param_dict.items():
             active_key = key + '_active'
             quiescent_key = key + '_quiescent'
             self.param_dict[active_key] = value
@@ -284,7 +284,7 @@ class Tinker13Cens(OccupationComponent):
 
     def _update_smhm_param_dict(self, sfr_key):
 
-        for key, value in self.param_dict.iteritems():
+        for key, value in self.param_dict.items():
             if sfr_key in key:
                 stripped_key = key[:-len(sfr_key)-1]
             else:
@@ -453,9 +453,9 @@ class Tinker13QuiescentSats(OccupationComponent):
         Assumes constant scatter in the stellar-to-halo-mass relation. 
         """
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             function_name = "Tinker13QuiescentSats.mean_occupation"
@@ -493,7 +493,7 @@ class Tinker13QuiescentSats(OccupationComponent):
         self.param_dict['betasat_quiescent'] = 0.62
         self.param_dict['alphasat_quiescent'] = 1.08
 
-        for key, value in self.smhm_model.param_dict.iteritems():
+        for key, value in self.smhm_model.param_dict.items():
             quiescent_key = key + '_quiescent'
             self.param_dict[quiescent_key] = value
 
@@ -510,7 +510,7 @@ class Tinker13QuiescentSats(OccupationComponent):
         """ Private method to update the model parameters. 
 
         """
-        for key, value in self.param_dict.iteritems():
+        for key, value in self.param_dict.items():
             stripped_key = key[:-len('_quiescent')]
             if stripped_key in self.smhm_model.param_dict:
                 self.smhm_model.param_dict[stripped_key] = value
@@ -617,9 +617,9 @@ class Tinker13ActiveSats(OccupationComponent):
         Assumes constant scatter in the stellar-to-halo-mass relation. 
         """
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             function_name = "Tinker13ActiveSats.mean_occupation"
@@ -653,7 +653,7 @@ class Tinker13ActiveSats(OccupationComponent):
         self.param_dict['betasat_active'] = 1.05
         self.param_dict['alphasat_active'] = 0.99
 
-        for key, value in self.smhm_model.param_dict.iteritems():
+        for key, value in self.smhm_model.param_dict.items():
             active_key = key + '_active'
             self.param_dict[active_key] = value
 
@@ -670,7 +670,7 @@ class Tinker13ActiveSats(OccupationComponent):
         """ Private method to update the model parameters. 
 
         """
-        for key, value in self.param_dict.iteritems():
+        for key, value in self.param_dict.items():
             stripped_key = key[:-len('_active')]
             if stripped_key in self.smhm_model.param_dict:
                 self.smhm_model.param_dict[stripped_key] = value

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -130,9 +130,9 @@ class Zheng07Cens(OccupationComponent):
 
         """
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             msg = ("\nYou must pass either a ``table`` or ``prim_haloprop`` argument \n"
@@ -305,7 +305,7 @@ class Zheng07Sats(OccupationComponent):
             self.central_occupation_model = Zheng07Cens(
                 prim_haloprop_key = prim_haloprop_key, 
                 threshold = threshold)
-            for key, value in self.central_occupation_model.param_dict.iteritems():
+            for key, value in self.central_occupation_model.param_dict.items():
                 self.param_dict[key] = value
 
         self.publications = ['arXiv:0308519', 'arXiv:0703457']
@@ -360,14 +360,14 @@ class Zheng07Sats(OccupationComponent):
 
         """
         if self.modulate_with_cenocc is True:
-            for key, value in self.param_dict.iteritems():
+            for key, value in self.param_dict.items():
                 if key in self.central_occupation_model.param_dict:
                     self.central_occupation_model.param_dict[key] = value 
 
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             msg = ("\nYou must pass either a ``table`` or ``prim_haloprop`` argument \n"

--- a/halotools/empirical_models/phase_space_models/monte_carlo_helpers.py
+++ b/halotools/empirical_models/phase_space_models/monte_carlo_helpers.py
@@ -161,8 +161,8 @@ class MonteCarloGalProf(object):
                         )
                     if runtime > 5:
                         modelname = self.__class__.__name__
-                        print("\n...Building lookup tables for the %s radial profile." % modelname)
-                        print("    (This will take about %.0f seconds, and only needs to be done once)" % runtime)
+                        print(("\n...Building lookup tables for the %s radial profile." % modelname))
+                        print(("    (This will take about %.0f seconds, and only needs to be done once)" % runtime))
 
             profile_params_dimensions = [len(profile_params) for profile_params in profile_params_list]
             self.rad_prof_func_table = np.array(func_table).reshape(profile_params_dimensions)
@@ -496,7 +496,7 @@ class MonteCarloGalProf(object):
                 # profile_params = kwargs['profile_params']
                 halo_radius = convert_to_ndarray(kwargs['halo_radius'])
                 assert len(halo_radius) == len(profile_params[0])
-            except KeyError, AssertionError:
+            except KeyError as AssertionError:
                 raise HalotoolsError("\nIf not passing a ``table`` keyword argument "
                     "to mc_pos, must pass the following keyword arguments:\n"
                     "``profile_params``, ``halo_radius``.")
@@ -613,7 +613,7 @@ class MonteCarloGalProf(object):
         virial_velocities = self.virial_velocity(total_mass)
         radial_dispersions = virial_velocities*dimensionless_radial_dispersions
 
-        if 'seed' in kwargs.keys():
+        if 'seed' in list(kwargs.keys()):
             np.random.seed(kwargs['seed'])
 
         radial_velocities = np.random.normal(scale = radial_dispersions)

--- a/halotools/empirical_models/phase_space_models/profile_models/conc_mass_models.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/conc_mass_models.py
@@ -183,9 +183,9 @@ class ConcMass(object):
         """
 
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             raise HalotoolsError("Must pass one of the following keyword arguments "

--- a/halotools/empirical_models/phase_space_models/profile_models/tests/test_halo_catalog_nfw_consistency.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/tests/test_halo_catalog_nfw_consistency.py
@@ -26,7 +26,7 @@ from .....custom_exceptions import HalotoolsError
 # returned values depend on the configuration 
 # of my personal cache directory files
 from astropy.config.paths import _find_home 
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/empirical_models/phase_space_models/velocity_models/tests/__init__.py
+++ b/halotools/empirical_models/phase_space_models/velocity_models/tests/__init__.py
@@ -1,1 +1,1 @@
-from test_nfw_isotropic_jeans import *
+from .test_nfw_isotropic_jeans import *

--- a/halotools/empirical_models/smhm_models/behroozi10.py
+++ b/halotools/empirical_models/smhm_models/behroozi10.py
@@ -207,9 +207,9 @@ class Behroozi10SmHm(PrimGalpropModel):
         redshift = safely_retrieve_redshift(self, 'mean_stellar_mass', **kwargs)
 
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             halo_mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             halo_mass = kwargs['prim_haloprop']
         else:
             raise KeyError("Must pass one of the following keyword arguments to mean_occupation:\n"

--- a/halotools/empirical_models/smhm_models/moster13.py
+++ b/halotools/empirical_models/smhm_models/moster13.py
@@ -99,15 +99,15 @@ class Moster13SmHm(PrimGalpropModel):
         """
 
         # Retrieve the array storing the mass-like variable
-        if 'table' in kwargs.keys():
+        if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
-        elif 'prim_haloprop' in kwargs.keys():
+        elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
             raise KeyError("Must pass one of the following keyword arguments to mean_occupation:\n"
                 "``table`` or ``prim_haloprop``")
 
-        if 'redshift' in kwargs.keys():
+        if 'redshift' in list(kwargs.keys()):
             redshift = kwargs['redshift']
         elif hasattr(self, 'redshift'):
             redshift = self.redshift

--- a/halotools/empirical_models/smhm_models/tests/test_smhm_components.py
+++ b/halotools/empirical_models/smhm_models/tests/test_smhm_components.py
@@ -37,7 +37,7 @@ def test_Moster13SmHm_initialization():
 
 	keys = ['m10', 'm11', 'n10', 'n11', 'beta10', 'beta11', 'gamma10', 'gamma11', 'scatter_model_param1']
 	for key in keys:
-		assert key in default_model.param_dict.keys()
+		assert key in list(default_model.param_dict.keys())
 	assert default_model.param_dict['scatter_model_param1'] == model_defaults.default_smhm_scatter
 
 	default_scatter_dict = {'scatter_model_param1': model_defaults.default_smhm_scatter}

--- a/halotools/empirical_models/tests/test_model_helpers.py
+++ b/halotools/empirical_models/tests/test_model_helpers.py
@@ -38,14 +38,14 @@ class TestModelHelpers(TestCase):
             newcoords = occuhelp.enforce_periodicity_of_box(x, box_length, 
                 check_multiple_box_lengths = True)
         substr = "There is at least one input point with a coordinate less than -Lbox"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         x = np.linspace(-box_length, 2.1*box_length, Npts)
         with pytest.raises(HalotoolsError) as err:
             newcoords = occuhelp.enforce_periodicity_of_box(x, box_length, 
                 check_multiple_box_lengths = True)
         substr = "There is at least one input point with a coordinate greater than 2*Lbox"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         x = np.linspace(-box_length, 2*box_length, Npts)
         newcoords = occuhelp.enforce_periodicity_of_box(x, box_length, 

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-""" Common functions used when analyzing 
+""" Common functions used when analyzing
 catalogs of galaxies/halos.
 
 """
@@ -19,60 +19,60 @@ __author__ = ['Andrew Hearin']
 
 def mean_y_vs_x(x, y, error_estimator = 'error_on_mean', **kwargs):
     """
-    Estimate the mean value of the property *y* as a function of *x* 
-    for an input sample of galaxies/halos, 
-    optionally returning an error estimate. 
+    Estimate the mean value of the property *y* as a function of *x*
+    for an input sample of galaxies/halos,
+    optionally returning an error estimate.
 
-    The `mean_y_vs_x` function is just a convenience wrapper 
-    around `scipy.stats.binned_statistic` and `np.histogram`. 
+    The `mean_y_vs_x` function is just a convenience wrapper
+    around `scipy.stats.binned_statistic` and `np.histogram`.
 
-    See also :ref:`galaxy_catalog_analysis_tutorial1`. 
+    See also :ref:`galaxy_catalog_analysis_tutorial1`.
 
-    Parameters 
+    Parameters
     -----------
-    x : array_like 
-        Array storing values of the independent variable of the sample. 
+    x : array_like
+        Array storing values of the independent variable of the sample.
 
-    y : array_like 
-        Array storing values of the dependent variable of the sample. 
+    y : array_like
+        Array storing values of the dependent variable of the sample.
 
-    bins : array_like, optional 
-        Bins of the input *x*. 
-        Defaults are set by `scipy.stats.binned_statistic`.  
+    bins : array_like, optional
+        Bins of the input *x*.
+        Defaults are set by `scipy.stats.binned_statistic`.
 
-    error_estimator : string, optional 
-        If set to ``error_on_mean``, function will also return an array storing  
-        :math:`\\sigma_{y}/\\sqrt{N}`, where :math:`\\sigma_{y}` is the 
-        standard deviation of *y* in the bin 
-        and :math:`\\sqrt{N}` is the counts in each bin. 
+    error_estimator : string, optional
+        If set to ``error_on_mean``, function will also return an array storing
+        :math:`\\sigma_{y}/\\sqrt{N}`, where :math:`\\sigma_{y}` is the
+        standard deviation of *y* in the bin
+        and :math:`\\sqrt{N}` is the counts in each bin.
 
-        If set to ``variance``, function will also return an array storing  
-        :math:`\\sigma_{y}`. 
+        If set to ``variance``, function will also return an array storing
+        :math:`\\sigma_{y}`.
 
         Default is ``error_on_mean``
 
-    Returns 
+    Returns
     ----------
-    bin_midpoints : array_like 
-        Midpoints of the *x*-bins. 
+    bin_midpoints : array_like
+        Midpoints of the *x*-bins.
 
-    mean : array_like 
-        Mean of *y* estimated in bins 
+    mean : array_like
+        Mean of *y* estimated in bins
 
-    err : array_like 
+    err : array_like
         Error on *y* estimated in bins
 
-    Examples 
+    Examples
     ---------
     >>> from halotools.sim_manager import FakeSim
     >>> halocat = FakeSim()
-    >>> halos = halocat.halo_table 
+    >>> halos = halocat.halo_table
     >>> halo_mass, mean_spin, err = mean_y_vs_x(halos['halo_mvir'], halos['halo_spin'])
 
-    See also 
+    See also
     ---------
     :ref:`galaxy_catalog_analysis_tutorial1`
-    
+
     """
     try:
         assert error_estimator in ('error_on_mean', 'variance')
@@ -100,52 +100,52 @@ def mean_y_vs_x(x, y, error_estimator = 'error_on_mean', **kwargs):
     return bin_midpoints, mean, err
 
 def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
-    """ Returns a Numpy array of shape *(Npts, 3)* storing the 
+    """ Returns a Numpy array of shape *(Npts, 3)* storing the
     xyz-positions in the format used throughout
-    the `~halotools.mock_observables` package. 
+    the `~halotools.mock_observables` package.
 
-    See :ref:`mock_obs_pos_formatting` for a tutorial. 
+    See :ref:`mock_obs_pos_formatting` for a tutorial.
 
-    Parameters 
+    Parameters
     -----------
-    x, y, z : sequence of length-Npts arrays 
-        Units of Mpc assuming h=1, as throughout Halotools. 
+    x, y, z : sequence of length-Npts arrays
+        Units of Mpc assuming h=1, as throughout Halotools.
 
-    velocity : array, optional 
-        Length-Npts array of velocities in units of km/s 
-        used to apply peculiar velocity distortions, e.g.,  
-        :math:`z_{\\rm dist} = z + v/H_{0}`. 
-        Since Halotools workes exclusively in h=1 units, 
+    velocity : array, optional
+        Length-Npts array of velocities in units of km/s
+        used to apply peculiar velocity distortions, e.g.,
+        :math:`z_{\\rm dist} = z + v/H_{0}`.
+        Since Halotools workes exclusively in h=1 units,
         in the above formula :math:`H_{0} = 100 km/s/Mpc`.
 
-        If ``velocity`` argument is passed, 
-        ``velocity_distortion_dimension`` must also be passed. 
+        If ``velocity`` argument is passed,
+        ``velocity_distortion_dimension`` must also be passed.
 
-    velocity_distortion_dimension : string, optional 
-        If set to ``'x'``, ``'y'`` or ``'z'``, 
-        the requested dimension in the returned ``pos`` array 
-        will be distorted due to peculiar motion. 
-        For example, if ``velocity_distortion_dimension`` is ``z``, 
-        then ``pos`` can be treated as physically observed 
-        galaxy positions under the distant-observer approximation. 
-        Default is no distortions. 
+    velocity_distortion_dimension : string, optional
+        If set to ``'x'``, ``'y'`` or ``'z'``,
+        the requested dimension in the returned ``pos`` array
+        will be distorted due to peculiar motion.
+        For example, if ``velocity_distortion_dimension`` is ``z``,
+        then ``pos`` can be treated as physically observed
+        galaxy positions under the distant-observer approximation.
+        Default is no distortions.
 
-    mask : array_like, optional 
-        Boolean mask that can be used to select the positions 
-        of a subcollection of the galaxies stored in the ``galaxy_table``. 
+    mask : array_like, optional
+        Boolean mask that can be used to select the positions
+        of a subcollection of the galaxies stored in the ``galaxy_table``.
 
-    period : float, optional 
-        Length of the periodic box. Default is np.inf. 
+    period : float, optional
+        Length of the periodic box. Default is np.inf.
 
-        If period is not np.inf, then after applying peculiar velocity distortions 
-        the new coordinates will be remapped into the periodic box. 
+        If period is not np.inf, then after applying peculiar velocity distortions
+        the new coordinates will be remapped into the periodic box.
 
-    Returns 
+    Returns
     --------
-    pos : array_like 
-        Numpy array with shape *(Npts, 3)*. 
+    pos : array_like
+        Numpy array with shape *(Npts, 3)*.
 
-    Examples 
+    Examples
     ---------
     >>> npts = 100
     >>> Lbox = 250.
@@ -154,10 +154,10 @@ def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
     >>> z = np.random.uniform(0, Lbox, npts)
     >>> pos = return_xyz_formatted_array(x, y, z, period = Lbox)
 
-    Now we will define an array of random velocities that we will use 
-    to apply z-space distortions to the z-dimension. For our random velocities 
-    we'll assume the values are drawn from a Gaussian centered at zero 
-    using `numpy.random.normal`. 
+    Now we will define an array of random velocities that we will use
+    to apply z-space distortions to the z-dimension. For our random velocities
+    we'll assume the values are drawn from a Gaussian centered at zero
+    using `numpy.random.normal`.
 
     >>> velocity = np.random.normal(loc=0, scale=100, size=npts)
     >>> pos = return_xyz_formatted_array(x, y, z, period = Lbox, velocity = velocity, velocity_distortion_dimension='z')
@@ -165,8 +165,8 @@ def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
     """
     posdict = {'x': np.copy(x), 'y': np.copy(y), 'z': np.copy(z)}
 
-    a = 'velocity_distortion_dimension' in kwargs.keys()
-    b = 'velocity' in kwargs.keys()
+    a = 'velocity_distortion_dimension' in list(kwargs.keys())
+    b = 'velocity' in list(kwargs.keys())
     if bool(a+b) is True:
         if bool(a*b) is False:
             msg = ("You must either both or none of the following keyword arguments: "

--- a/halotools/mock_observables/delta_sigma.py
+++ b/halotools/mock_observables/delta_sigma.py
@@ -4,7 +4,7 @@
 calculate the galaxy-galaxy lensing signal.
 """
 
-from __future__ import division, print_function
+
 
 import sys
 import numpy as np

--- a/halotools/mock_observables/groups.py
+++ b/halotools/mock_observables/groups.py
@@ -289,7 +289,7 @@ def _scipy_to_igraph(matrix, coords, directed=False):
     y = coords[:,1]
     z = coords[:,2]
     if igraph_available:
-        g = igraph.Graph(zip(sources, targets), n=matrix.shape[0], directed=directed,\
+        g = igraph.Graph(list(zip(sources, targets)), n=matrix.shape[0], directed=directed,\
                             edge_attrs={'weight': weights},\
                             vertex_attrs={'x':x, 'y':y, 'z':z })
         return g

--- a/halotools/mock_observables/pair_counters/double_tree.py
+++ b/halotools/mock_observables/pair_counters/double_tree.py
@@ -7,7 +7,7 @@ cache-aware pairwise calculations on simulation boxes.
 
 import numpy as np
 from math import floor
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 from ...custom_exceptions import *
 
 __all__ = ['FlatRectanguloidTree', 'FlatRectanguloidDoubleTree']

--- a/halotools/mock_observables/pair_counters/double_tree.py
+++ b/halotools/mock_observables/pair_counters/double_tree.py
@@ -1,25 +1,27 @@
 # -*- coding: utf-8 -*-
 
 """
-Data structures used for efficient, 
+Data structures used for efficient,
 cache-aware pairwise calculations on simulation boxes.
 """
 
 import numpy as np
-from math import ceil, floor
+from math import floor
+from astropy.extern.six import xrange as range
 from ...custom_exceptions import *
 
-__all__=['FlatRectanguloidTree', 'FlatRectanguloidDoubleTree']
+__all__ = ['FlatRectanguloidTree', 'FlatRectanguloidDoubleTree']
 __author__ = ['Andrew Hearin', 'Duncan Campbell']
 
-class FlatRectanguloidTree(object):
-    """ Flat, rectangular tree structure for the simulation box used by the `~halotools.mock_observables` sub-package. 
 
-    The simulation box is divided into rectanguloid cells whose edges 
-    and faces are aligned with the x-, y- and z-axes of the box. 
-    Each spatial point in the box belongs to a unique cell. 
-    Any cell can be identified by either its tuple indices, (ix, iy, iz), 
-    or by the unique integer ID assigned it via the dictionary ordering 
+class FlatRectanguloidTree(object):
+    """ Flat, rectangular tree structure for the simulation box used by the `~halotools.mock_observables` sub-package.
+
+    The simulation box is divided into rectanguloid cells whose edges
+    and faces are aligned with the x-, y- and z-axes of the box.
+    Each spatial point in the box belongs to a unique cell.
+    Any cell can be identified by either its tuple indices, (ix, iy, iz),
+    or by the unique integer ID assigned it via the dictionary ordering
     of tuple indices:
 
         * (0, 0, 0) <--> 0
@@ -28,43 +30,43 @@ class FlatRectanguloidTree(object):
 
         * (0, 0, 2) <--> 2
 
-        * ... 
+        * ...
 
         * (0, 1, 0) <--> num_zdivs
 
         * (0, 1, 1) <--> num_zdivs + 1
 
-        * ..., 
-        
-    and so forth. 
+        * ...,
 
-    Each point thus has a unique triplet specifying 
-    the subvolume containing it, referred to as the 
-    *cell_tupleIDs* of that point. And equivalently, 
-    And equivalently, each point has a unique integer specifying 
-    the subvolume containing it, called the *cellID*. 
+    and so forth.
+
+    Each point thus has a unique triplet specifying
+    the subvolume containing it, referred to as the
+    *cell_tupleIDs* of that point. And equivalently,
+    And equivalently, each point has a unique integer specifying
+    the subvolume containing it, called the *cellID*.
 
     """
 
-    def __init__(self, x, y, z, 
-        approx_xcell_size, approx_ycell_size, approx_zcell_size, 
+    def __init__(self, x, y, z,
+        approx_xcell_size, approx_ycell_size, approx_zcell_size,
         xperiod, yperiod, zperiod):
         """
-        Parameters 
+        Parameters
         ----------
         x, y, z : arrays
-            Length-*Npts* arrays containing the spatial position of the *Npts* points. 
+            Length-*Npts* arrays containing the spatial position of the *Npts* points.
 
-        approx_xcell_size, approx_ycell_size, approx_zcell_size : float 
-            approximate cell sizes into which the simulation box will be divided. 
-            These are only approximate because in each dimension, 
-            the actual cell size must be evenly divide the box size. 
+        approx_xcell_size, approx_ycell_size, approx_zcell_size : float
+            approximate cell sizes into which the simulation box will be divided.
+            These are only approximate because in each dimension,
+            the actual cell size must be evenly divide the box size.
 
         xperiod, yperiod, zperiod : floats
-            Length scale defining the periodic boundary conditions in each dimension. 
-            In virtually all realistic cases, these are all equal. 
+            Length scale defining the periodic boundary conditions in each dimension.
+            In virtually all realistic cases, these are all equal.
 
-        Examples 
+        Examples
         ---------
         >>> Npts, Lbox = 1e4, 1000
         >>> xperiod, yperiod, zperiod = Lbox, Lbox, Lbox
@@ -76,20 +78,20 @@ class FlatRectanguloidTree(object):
 
         >>> np.random.seed(43)
         >>> x = np.random.uniform(0, Lbox, Npts)
-        >>> y = np.random.uniform(0, Lbox, Npts) 
-        >>> z = np.random.uniform(0, Lbox, Npts) 
+        >>> y = np.random.uniform(0, Lbox, Npts)
+        >>> z = np.random.uniform(0, Lbox, Npts)
         >>> tree = FlatRectanguloidTree(x, y, z, approx_xcell_size, approx_ycell_size, approx_zcell_size, xperiod, yperiod, zperiod)
 
-        Since we used approximate cell sizes *Lbox/10* that 
-        exactly divided the period in each dimension, 
-        then we know there are *10* subvolumes-per-dimension. 
-        So, for example, based on the discussion above, 
-        *cellID = 0* will correspond to *cell_tupleID = (0, 0, 0)*,  
-        *cellID = 5* will correspond to *cell_tupleID = (0, 0, 5)* and 
-        *cellID = 13* will correspond to *cell_tupleID = (0, 1, 3).* 
+        Since we used approximate cell sizes *Lbox/10* that
+        exactly divided the period in each dimension,
+        then we know there are *10* subvolumes-per-dimension.
+        So, for example, based on the discussion above,
+        *cellID = 0* will correspond to *cell_tupleID = (0, 0, 0)*,
+        *cellID = 5* will correspond to *cell_tupleID = (0, 0, 5)* and
+        *cellID = 13* will correspond to *cell_tupleID = (0, 1, 3).*
 
-        Now that your tree has been built, you can efficiently access 
-        the *x, y, z* positions of the points lying in 
+        Now that your tree has been built, you can efficiently access
+        the *x, y, z* positions of the points lying in
         the subvolume with *cellID = i* as follows:
 
         >>> i = 13
@@ -102,9 +104,9 @@ class FlatRectanguloidTree(object):
 
         self._check_sensible_constructor_inputs()
 
-        self.xperiod = xperiod 
-        self.yperiod = yperiod 
-        self.zperiod = zperiod 
+        self.xperiod = xperiod
+        self.yperiod = yperiod
+        self.zperiod = zperiod
 
         self.num_xdivs = int(round(xperiod/float(approx_xcell_size)))
         self.num_ydivs = int(round(yperiod/float(approx_ycell_size)))
@@ -113,7 +115,7 @@ class FlatRectanguloidTree(object):
         self.xcell_size = self.xperiod/float(self.num_xdivs)
         self.ycell_size = self.yperiod/float(self.num_ydivs)
         self.zcell_size = self.zperiod/float(self.num_zdivs)
-        
+
         # Build the tree
         idx_sorted, slice_array = self.compute_cell_structure(x, y, z)
         self.x = np.ascontiguousarray(x[idx_sorted], dtype=np.float64)
@@ -128,145 +130,145 @@ class FlatRectanguloidTree(object):
         pass
 
     def cell_idx_from_cell_tuple(self, ix, iy, iz):
-        """ Return the *cellID* from the *cell_tupleIDs*. 
+        """ Return the *cellID* from the *cell_tupleIDs*.
 
-        Parameters 
+        Parameters
         -----------
-        ix, iy, iz : int 
-            Integers providing the *cell_tupleIDs* of the points. 
+        ix, iy, iz : int
+            Integers providing the *cell_tupleIDs* of the points.
 
-        Returns 
+        Returns
         ---------
-        cellID : int 
-            Integers providing the corresponding *cellIDs*. 
+        cellID : int
+            Integers providing the corresponding *cellIDs*.
         """
         return ix*(self.num_ydivs*self.num_zdivs) + iy*self.num_zdivs + iz
 
     def cell_tuple_from_cell_idx(self, cellID):
-        """ Return the *cell_tupleIDs* from the *cellID*. 
+        """ Return the *cell_tupleIDs* from the *cellID*.
 
-        Parameters 
+        Parameters
         -----------
-        cellID : int 
-            Integers providing the corresponding *cellIDs*. 
+        cellID : int
+            Integers providing the corresponding *cellIDs*.
 
-        Returns 
+        Returns
         ---------
-        ix, iy, iz : int 
-            Integers providing the *cell_tupleIDs* of the points. 
+        ix, iy, iz : int
+            Integers providing the *cell_tupleIDs* of the points.
         """
-        
+
         nxny = self.num_ydivs*self.num_zdivs
-        
+
         ix = cellID / nxny
-        
+
         iy = (cellID - ix*nxny) / self.num_zdivs
-        
+
         iz = cellID - (ix*self.num_ydivs*self.num_zdivs) - (iy*self.num_zdivs)
-        
+
         return ix, iy, iz
 
     def compute_cell_structure(self, x, y, z):
-        """ 
-        Method divides the periodic box into rectangular subvolumes, and assigns a 
-        subvolume index to each point.  The returned arrays can be used to efficiently 
-        access only those points in a given subvolume. 
+        """
+        Method divides the periodic box into rectangular subvolumes, and assigns a
+        subvolume index to each point.  The returned arrays can be used to efficiently
+        access only those points in a given subvolume.
 
-        Parameters 
+        Parameters
         ----------
         x, y, z : arrays
-            Length-*Npts* arrays containing the spatial position of the *Npts* points. 
+            Length-*Npts* arrays containing the spatial position of the *Npts* points.
 
-        Returns 
+        Returns
         -------
-        idx_sorted : array_like 
-            Array of indices that sort the points according to the dictionary 
-            order of the 3d subvolumes. 
+        idx_sorted : array_like
+            Array of indices that sort the points according to the dictionary
+            order of the 3d subvolumes.
 
-        slice_array : array_like 
-            array of `slice` objects used to access the elements of the *x, y, z* 
-            values of points residing in a given subvolume. 
+        slice_array : array_like
+            array of `slice` objects used to access the elements of the *x, y, z*
+            values of points residing in a given subvolume.
         """
 
         ix = np.floor(x/self.xcell_size).astype(int)
         iy = np.floor(y/self.ycell_size).astype(int)
         iz = np.floor(z/self.zcell_size).astype(int)
-        
+
         #take care of points right on the boundary
         ix = np.where(ix >= self.num_xdivs, self.num_xdivs-1, ix)
         iy = np.where(iy >= self.num_ydivs, self.num_ydivs-1, iy)
         iz = np.where(iz >= self.num_zdivs, self.num_zdivs-1, iz)
 
         cell_idx_of_particles = self.cell_idx_from_cell_tuple(ix, iy, iz)
-        
+
         num_total_cells = self.num_xdivs*self.num_ydivs*self.num_zdivs
 
         idx_sorted = np.argsort(cell_idx_of_particles)
-        bin_indices = np.searchsorted(cell_idx_of_particles[idx_sorted], 
+        bin_indices = np.searchsorted(cell_idx_of_particles[idx_sorted],
             np.arange(num_total_cells))
         bin_indices = np.append(bin_indices, None)
-        
+
         slice_array = np.empty(num_total_cells, dtype=object)
-        for icell in xrange(num_total_cells):
+        for icell in range(num_total_cells):
             slice_array[icell] = slice(bin_indices[icell], bin_indices[icell+1], 1)
-            
+
         return idx_sorted, slice_array
 
 
-class FlatRectanguloidDoubleTree(object): 
-    """ Double tree structure built up from two instances of `~halotools.mock_observables.pair_counters.FlatRectanguloidTree` used by the `~halotools.mock_observables` sub-package. 
+class FlatRectanguloidDoubleTree(object):
+    """ Double tree structure built up from two instances of `~halotools.mock_observables.pair_counters.FlatRectanguloidTree` used by the `~halotools.mock_observables` sub-package.
     """
 
-    def __init__(self, x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
-        search_xlength, search_ylength, search_zlength, 
+    def __init__(self, x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
+        search_xlength, search_ylength, search_zlength,
         xperiod, yperiod, zperiod, PBCs = True):
         """
-        Parameters 
+        Parameters
         ----------
         x1, y1, z1 : arrays
-            Length-*Npts1* arrays containing the spatial position of the *Npts1* points. 
+            Length-*Npts1* arrays containing the spatial position of the *Npts1* points.
 
         x2, y2, z2 : arrays
-            Length-*Npts2* arrays containing the spatial position of the *Npts2* points. 
+            Length-*Npts2* arrays containing the spatial position of the *Npts2* points.
 
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size : float 
-            approximate cell sizes into which the simulation box will be divided. 
-            These are only approximate because in each dimension, 
-            the actual cell size must be evenly divide the box size. 
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size : float
+            approximate cell sizes into which the simulation box will be divided.
+            These are only approximate because in each dimension,
+            the actual cell size must be evenly divide the box size.
 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size : float 
-            An entirely separate tree is built for the *Npts2* points, the structure of 
-            which is dependent on the struture of the *Npts1* tree as described below. 
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size : float
+            An entirely separate tree is built for the *Npts2* points, the structure of
+            which is dependent on the struture of the *Npts1* tree as described below.
 
         search_xlength, search_ylength, search_zlength, floats, optional
-            Maximum length over which a pair of points will searched for. 
-            For example, if using `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-            to compute a 3-D correlation function with radial separation bins 
-            *rbins = [0.1, 1, 10, 25]*, then in this case 
-            all the search lengths will equal 25. 
-            If using `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-            in a projected correlation function with *rp_bins = [0.1, 1, 10, 25]* and 
-            *pi_max = 40*, then *search_xlength = search_ylength = 25* and 
-            *search_zlength = 40*. 
+            Maximum length over which a pair of points will searched for.
+            For example, if using `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+            to compute a 3-D correlation function with radial separation bins
+            *rbins = [0.1, 1, 10, 25]*, then in this case
+            all the search lengths will equal 25.
+            If using `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+            in a projected correlation function with *rp_bins = [0.1, 1, 10, 25]* and
+            *pi_max = 40*, then *search_xlength = search_ylength = 25* and
+            *search_zlength = 40*.
 
         xperiod, yperiod, zperiod : floats
-            Length scale defining the periodic boundary conditions in each dimension. 
-            In virtually all realistic cases, these are all equal. 
+            Length scale defining the periodic boundary conditions in each dimension.
+            In virtually all realistic cases, these are all equal.
 
-        PBCs : bool, optional 
-            Boolean specifying whether or not the box has periodic boundary conditions. 
-            Default is True. 
+        PBCs : bool, optional
+            Boolean specifying whether or not the box has periodic boundary conditions.
+            Default is True.
         """
 
 
-        self.xperiod = xperiod 
-        self.yperiod = yperiod 
-        self.zperiod = zperiod 
-        self.search_xlength = search_xlength 
-        self.search_ylength = search_ylength 
-        self.search_zlength = search_zlength 
+        self.xperiod = xperiod
+        self.yperiod = yperiod
+        self.zperiod = zperiod
+        self.search_xlength = search_xlength
+        self.search_ylength = search_ylength
+        self.search_zlength = search_zlength
         self._PBCs = PBCs
 
         self._check_sensible_constructor_inputs()
@@ -278,14 +280,14 @@ class FlatRectanguloidDoubleTree(object):
             )
 
         # Build the tree for sample 1
-        self.tree1 = FlatRectanguloidTree(x1, y1, z1, 
-            modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize, 
+        self.tree1 = FlatRectanguloidTree(x1, y1, z1,
+            modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize,
             xperiod, yperiod, zperiod)
 
         # Define a few convenient pointers
-        self.num_x1divs = self.tree1.num_xdivs 
-        self.num_y1divs = self.tree1.num_ydivs 
-        self.num_z1divs = self.tree1.num_zdivs 
+        self.num_x1divs = self.tree1.num_xdivs
+        self.num_y1divs = self.tree1.num_ydivs
+        self.num_z1divs = self.tree1.num_zdivs
 
         self.x1cell_size = self.tree1.xcell_size
         self.y1cell_size = self.tree1.ycell_size
@@ -298,14 +300,14 @@ class FlatRectanguloidDoubleTree(object):
             )
 
         # Build the tree for sample 2
-        self.tree2 = FlatRectanguloidTree(x2, y2, z2, 
-            modified_x2_cellsize, modified_y2_cellsize, modified_z2_cellsize, 
+        self.tree2 = FlatRectanguloidTree(x2, y2, z2,
+            modified_x2_cellsize, modified_y2_cellsize, modified_z2_cellsize,
             xperiod, yperiod, zperiod)
 
         # Define a few convenient pointers
-        self.num_x2divs = self.tree2.num_xdivs 
-        self.num_y2divs = self.tree2.num_ydivs 
-        self.num_z2divs = self.tree2.num_zdivs 
+        self.num_x2divs = self.tree2.num_xdivs
+        self.num_y2divs = self.tree2.num_ydivs
+        self.num_z2divs = self.tree2.num_zdivs
 
         self.x2cell_size = self.tree2.xcell_size
         self.y2cell_size = self.tree2.ycell_size
@@ -328,42 +330,42 @@ class FlatRectanguloidDoubleTree(object):
                 "If you need to count pairs on these length scales, \n"
                 "you should use a larger simulation.\n")
             raise HalotoolsError(msg)
-        
 
 
-    def set_tree1_cell_sizes(self, 
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
+
+    def set_tree1_cell_sizes(self,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
         max_cells_per_dimension = 25):
-        """ Method sets the size of the cells of the first tree structure. 
+        """ Method sets the size of the cells of the first tree structure.
 
-        In each dimension, the cell size is required to evenly divide the 
-        size of the box enclosing the points. In order for the bookkeeping 
-        of the `adjacent_cell_generator` method to be correct, 
-        there must be at least three cell-lengths per box-length. 
-        Furthermore, there should not be too many cells per dimension 
-        or performance suffers, so the ``max_cells_per_dimension`` argument 
-        limits how small the cell-lengths can be. 
-        
-        Parameters 
+        In each dimension, the cell size is required to evenly divide the
+        size of the box enclosing the points. In order for the bookkeeping
+        of the `adjacent_cell_generator` method to be correct,
+        there must be at least three cell-lengths per box-length.
+        Furthermore, there should not be too many cells per dimension
+        or performance suffers, so the ``max_cells_per_dimension`` argument
+        limits how small the cell-lengths can be.
+
+        Parameters
         -----------
-        approx_x1cell_size : float 
-            Rough estimate for cell-length in the x-dimension. The exact 
-            cell-length will be adjusted to meet the criteria described above. 
+        approx_x1cell_size : float
+            Rough estimate for cell-length in the x-dimension. The exact
+            cell-length will be adjusted to meet the criteria described above.
 
-        approx_y1cell_size : float 
+        approx_y1cell_size : float
 
-        approx_z1cell_size : float 
+        approx_z1cell_size : float
 
-        max_cells_per_dimension : int, optional 
+        max_cells_per_dimension : int, optional
 
-        Returns 
+        Returns
         -------
-        modified_x1_cellsize : float 
-            Exact size of the cell-length in the x-dimension. 
+        modified_x1_cellsize : float
+            Exact size of the cell-length in the x-dimension.
 
-        modified_y1_cellsize : float 
+        modified_y1_cellsize : float
 
-        modified_z1_cellsize : float 
+        modified_z1_cellsize : float
         """
 
         x1mult = int(floor(self.xperiod/float(approx_x1cell_size)))
@@ -392,40 +394,40 @@ class FlatRectanguloidDoubleTree(object):
 
         return modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize
 
-    def set_tree2_cell_sizes(self, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+    def set_tree2_cell_sizes(self,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         max_cells_per_dimension = 25):
-        """ Method sets the size of the cells of the second tree structure. 
+        """ Method sets the size of the cells of the second tree structure.
 
-        In each dimension, the cell size is required to evenly divide the 
-        cell-size of the corresponding dimension of the first tree structure. 
-        In order for the bookkeeping of the `adjacent_cell_generator` method 
-        to be correct, in each dimension the cell-lengths of tree 2 cannot 
-        be larger than the cell-length of tree 1. 
-        Furthermore, there should not be too many cells per dimension 
-        or performance suffers, so the ``max_cells_per_dimension`` argument 
-        limits how small the cell-lengths can be. 
+        In each dimension, the cell size is required to evenly divide the
+        cell-size of the corresponding dimension of the first tree structure.
+        In order for the bookkeeping of the `adjacent_cell_generator` method
+        to be correct, in each dimension the cell-lengths of tree 2 cannot
+        be larger than the cell-length of tree 1.
+        Furthermore, there should not be too many cells per dimension
+        or performance suffers, so the ``max_cells_per_dimension`` argument
+        limits how small the cell-lengths can be.
 
-        Parameters 
+        Parameters
         -----------
-        approx_x2cell_size : float 
-            Rough estimate for cell-length in the x-dimension. The exact 
-            cell-length will be adjusted to meet the criteria described above. 
+        approx_x2cell_size : float
+            Rough estimate for cell-length in the x-dimension. The exact
+            cell-length will be adjusted to meet the criteria described above.
 
-        approx_y2cell_size : float 
+        approx_y2cell_size : float
 
-        approx_z2cell_size : float 
+        approx_z2cell_size : float
 
-        max_cells_per_dimension : int, optional 
+        max_cells_per_dimension : int, optional
 
-        Returns 
+        Returns
         -------
-        modified_x2_cellsize : float 
-            Exact size of the cell-length in the x-dimension. 
+        modified_x2_cellsize : float
+            Exact size of the cell-length in the x-dimension.
 
-        modified_y2_cellsize : float 
+        modified_y2_cellsize : float
 
-        modified_z2_cellsize : float 
+        modified_z2_cellsize : float
         """
 
         x2mult = int(round(self.tree1.xcell_size/float(approx_x2cell_size)))
@@ -448,49 +450,49 @@ class FlatRectanguloidDoubleTree(object):
 
 
     def leftmost_cell_tuple_idx2(self, tuple_idx1, num_cell2_per_cell1):
-        """ Given a *cell_tupleID1* for tree 1 in a single dimension, 
-        and given the number of tree-2 cells per tree1 cells in that dimension, 
-        return the *cell_tupleID2* of the tree-2 cell that is flush against the 
-        leftmost edge of the tree-1 cell with *cell_tupleID1*. 
+        """ Given a *cell_tupleID1* for tree 1 in a single dimension,
+        and given the number of tree-2 cells per tree1 cells in that dimension,
+        return the *cell_tupleID2* of the tree-2 cell that is flush against the
+        leftmost edge of the tree-1 cell with *cell_tupleID1*.
 
-        Parameters 
+        Parameters
         ------------
-        tuple_idx1 : int 
+        tuple_idx1 : int
             Index of the *cell_tupleID1* for tree 1 in a single dimension
 
-        num_cell2_per_cell1 : int 
-            Number of tree-2 cells per tree-1 cell in the given dimension 
+        num_cell2_per_cell1 : int
+            Number of tree-2 cells per tree-1 cell in the given dimension
 
-        Returns 
+        Returns
         --------
-        result : int 
+        result : int
 
         """
         return tuple_idx1*num_cell2_per_cell1
 
     def rightmost_cell_tuple_idx2(self, tuple_idx1, num_cell2_per_cell1):
-        """ Given a *cell_tupleID1* for tree 1 in a single dimension, 
-        and given the number of tree-2 cells per tree1 cells in that dimension, 
-        return the *cell_tupleID2* of the tree-2 cell that is flush against the 
-        rightmost edge of the tree-1 cell with *cell_tupleID1*. 
+        """ Given a *cell_tupleID1* for tree 1 in a single dimension,
+        and given the number of tree-2 cells per tree1 cells in that dimension,
+        return the *cell_tupleID2* of the tree-2 cell that is flush against the
+        rightmost edge of the tree-1 cell with *cell_tupleID1*.
 
-        Parameters 
+        Parameters
         ------------
-        tuple_idx1 : int 
+        tuple_idx1 : int
             Index of the *cell_tupleID1* for tree 1 in a single dimension
 
-        num_cell2_per_cell1 : int 
-            Number of tree-2 cells per tree-1 cell in the given dimension 
+        num_cell2_per_cell1 : int
+            Number of tree-2 cells per tree-1 cell in the given dimension
 
-        Returns 
+        Returns
         --------
-        result : int 
+        result : int
         """
         return (tuple_idx1+1)*num_cell2_per_cell1 - 1
 
     def num_cells_to_cover_search_length(self, cell_size, search_length):
-        """ Number of tree-2 cells that need to be searched to the left and right 
-        of the current tree-1 cell in order to guarantee that all points 
+        """ Number of tree-2 cells that need to be searched to the left and right
+        of the current tree-1 cell in order to guarantee that all points
         inside the search length will be found.
         """
         return int(np.ceil(search_length/float(cell_size)))
@@ -499,17 +501,17 @@ class FlatRectanguloidDoubleTree(object):
         """
         """
         leftmost_tuple_idx = (
-            self.leftmost_cell_tuple_idx2(dim_idx, num_cell2_per_cell1) - 
+            self.leftmost_cell_tuple_idx2(dim_idx, num_cell2_per_cell1) -
             num_covering_steps)
 
         rightmost_tuple_idx = (
-            self.rightmost_cell_tuple_idx2(dim_idx, num_cell2_per_cell1) + 
+            self.rightmost_cell_tuple_idx2(dim_idx, num_cell2_per_cell1) +
             num_covering_steps)
 
-        return xrange(leftmost_tuple_idx, rightmost_tuple_idx+1)
+        return range(leftmost_tuple_idx, rightmost_tuple_idx+1)
 
 
-    def adjacent_cell_generator(self, icell1, 
+    def adjacent_cell_generator(self, icell1,
         search_xlength, search_ylength, search_zlength):
         """
         """
@@ -518,28 +520,28 @@ class FlatRectanguloidDoubleTree(object):
         # Determine the cell tuple from the input cellID
         ix1, iy1, iz1 = self.tree1.cell_tuple_from_cell_idx(icell1)
 
-        # Determine the number of d2 cells are necessary to guarantee that 
-        ### we search for all points within the search length 
+        # Determine the number of d2 cells are necessary to guarantee that
+        ### we search for all points within the search length
         num_x2_covering_steps = self.num_cells_to_cover_search_length(
-            self.x2cell_size, search_xlength) 
+            self.x2cell_size, search_xlength)
 
         num_y2_covering_steps = self.num_cells_to_cover_search_length(
-            self.y2cell_size, search_ylength)    
+            self.y2cell_size, search_ylength)
 
         num_z2_covering_steps = self.num_cells_to_cover_search_length(
-            self.z2cell_size, search_zlength)  
+            self.z2cell_size, search_zlength)
 
 
-        # For each spatial dimension, retrieve a generator that yields 
-        ### the tuple indices of the adjacent cells that 
-        ### we need to search for pairs 
-        nonPBC_ix2_generator = self.nonPBC_generator(ix1, 
+        # For each spatial dimension, retrieve a generator that yields
+        ### the tuple indices of the adjacent cells that
+        ### we need to search for pairs
+        nonPBC_ix2_generator = self.nonPBC_generator(ix1,
             num_x2_covering_steps, self.num_xcell2_per_xcell1)
 
-        nonPBC_iy2_generator = self.nonPBC_generator(iy1, 
+        nonPBC_iy2_generator = self.nonPBC_generator(iy1,
             num_y2_covering_steps, self.num_ycell2_per_ycell1)
 
-        nonPBC_iz2_generator = self.nonPBC_generator(iz1, 
+        nonPBC_iz2_generator = self.nonPBC_generator(iz1,
             num_z2_covering_steps, self.num_zcell2_per_zcell1)
 
         for nonPBC_ix2 in nonPBC_ix2_generator:
@@ -579,5 +581,5 @@ class FlatRectanguloidDoubleTree(object):
                     icell2 = self.tree2.cell_idx_from_cell_tuple(ix2, iy2, iz2)
 
                     yield icell2, x2shift*self._PBCs, y2shift*self._PBCs, z2shift*self._PBCs
-                    
-                    
+
+

--- a/halotools/mock_observables/pair_counters/double_tree.py
+++ b/halotools/mock_observables/pair_counters/double_tree.py
@@ -5,6 +5,7 @@ Data structures used for efficient,
 cache-aware pairwise calculations on simulation boxes.
 """
 
+from __future__ import division
 import numpy as np
 from math import floor
 from astropy.extern.six.moves import xrange as range
@@ -108,13 +109,13 @@ class FlatRectanguloidTree(object):
         self.yperiod = yperiod
         self.zperiod = zperiod
 
-        self.num_xdivs = int(round(xperiod/float(approx_xcell_size)))
-        self.num_ydivs = int(round(yperiod/float(approx_ycell_size)))
-        self.num_zdivs = int(round(zperiod/float(approx_zcell_size)))
+        self.num_xdivs = int(np.round(xperiod / approx_xcell_size))
+        self.num_ydivs = int(np.round(yperiod / approx_ycell_size))
+        self.num_zdivs = int(np.round(zperiod / approx_zcell_size))
 
-        self.xcell_size = self.xperiod/float(self.num_xdivs)
-        self.ycell_size = self.yperiod/float(self.num_ydivs)
-        self.zcell_size = self.zperiod/float(self.num_zdivs)
+        self.xcell_size = self.xperiod / self.num_xdivs
+        self.ycell_size = self.yperiod / self.num_ydivs
+        self.zcell_size = self.zperiod / self.num_zdivs
 
         # Build the tree
         idx_sorted, slice_array = self.compute_cell_structure(x, y, z)
@@ -160,9 +161,9 @@ class FlatRectanguloidTree(object):
 
         nxny = self.num_ydivs*self.num_zdivs
 
-        ix = cellID / nxny
+        ix = cellID // nxny
 
-        iy = (cellID - ix*nxny) / self.num_zdivs
+        iy = (cellID - ix*nxny) // self.num_zdivs
 
         iz = cellID - (ix*self.num_ydivs*self.num_zdivs) - (iy*self.num_zdivs)
 
@@ -190,9 +191,9 @@ class FlatRectanguloidTree(object):
             values of points residing in a given subvolume.
         """
 
-        ix = np.floor(x/self.xcell_size).astype(int)
-        iy = np.floor(y/self.ycell_size).astype(int)
-        iz = np.floor(z/self.zcell_size).astype(int)
+        ix = np.floor(x // self.xcell_size).astype(int)
+        iy = np.floor(y // self.ycell_size).astype(int)
+        iz = np.floor(z // self.zcell_size).astype(int)
 
         #take care of points right on the boundary
         ix = np.where(ix >= self.num_xdivs, self.num_xdivs-1, ix)
@@ -313,9 +314,9 @@ class FlatRectanguloidDoubleTree(object):
         self.y2cell_size = self.tree2.ycell_size
         self.z2cell_size = self.tree2.zcell_size
 
-        self.num_xcell2_per_xcell1 = self.num_x2divs/self.num_x1divs
-        self.num_ycell2_per_ycell1 = self.num_y2divs/self.num_y1divs
-        self.num_zcell2_per_zcell1 = self.num_z2divs/self.num_z1divs
+        self.num_xcell2_per_xcell1 = self.num_x2divs // self.num_x1divs
+        self.num_ycell2_per_ycell1 = self.num_y2divs // self.num_y1divs
+        self.num_zcell2_per_zcell1 = self.num_z2divs // self.num_z1divs
 
     def _check_sensible_constructor_inputs(self):
         """
@@ -368,17 +369,17 @@ class FlatRectanguloidDoubleTree(object):
         modified_z1_cellsize : float
         """
 
-        x1mult = int(floor(self.xperiod/float(approx_x1cell_size)))
-        y1mult = int(floor(self.yperiod/float(approx_y1cell_size)))
-        z1mult = int(floor(self.zperiod/float(approx_z1cell_size)))
+        x1mult = int(floor(self.xperiod / approx_x1cell_size))
+        y1mult = int(floor(self.yperiod / approx_y1cell_size))
+        z1mult = int(floor(self.zperiod / approx_z1cell_size))
 
         x1mult = min(max_cells_per_dimension, x1mult)
         y1mult = min(max_cells_per_dimension, y1mult)
         z1mult = min(max_cells_per_dimension, z1mult)
 
-        xsearch_mult = int(floor(self.xperiod/float(self.search_xlength)))
-        ysearch_mult = int(floor(self.yperiod/float(self.search_ylength)))
-        zsearch_mult = int(floor(self.zperiod/float(self.search_zlength)))
+        xsearch_mult = int(floor(self.xperiod / self.search_xlength))
+        ysearch_mult = int(floor(self.yperiod / self.search_ylength))
+        zsearch_mult = int(floor(self.zperiod / self.search_zlength))
 
         x1mult = min(x1mult, xsearch_mult)
         y1mult = min(y1mult, ysearch_mult)
@@ -388,9 +389,9 @@ class FlatRectanguloidDoubleTree(object):
         y1mult = max(3, y1mult)
         z1mult = max(3, z1mult)
 
-        modified_x1_cellsize = self.xperiod/float(x1mult)
-        modified_y1_cellsize = self.yperiod/float(y1mult)
-        modified_z1_cellsize = self.zperiod/float(z1mult)
+        modified_x1_cellsize = self.xperiod / x1mult
+        modified_y1_cellsize = self.yperiod / y1mult
+        modified_z1_cellsize = self.zperiod / z1mult
 
         return modified_x1_cellsize, modified_y1_cellsize, modified_z1_cellsize
 
@@ -430,9 +431,9 @@ class FlatRectanguloidDoubleTree(object):
         modified_z2_cellsize : float
         """
 
-        x2mult = int(round(self.tree1.xcell_size/float(approx_x2cell_size)))
-        y2mult = int(round(self.tree1.ycell_size/float(approx_y2cell_size)))
-        z2mult = int(round(self.tree1.zcell_size/float(approx_z2cell_size)))
+        x2mult = int(np.round(self.tree1.xcell_size / approx_x2cell_size))
+        y2mult = int(np.round(self.tree1.ycell_size / approx_y2cell_size))
+        z2mult = int(np.round(self.tree1.zcell_size / approx_z2cell_size))
 
         x2mult = max(1, x2mult)
         y2mult = max(1, y2mult)
@@ -442,9 +443,9 @@ class FlatRectanguloidDoubleTree(object):
         y2mult = min(max_cells_per_dimension, y2mult)
         z2mult = min(max_cells_per_dimension, z2mult)
 
-        modified_x2_cellsize = self.tree1.xcell_size/x2mult
-        modified_y2_cellsize = self.tree1.ycell_size/y2mult
-        modified_z2_cellsize = self.tree1.zcell_size/z2mult
+        modified_x2_cellsize = self.tree1.xcell_size / x2mult
+        modified_y2_cellsize = self.tree1.ycell_size / y2mult
+        modified_z2_cellsize = self.tree1.zcell_size / z2mult
 
         return modified_x2_cellsize, modified_y2_cellsize, modified_z2_cellsize
 
@@ -495,7 +496,7 @@ class FlatRectanguloidDoubleTree(object):
         of the current tree-1 cell in order to guarantee that all points
         inside the search length will be found.
         """
-        return int(np.ceil(search_length/float(cell_size)))
+        return int(np.ceil(search_length / cell_size))
 
     def nonPBC_generator(self, dim_idx, num_covering_steps, num_cell2_per_cell1):
         """

--- a/halotools/mock_observables/pair_counters/double_tree.py
+++ b/halotools/mock_observables/pair_counters/double_tree.py
@@ -109,9 +109,9 @@ class FlatRectanguloidTree(object):
         self.yperiod = yperiod
         self.zperiod = zperiod
 
-        self.num_xdivs = int(np.round(xperiod / approx_xcell_size))
-        self.num_ydivs = int(np.round(yperiod / approx_ycell_size))
-        self.num_zdivs = int(np.round(zperiod / approx_zcell_size))
+        self.num_xdivs = max(int(np.round(xperiod / approx_xcell_size)), 1)
+        self.num_ydivs = max(int(np.round(yperiod / approx_ycell_size)), 1)
+        self.num_zdivs = max(int(np.round(zperiod / approx_zcell_size)), 1)
 
         self.xcell_size = self.xperiod / self.num_xdivs
         self.ycell_size = self.yperiod / self.num_ydivs

--- a/halotools/mock_observables/pair_counters/double_tree_pair_matrix.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pair_matrix.py
@@ -147,10 +147,10 @@ def pair_matrix(data1, data2, r_max, period=None, verbose=False, num_threads=1,
     #do the pair counting
     if num_threads>1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         pool.close()
     if num_threads==1:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
     
     #arrays to store result
     d = np.zeros((0,), dtype='float')
@@ -356,10 +356,10 @@ def xy_z_pair_matrix(data1, data2, rp_max, pi_max, period=None, verbose=False,\
     #do the pair counting
     if num_threads>1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         pool.close()
     if num_threads==1:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
     
     #arrays to store result
     d_perp = np.zeros((0,), dtype='float')
@@ -659,10 +659,10 @@ def conditional_pair_matrix(data1, data2, r_max, weights1, weights2, cond_func_i
     #do the pair counting
     if num_threads>1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         pool.close()
     if num_threads==1:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
     
     #arrays to store result
     d = np.zeros((0,), dtype='float')
@@ -974,10 +974,10 @@ def conditional_xy_z_pair_matrix(data1, data2, rp_max, pi_max, weights1, weights
     #do the pair counting
     if num_threads>1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         pool.close()
     if num_threads==1:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
     
     #arrays to store result
     d_perp = np.zeros((0,), dtype='float')

--- a/halotools/mock_observables/pair_counters/double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pairs.py
@@ -19,7 +19,7 @@ import numpy as np
 import time
 import multiprocessing
 from functools import partial
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 from .double_tree import FlatRectanguloidDoubleTree
 from .double_tree_helpers import *

--- a/halotools/mock_observables/pair_counters/double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_pairs.py
@@ -2,26 +2,24 @@
 
 """
 This module contains functions used to calculate the number of pairs of points
-as a function of the separation between the points. Many choices for the 
-separation variable(s) are available, including 3-D spherical shells, 
-`~halotools.mock_observables.pair_counters.npairs`, 2+1-D cylindrical shells, 
-`~halotools.mock_observables.pair_counters.xy_z_npairs`, and separations 
-:math:`s + \\theta_{\\rm los}` defined by angular & line-of-sight coordinates, 
-`~halotools.mock_observables.pair_counters.s_mu_npairs`. 
-There is also a function `~halotools.mock_observables.pair_counters.jnpairs` 
-used to provide jackknife error estimates on the pair counts. 
+as a function of the separation between the points. Many choices for the
+separation variable(s) are available, including 3-D spherical shells,
+`~halotools.mock_observables.pair_counters.npairs`, 2+1-D cylindrical shells,
+`~halotools.mock_observables.pair_counters.xy_z_npairs`, and separations
+:math:`s + \\theta_{\\rm los}` defined by angular & line-of-sight coordinates,
+`~halotools.mock_observables.pair_counters.s_mu_npairs`.
+There is also a function `~halotools.mock_observables.pair_counters.jnpairs`
+used to provide jackknife error estimates on the pair counts.
 """
 
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
-from copy import copy 
 
 import time
-import sys
 import multiprocessing
-from multiprocessing import Value, Lock
 from functools import partial
+from astropy.extern.six import xrange as range
 
 from .double_tree import FlatRectanguloidDoubleTree
 from .double_tree_helpers import *
@@ -40,117 +38,117 @@ def npairs(data1, data2, rbins, period = None,\
            verbose = False, num_threads = 1,\
            approx_cell1_size = None, approx_cell2_size = None):
     """
-    Function counts the number of pairs of points separated by a three-dimensional distance 
-    smaller than the input ``rbins``. 
-        
-    Note that if data1 == data2 that the 
-    `~halotools.mock_observables.npairs` function double-counts pairs. 
-    If your science application requires data1==data2 inputs and also pairs 
-    to not be double-counted, simply divide the final counts by 2. 
+    Function counts the number of pairs of points separated by a three-dimensional distance
+    smaller than the input ``rbins``.
 
-    A common variation of pair-counting calculations is to count pairs with 
-    separations *between* two different distances *r1* and *r2*. You can retrieve 
-    this information from the `~halotools.mock_observables.npairs` 
-    by taking `numpy.diff` of the returned array. 
+    Note that if data1 == data2 that the
+    `~halotools.mock_observables.npairs` function double-counts pairs.
+    If your science application requires data1==data2 inputs and also pairs
+    to not be double-counted, simply divide the final counts by 2.
 
-    See Notes section for further clarification. 
+    A common variation of pair-counting calculations is to count pairs with
+    separations *between* two different distances *r1* and *r2*. You can retrieve
+    this information from the `~halotools.mock_observables.npairs`
+    by taking `numpy.diff` of the returned array.
+
+    See Notes section for further clarification.
 
     Parameters
     ----------
     data1 : array_like
-        N1 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N1 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     data2 : array_like
         N2 by 3 numpy array of 3-dimensional positions.
-        Values of each dimension should be between zero and the corresponding dimension 
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     rbins : array_like
         Boundaries defining the bins in which pairs are counted.
-        
+
     period : array_like, optional
-        Length-3 array defining the periodic boundary conditions. 
-        If only one number is specified, the enclosing volume is assumed to 
-        be a periodic cube (by far the most common case). 
-        If period is set to None, the default option, 
-        PBCs are set to infinity.  
-    
+        Length-3 array defining the periodic boundary conditions.
+        If only one number is specified, the enclosing volume is assumed to
+        be a periodic cube (by far the most common case).
+        If period is set to None, the default option,
+        PBCs are set to infinity.
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        Number of CPU cores to use in the pair counting. 
-        If ``num_threads`` is set to the string 'max', use all available cores. 
-        Default is 1 thread for a serial calculation that 
-        does not open a multiprocessing pool. 
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-    
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-    
+        Number of CPU cores to use in the pair counting.
+        If ``num_threads`` is set to the string 'max', use all available cores.
+        Default is 1 thread for a serial calculation that
+        does not open a multiprocessing pool.
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
-    num_pairs : array_like 
-        Numpy array of length len(rbins) storing the numbers of pairs in the input bins. 
-    
-    Examples 
+    num_pairs : array_like
+        Numpy array of length len(rbins) storing the numbers of pairs in the input bins.
+
+    Examples
     --------
-    For demonstration purposes we create randomly distributed sets of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create randomly distributed sets of points within a
+    periodic unit cube.
+
     >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rbins = np.logspace(-1, 1.5, 15)
-    
+
     >>> x1 = np.random.uniform(0, Lbox, Npts1)
     >>> y1 = np.random.uniform(0, Lbox, Npts1)
     >>> z1 = np.random.uniform(0, Lbox, Npts1)
     >>> x2 = np.random.uniform(0, Lbox, Npts2)
     >>> y2 = np.random.uniform(0, Lbox, Npts2)
     >>> z2 = np.random.uniform(0, Lbox, Npts2)
-    
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
-    
-    >>> data1 = np.vstack([x1, y1, z1]).T 
-    >>> data2 = np.vstack([x2, y2, z2]).T 
+
+    >>> data1 = np.vstack([x1, y1, z1]).T
+    >>> data2 = np.vstack([x2, y2, z2]).T
 
     >>> result = npairs(data1, data2, rbins, period = period)
 
-    Notes 
+    Notes
     -----
-    One final point of clarification concerning double-counting may be in order. 
-    Suppose data1==data2 and rbins[0]==0. Then the returned value for this bin 
-    will be len(data1), since each data1 point has distance 0 from itself. 
+    One final point of clarification concerning double-counting may be in order.
+    Suppose data1==data2 and rbins[0]==0. Then the returned value for this bin
+    will be len(data1), since each data1 point has distance 0 from itself.
     """
 
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rbins, period, num_threads, PBCs = (
-        _npairs_process_args(data1, data2, rbins, period, 
+        _npairs_process_args(data1, data2, rbins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
-        )        
-    
-    xperiod, yperiod, zperiod = period 
+        )
+
+    xperiod, yperiod, zperiod = period
     rmax = np.max(rbins)
-    
+
     if verbose==True:
         print("running double_tree_pairs.xy_z_npairs on {0} x {1}\n"
               "points with PBCs={2}".format(len(data1), len(data2), PBCs))
         start = time.time()
-    
+
     ### Compute the estimates for the cell sizes
     approx_cell1_size, approx_cell2_size = (
         _set_approximate_cell_sizes(approx_cell1_size, approx_cell2_size, rmax, period)
@@ -159,15 +157,15 @@ def npairs(data1, data2, rbins, period = None,\
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
 
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rmax, rmax, rmax, xperiod, yperiod, zperiod, PBCs=PBCs)
-        
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
-    
+
     if verbose==True:
         print("volume 1 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x1divs,\
@@ -175,23 +173,23 @@ def npairs(data1, data2, rbins, period = None,\
         print("volume 2 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x2divs,\
               double_tree.num_y2divs,double_tree.num_z2divs,Ncell2))
-    
+
     #create a function to call with only one argument
-    engine = partial(_npairs_engine, 
+    engine = partial(_npairs_engine,
         double_tree, rbins, period, PBCs)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        cell1_chunk_list = np.array_split(xrange(Ncell1), num_threads)
+        cell1_chunk_list = np.array_split(range(Ncell1), num_threads)
         result = pool.map(engine,cell1_chunk_list)
         pool.close()
         counts = np.sum(np.array(result), axis=0)
     if num_threads == 1:
-        counts = engine(xrange(Ncell1))
+        counts = engine(range(Ncell1))
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
-    
+
     return counts
 
 
@@ -200,9 +198,9 @@ def _npairs_engine(double_tree, rbins, period, PBCs, cell1_list):
     pair counting engine for npairs function.  This code calls a cython function.
     """
     # print("...working on icell1 = %i" % icell1)
-    
+
     counts = np.zeros(len(rbins))
-    
+
     for icell1 in cell1_list:
         #extract the points in the cell
         s1 = double_tree.tree1.slice_array[icell1]
@@ -210,19 +208,19 @@ def _npairs_engine(double_tree, rbins, period, PBCs, cell1_list):
             double_tree.tree1.x[s1],
             double_tree.tree1.y[s1],
             double_tree.tree1.z[s1])
-            
+
         xsearch_length = rbins[-1]
         ysearch_length = rbins[-1]
         zsearch_length = rbins[-1]
         adj_cell_generator = double_tree.adjacent_cell_generator(
             icell1, xsearch_length, ysearch_length, zsearch_length)
-                
+
         for icell2, xshift, yshift, zshift in adj_cell_generator:
-                    
+
             #extract the points in the cell
             s2 = double_tree.tree2.slice_array[icell2]
             x_icell2 = double_tree.tree2.x[s2] + xshift
-            y_icell2 = double_tree.tree2.y[s2] + yshift 
+            y_icell2 = double_tree.tree2.y[s2] + yshift
             z_icell2 = double_tree.tree2.z[s2] + zshift
 
 
@@ -231,7 +229,7 @@ def _npairs_engine(double_tree, rbins, period, PBCs, cell1_list):
                 x_icell1, y_icell1, z_icell1,
                 x_icell2, y_icell2, z_icell2,
                 rbins)
-            
+
     return counts
 
 
@@ -239,136 +237,136 @@ def _npairs_engine(double_tree, rbins, period, PBCs, cell1_list):
 ##########################################################################
 
 def jnpairs(data1, data2, rbins, period=None, weights1=None, weights2=None,
-    jtags1=None, jtags2=None, N_samples=0, verbose=False, num_threads=1, 
+    jtags1=None, jtags2=None, N_samples=0, verbose=False, num_threads=1,
     approx_cell1_size = None, approx_cell2_size = None):
     """
-    Pair counter used to make jackknife error estimates of real-space pair counter 
-    `~halotools.mock_observables.pair_counters.npairs`. 
-        
+    Pair counter used to make jackknife error estimates of real-space pair counter
+    `~halotools.mock_observables.pair_counters.npairs`.
+
     Parameters
     ----------
     data1 : array_like
-        N1 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N1 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     data2 : array_like
-        N1 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N1 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     rbins : array_like
         Boundaries defining the bins in which pairs are counted.
-        
+
     period : array_like, optional
-        Length-3 array defining the periodic boundary conditions. 
-        If only one number is specified, the enclosing volume is assumed to 
-        be a periodic cube (by far the most common case). 
-        If period is set to None, the default option, 
-        PBCs are set to infinity.  
-    
+        Length-3 array defining the periodic boundary conditions.
+        If only one number is specified, the enclosing volume is assumed to
+        be a periodic cube (by far the most common case).
+        If period is set to None, the default option,
+        PBCs are set to infinity.
+
     weights1 : array_like, optional
-        length N1 array containing weights used for weighted pair counts. 
-        
+        length N1 array containing weights used for weighted pair counts.
+
     weights2 : array_like, optional
         length N2 array containing weights used for weighted pair counts.
-    
+
     jtags1 : array_like, optional
-        length N1 array containing integer tags used to define jackknife sample 
-        membership. Tags are in the range [1, N_samples]. 
+        length N1 array containing integer tags used to define jackknife sample
+        membership. Tags are in the range [1, N_samples].
         The tag '0' is a reserved tag and should not be used.
-        
+
     jtags2 : array_like, optional
-        length N2 array containing integer tags used to define jackknife sample 
-        membership. Tags are in the range [1, N_samples]. 
+        length N2 array containing integer tags used to define jackknife sample
+        membership. Tags are in the range [1, N_samples].
         The tag '0' is a reserved tag and should not be used.
-    
+
     N_samples : int, optional
-        Total number of jackknife samples. All values of ``jtags1`` and ``jtags2`` 
-        should be in the range [1, N_samples]. 
-    
+        Total number of jackknife samples. All values of ``jtags1`` and ``jtags2``
+        should be in the range [1, N_samples].
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
-    num_threads : int, optional
-        Number of CPU cores to use in the pair counting. 
-        If ``num_threads`` is set to the string 'max', use all available cores. 
-        Default is 1 thread for a serial calculation that 
-        does not open a multiprocessing pool. 
 
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
+    num_threads : int, optional
+        Number of CPU cores to use in the pair counting.
+        If ``num_threads`` is set to the string 'max', use all available cores.
+        Default is 1 thread for a serial calculation that
+        does not open a multiprocessing pool.
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
         will apportion the ``data`` points into subvolumes of the simulation box.
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-        
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
 
     Returns
     -------
-    N_pairs : array_like  
-        Numpy array of shape (N_samples+1,len(rbins)). 
-        The sub-array N_pairs[0, :] stores numbers of pairs 
-        in the input bins for the entire sample. 
-        The sub-array N_pairs[i, :] stores numbers of pairs 
-        in the input bins for the :math:`i^{\\rm th}` jackknife sub-sample. 
-    
+    N_pairs : array_like
+        Numpy array of shape (N_samples+1,len(rbins)).
+        The sub-array N_pairs[0, :] stores numbers of pairs
+        in the input bins for the entire sample.
+        The sub-array N_pairs[i, :] stores numbers of pairs
+        in the input bins for the :math:`i^{\\rm th}` jackknife sub-sample.
+
     Notes
     -----
     Jackknife weights are calculated using a weighting function.
-    
+
     If both points are outside the sample, the weighting function returns 0.
     If both points are inside the sample, the weighting function returns (w1 * w2)
     If one point is inside, and the other is outside, the weighting function returns (w1 * w2)/2
 
-    Examples 
+    Examples
     --------
-    For demonstration purposes we create randomly distributed sets of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create randomly distributed sets of points within a
+    periodic unit cube.
+
     >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rbins = np.logspace(-1, 1.5, 15)
-    
+
     >>> x1 = np.random.uniform(0, Lbox, Npts1)
     >>> y1 = np.random.uniform(0, Lbox, Npts1)
     >>> z1 = np.random.uniform(0, Lbox, Npts1)
     >>> x2 = np.random.uniform(0, Lbox, Npts2)
     >>> y2 = np.random.uniform(0, Lbox, Npts2)
     >>> z2 = np.random.uniform(0, Lbox, Npts2)
-    
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
-    
-    >>> data1 = np.vstack([x1, y1, z1]).T 
-    >>> data2 = np.vstack([x2, y2, z2]).T 
-    
-    Ordinarily, you would create ``jtags`` for the points by properly subdivide 
-    the points into spatial sub-volumes. For illustration purposes, we'll simply 
+
+    >>> data1 = np.vstack([x1, y1, z1]).T
+    >>> data2 = np.vstack([x2, y2, z2]).T
+
+    Ordinarily, you would create ``jtags`` for the points by properly subdivide
+    the points into spatial sub-volumes. For illustration purposes, we'll simply
     use randomly assigned sub-volumes as this has no impact on the calling signature:
-    
+
     >>> N_samples = 10
     >>> jtags1 = np.random.random_integers(1, N_samples, Npts1)
     >>> jtags2 = np.random.random_integers(1, N_samples, Npts2)
-    
+
     >>> result = jnpairs(data1, data2, rbins, period = period, jtags1=jtags1, jtags2=jtags2, N_samples = N_samples)
 
     """
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rbins, period, num_threads, PBCs = (
-        _npairs_process_args(data1, data2, rbins, period, 
+        _npairs_process_args(data1, data2, rbins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
         )
-    xperiod, yperiod, zperiod = period 
+    xperiod, yperiod, zperiod = period
     rmax = np.max(rbins)
-    
+
     if verbose==True:
         print("running double_tree_pairs.xy_z_npairs on {0} x {1}\n"
               "points with PBCs={2}".format(len(data1), len(data2), PBCs))
@@ -376,10 +374,10 @@ def jnpairs(data1, data2, rbins, period=None, weights1=None, weights2=None,
         total_volume  = period.prod()
         print("searching for pairs over {}% of the total volume\n"
               "for each point.".format(search_volume/total_volume))
-    
+
     # Process the input weights and jackknife-tags with the helper function
     weights1, weights2, jtags1, jtags2 = (
-        _jnpairs_process_weights_jtags(data1, data2, 
+        _jnpairs_process_weights_jtags(data1, data2,
             weights1, weights2, jtags1, jtags2, N_samples))
 
     ### Compute the estimates for the cell sizes
@@ -390,24 +388,24 @@ def jnpairs(data1, data2, rbins, period=None, weights1=None, weights2=None,
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
 
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rmax, rmax, rmax, xperiod, yperiod, zperiod, PBCs=PBCs)
 
 
     #sort the weights arrays
     weights1 = weights1[double_tree.tree1.idx_sorted]
     weights2 = weights2[double_tree.tree2.idx_sorted]
-        
+
     #sort the jackknife tag arrays
     jtags1 = jtags1[double_tree.tree1.idx_sorted]
     jtags2 = jtags2[double_tree.tree2.idx_sorted]
-    
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
-    
+
     if verbose==True:
         print("volume 1 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x1divs,\
@@ -415,35 +413,35 @@ def jnpairs(data1, data2, rbins, period=None, weights1=None, weights2=None,
         print("volume 2 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x2divs,\
               double_tree.num_y2divs,double_tree.num_z2divs,Ncell2))
-    
+
     #create a function to call with only one argument
-    engine = partial(_jnpairs_engine, double_tree, 
+    engine = partial(_jnpairs_engine, double_tree,
         weights1, weights2, jtags1, jtags2, N_samples, rbins, period, PBCs)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        cell1_chunk_list = np.array_split(xrange(Ncell1), num_threads)
+        cell1_chunk_list = np.array_split(range(Ncell1), num_threads)
         result = pool.map(engine,cell1_chunk_list)
         pool.close()
         counts = np.sum(np.array(result), axis=0)
     if num_threads == 1:
-        counts = engine(xrange(Ncell1))
+        counts = engine(range(Ncell1))
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
-    
+
     return counts
 
 
 ##########################################################################
 
-def _jnpairs_engine(double_tree, weights1, weights2, jtags1, jtags2, 
+def _jnpairs_engine(double_tree, weights1, weights2, jtags1, jtags2,
     N_samples, rbins, period, PBCs, cell1_list):
     """
     """
 
     counts = np.zeros((N_samples+1,len(rbins)))
-    
+
     for icell1 in cell1_list:
         #extract the points in the cell
         s1 = double_tree.tree1.slice_array[icell1]
@@ -454,7 +452,7 @@ def _jnpairs_engine(double_tree, weights1, weights2, jtags1, jtags2,
 
         #extract the weights in the cell
         w_icell1 = weights1[s1]
-            
+
         #extract the jackknife tags in the cell
         j_icell1 = jtags1[s1]
 
@@ -463,146 +461,146 @@ def _jnpairs_engine(double_tree, weights1, weights2, jtags1, jtags2,
         zsearch_length = rbins[-1]
         adj_cell_generator = double_tree.adjacent_cell_generator(
             icell1, xsearch_length, ysearch_length, zsearch_length)
-                
+
         for icell2, xshift, yshift, zshift in adj_cell_generator:
-                    
+
             #extract the points in the cell
             s2 = double_tree.tree2.slice_array[icell2]
             x_icell2 = double_tree.tree2.x[s2] + xshift
-            y_icell2 = double_tree.tree2.y[s2] + yshift 
+            y_icell2 = double_tree.tree2.y[s2] + yshift
             z_icell2 = double_tree.tree2.z[s2] + zshift
 
             #extract the weights in the cell
             w_icell2 = weights2[s2]
-                
+
             #extract the jackknife tags in the cell
             j_icell2 = jtags2[s2]
 
             #use cython functions to do pair counting
             counts += jnpairs_no_pbc(x_icell1, y_icell1, z_icell1,
                 x_icell2, y_icell2, z_icell2,
-                w_icell1, w_icell2, j_icell1, j_icell2, 
+                w_icell1, w_icell2, j_icell1, j_icell2,
                 N_samples+1, rbins)
-            
+
     return counts
 
 ##########################################################################
-def xy_z_npairs(data1, data2, rp_bins, pi_bins, period=None, verbose=False, num_threads=1, 
+def xy_z_npairs(data1, data2, rp_bins, pi_bins, period=None, verbose=False, num_threads=1,
                 approx_cell1_size = None, approx_cell2_size = None):
     """
-    Function counts the number of pairs of points separated by less than 
-    projected separation :math:`r_{\\rm p}` and line-of-sight separation :math:`\\pi`.  
-        
-    Note that if data1 == data2 that the 
-    `~halotools.mock_observables.xy_z_npairs` function double-counts pairs. 
-    If your science application requires data1==data2 inputs and also pairs 
-    to not be double-counted, simply divide the final counts by 2. 
+    Function counts the number of pairs of points separated by less than
+    projected separation :math:`r_{\\rm p}` and line-of-sight separation :math:`\\pi`.
 
-    A common variation of pair-counting calculations is to count pairs with 
-    separations *between* two different distances *r1* and *r2*. You can retrieve 
-    this information from the `~halotools.mock_observables.xy_z_npairs` 
-    by taking `numpy.diff` of the returned array. 
+    Note that if data1 == data2 that the
+    `~halotools.mock_observables.xy_z_npairs` function double-counts pairs.
+    If your science application requires data1==data2 inputs and also pairs
+    to not be double-counted, simply divide the final counts by 2.
 
-    See Notes section for further clarification. 
+    A common variation of pair-counting calculations is to count pairs with
+    separations *between* two different distances *r1* and *r2*. You can retrieve
+    this information from the `~halotools.mock_observables.xy_z_npairs`
+    by taking `numpy.diff` of the returned array.
+
+    See Notes section for further clarification.
 
     Parameters
     ----------
     data1 : array_like
-        N1 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N1 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-    
+
     data2 : array_like
-        N2 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N2 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-    
+
     rp_bins : array_like
-        numpy array of boundaries defining the projected separation 
-        :math:`r_{\\rm p}` bins in which pairs are 
+        numpy array of boundaries defining the projected separation
+        :math:`r_{\\rm p}` bins in which pairs are
         counted.
-    
+
     pi_bins : array_like
-        numpy array of boundaries defining the line-of-sight separation 
+        numpy array of boundaries defining the line-of-sight separation
         :math:`\\pi` bins in which pairs are counted.
-    
+
     period : array_like, optional
-        Length-3 array defining the periodic boundary conditions. 
-        If only one number is specified, the enclosing volume is assumed to 
-        be a periodic cube (by far the most common case). 
-        If period is set to None, the default option, 
-        PBCs are set to infinity.  
-    
+        Length-3 array defining the periodic boundary conditions.
+        If only one number is specified, the enclosing volume is assumed to
+        be a periodic cube (by far the most common case).
+        If period is set to None, the default option,
+        PBCs are set to infinity.
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        Number of CPU cores to use in the pair counting. 
-        If ``num_threads`` is set to the string 'max', use all available cores. 
-        Default is 1 thread for a serial calculation that 
-        does not open a multiprocessing pool. 
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-        
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-    
+        Number of CPU cores to use in the pair counting.
+        If ``num_threads`` is set to the string 'max', use all available cores.
+        Default is 1 thread for a serial calculation that
+        does not open a multiprocessing pool.
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
-    N_pairs : array_like 
-        2-d array of length *Num_rp_bins x Num_pi_bins* storing the pair counts in each bin. 
-    
-    Examples 
+    N_pairs : array_like
+        2-d array of length *Num_rp_bins x Num_pi_bins* storing the pair counts in each bin.
+
+    Examples
     --------
-    For demonstration purposes we create randomly distributed sets of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create randomly distributed sets of points within a
+    periodic unit cube.
+
     >>> Npts1, Npts2, Lbox = 1e3, 1e3, 1000.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rp_bins = np.logspace(-1, 2, 15)
     >>> pi_bins = np.logspace(1, 2)
-    
+
     >>> x1 = np.random.uniform(0, Lbox, Npts1)
     >>> y1 = np.random.uniform(0, Lbox, Npts1)
     >>> z1 = np.random.uniform(0, Lbox, Npts1)
     >>> x2 = np.random.uniform(0, Lbox, Npts2)
     >>> y2 = np.random.uniform(0, Lbox, Npts2)
     >>> z2 = np.random.uniform(0, Lbox, Npts2)
-    
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
-    
-    >>> data1 = np.vstack([x1, y1, z1]).T 
-    >>> data2 = np.vstack([x2, y2, z2]).T 
-    
+
+    >>> data1 = np.vstack([x1, y1, z1]).T
+    >>> data2 = np.vstack([x2, y2, z2]).T
+
     >>> result = xy_z_npairs(data1, data2, rp_bins, pi_bins, period = period)
 
-    Notes 
+    Notes
     -----
-    One final point of clarification concerning double-counting may be in order. 
-    Suppose data1==data2 and rbins[0]==0. Then the returned value for this bin 
-    will be len(data1), since each data1 point has distance 0 from itself. 
+    One final point of clarification concerning double-counting may be in order.
+    Suppose data1==data2 and rbins[0]==0. Then the returned value for this bin
+    will be len(data1), since each data1 point has distance 0 from itself.
     """
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rp_bins, pi_bins, period, num_threads, PBCs = (
-        _xy_z_npairs_process_args(data1, data2, rp_bins, pi_bins, period, 
+        _xy_z_npairs_process_args(data1, data2, rp_bins, pi_bins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
-        )        
-    
-    xperiod, yperiod, zperiod = period 
+        )
+
+    xperiod, yperiod, zperiod = period
     rp_max = np.max(rp_bins)
     pi_max = np.max(pi_bins)
-    
+
     if verbose==True:
         print("running double_tree_pairs.xy_z_npairs on {0} x {1}\n"
               "points with PBCs={2}".format(len(data1), len(data2), PBCs))
@@ -610,30 +608,30 @@ def xy_z_npairs(data1, data2, rp_bins, pi_bins, period=None, verbose=False, num_
         total_volume  = period.prod()
         print("searching for pairs over {}% of the total volume\n"
               "for each point.".format(search_volume/total_volume))
-    
+
     ### Compute the estimates for the cell sizes
-    
+
     result = _set_approximate_xy_z_cell_sizes(
         approx_cell1_size, approx_cell2_size, rp_max, pi_max, period)
     approx_cell1_size = result[0]
     approx_cell2_size = result[1]
-    
+
     approx_x1cell_size, approx_y1cell_size = approx_cell1_size[:2]
     approx_z1cell_size = approx_cell1_size[2]
-    
+
     approx_x2cell_size, approx_y2cell_size = approx_cell2_size[:2]
     approx_z2cell_size = approx_cell2_size[2]
-    
+
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rp_max, rp_max, pi_max, xperiod, yperiod, zperiod, PBCs=PBCs)
 
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
-    
+
     if verbose==True:
         print("volume 1 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x1divs,\
@@ -641,20 +639,20 @@ def xy_z_npairs(data1, data2, rp_bins, pi_bins, period=None, verbose=False, num_
         print("volume 2 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x2divs,\
               double_tree.num_y2divs,double_tree.num_z2divs,Ncell1))
-    
+
     #create a function to call with only one argument
-    engine = partial(_xy_z_npairs_engine, double_tree, rp_bins, 
+    engine = partial(_xy_z_npairs_engine, double_tree, rp_bins,
         pi_bins, period, PBCs)
 
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        cell1_chunk_list = np.array_split(xrange(Ncell1), num_threads)
+        cell1_chunk_list = np.array_split(range(Ncell1), num_threads)
         result = pool.map(engine,cell1_chunk_list)
         pool.close()
         counts = np.sum(np.array(result), axis=0)
     if num_threads == 1:
-        counts = engine(xrange(Ncell1))
+        counts = engine(range(Ncell1))
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
 
@@ -665,9 +663,9 @@ def _xy_z_npairs_engine(double_tree, rp_bins, pi_bins, period, PBCs, cell1_list)
     pair counting engine for npairs function.  This code calls a cython function.
     """
     # print("...working on icell1 = %i" % icell1)
-    
+
     counts = np.zeros((len(rp_bins),len(pi_bins)))
-    
+
     for icell1 in cell1_list:
         #extract the points in the cell
         s1 = double_tree.tree1.slice_array[icell1]
@@ -675,19 +673,19 @@ def _xy_z_npairs_engine(double_tree, rp_bins, pi_bins, period, PBCs, cell1_list)
             double_tree.tree1.x[s1],
             double_tree.tree1.y[s1],
             double_tree.tree1.z[s1])
-            
+
         xsearch_length = rp_bins[-1]
         ysearch_length = rp_bins[-1]
         zsearch_length = pi_bins[-1]
         adj_cell_generator = double_tree.adjacent_cell_generator(
             icell1, xsearch_length, ysearch_length, zsearch_length)
-        
+
         for icell2, xshift, yshift, zshift in adj_cell_generator:
-                        
+
             #extract the points in the cell
             s2 = double_tree.tree2.slice_array[icell2]
             x_icell2 = double_tree.tree2.x[s2] + xshift
-            y_icell2 = double_tree.tree2.y[s2] + yshift 
+            y_icell2 = double_tree.tree2.y[s2] + yshift
             z_icell2 = double_tree.tree2.z[s2] + zshift
 
             #use cython functions to do pair counting
@@ -695,141 +693,141 @@ def _xy_z_npairs_engine(double_tree, rp_bins, pi_bins, period, PBCs, cell1_list)
                 x_icell1, y_icell1, z_icell1,
                 x_icell2, y_icell2, z_icell2,
                 rp_bins, pi_bins)
-                
+
     return counts
 
 
 def s_mu_npairs(data1, data2, s_bins, mu_bins, period = None,\
                 verbose = False, num_threads = 1,\
                 approx_cell1_size = None, approx_cell2_size = None):
-    """ 
-    Function counts the number of pairs of points separated by less than 
-    radial separation, *s,* and :math:`\\mu\\equiv\\sin(\\theta_{\\rm los})`, 
-    where :math:`\\theta_{\\rm los}` is the line-of-sight angle 
-    between points and :math:`s^2 = r_{\\rm parallel}^2 + r_{\\rm perp}^2`. 
-        
-    Note that if data1 == data2 that the 
-    `~halotools.mock_observables.s_mu_npairs` function double-counts pairs. 
-    If your science application requires data1==data2 inputs and also pairs 
-    to not be double-counted, simply divide the final counts by 2. 
+    """
+    Function counts the number of pairs of points separated by less than
+    radial separation, *s,* and :math:`\\mu\\equiv\\sin(\\theta_{\\rm los})`,
+    where :math:`\\theta_{\\rm los}` is the line-of-sight angle
+    between points and :math:`s^2 = r_{\\rm parallel}^2 + r_{\\rm perp}^2`.
 
-    A common variation of pair-counting calculations is to count pairs with 
-    separations *between* two different distances *r1* and *r2*. You can retrieve 
-    this information from the `~halotools.mock_observables.s_mu_npairs` 
-    by taking `numpy.diff` of the returned array. 
+    Note that if data1 == data2 that the
+    `~halotools.mock_observables.s_mu_npairs` function double-counts pairs.
+    If your science application requires data1==data2 inputs and also pairs
+    to not be double-counted, simply divide the final counts by 2.
 
-    See Notes section for further clarification. 
+    A common variation of pair-counting calculations is to count pairs with
+    separations *between* two different distances *r1* and *r2*. You can retrieve
+    this information from the `~halotools.mock_observables.s_mu_npairs`
+    by taking `numpy.diff` of the returned array.
+
+    See Notes section for further clarification.
 
     Parameters
     ----------
     data1 : array_like
-        N1 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N1 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     data2 : array_like
         N2 by 3 numpy array of 3-dimensional positions.
-        Values of each dimension should be between zero and the corresponding dimension 
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     s_bins : array_like
         numpy array of boundaries defining the radial bins in which pairs are counted.
-    
+
     mu_bins : array_like
-        numpy array of boundaries defining bins in :math:`\\sin(\\theta_{\\rm los})` 
-        in which the pairs are counted in.  
-        Note that using the sine is not common convention for 
+        numpy array of boundaries defining bins in :math:`\\sin(\\theta_{\\rm los})`
+        in which the pairs are counted in.
+        Note that using the sine is not common convention for
         calculating the two point correlation function (see notes).
-    
+
     period : array_like, optional
-        Length-3 array defining the periodic boundary conditions. 
-        If only one number is specified, the enclosing volume is assumed to 
-        be a periodic cube (by far the most common case). 
-        If period is set to None, the default option, 
-        PBCs are set to infinity.  
-    
+        Length-3 array defining the periodic boundary conditions.
+        If only one number is specified, the enclosing volume is assumed to
+        be a periodic cube (by far the most common case).
+        If period is set to None, the default option,
+        PBCs are set to infinity.
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
-    num_threads : int, optional
-        Number of CPU cores to use in the pair counting. 
-        If ``num_threads`` is set to the string 'max', use all available cores. 
-        Default is 1 thread for a serial calculation that 
-        does not open a multiprocessing pool. 
 
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will result in reasonable performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with it when carrying out  
-        performance-critical calculations. 
-    
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-    
+    num_threads : int, optional
+        Number of CPU cores to use in the pair counting.
+        If ``num_threads`` is set to the string 'max', use all available cores.
+        Default is 1 thread for a serial calculation that
+        does not open a multiprocessing pool.
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will result in reasonable performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with it when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
     num_pairs : array of length len(rbins)
         number of pairs
-    
+
     Notes
     ------
-    The quantity :math:`\\mu` is defined as the :math:`\\sin(\\theta_{\\rm los})` 
-    and not the conventional :math:`\\cos(\\theta_{\\rm los})`. This is 
-    because the pair counter has been optimized under the assumption that its 
-    separation variable (in this case, :math:`\\mu`) *increases* 
-    as :math:`\\theta_{\\rm los})` increases. 
+    The quantity :math:`\\mu` is defined as the :math:`\\sin(\\theta_{\\rm los})`
+    and not the conventional :math:`\\cos(\\theta_{\\rm los})`. This is
+    because the pair counter has been optimized under the assumption that its
+    separation variable (in this case, :math:`\\mu`) *increases*
+    as :math:`\\theta_{\\rm los})` increases.
 
-    One final point of clarification concerning double-counting may be in order. 
-    Suppose data1==data2 and rbins[0]==0. Then the returned value for this bin 
-    will be len(data1), since each data1 point has distance 0 from itself. 
-    
+    One final point of clarification concerning double-counting may be in order.
+    Suppose data1==data2 and rbins[0]==0. Then the returned value for this bin
+    will be len(data1), since each data1 point has distance 0 from itself.
+
     Returns
     -------
-    N_pairs : array_like 
-        2-d array of length *Num_rp_bins x Num_pi_bins* storing the pair counts in each bin. 
-    
-    Examples 
+    N_pairs : array_like
+        2-d array of length *Num_rp_bins x Num_pi_bins* storing the pair counts in each bin.
+
+    Examples
     --------
-    For demonstration purposes we create randomly distributed sets of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create randomly distributed sets of points within a
+    periodic unit cube.
+
     >>> Npts1, Npts2, Lbox = 1e3, 1e3, 200.
     >>> period = [Lbox, Lbox, Lbox]
     >>> s_bins = np.logspace(-1, 1.25, 15)
     >>> mu_bins = np.linspace(-0.5, 0.5)
-    
+
     >>> x1 = np.random.uniform(0, Lbox, Npts1)
     >>> y1 = np.random.uniform(0, Lbox, Npts1)
     >>> z1 = np.random.uniform(0, Lbox, Npts1)
     >>> x2 = np.random.uniform(0, Lbox, Npts2)
     >>> y2 = np.random.uniform(0, Lbox, Npts2)
     >>> z2 = np.random.uniform(0, Lbox, Npts2)
-    
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
-    
-    >>> data1 = np.vstack([x1, y1, z1]).T 
-    >>> data2 = np.vstack([x2, y2, z2]).T 
-    
+
+    >>> data1 = np.vstack([x1, y1, z1]).T
+    >>> data2 = np.vstack([x2, y2, z2]).T
+
     >>> result = s_mu_npairs(data1, data2, s_bins, mu_bins, period = period)
     """
-    
+
     #the parameters for this are similar to npairs, except mu_bins needs to be processed.
     # Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rbins, period, num_threads, PBCs = (
-        _npairs_process_args(data1, data2, s_bins, period, 
+        _npairs_process_args(data1, data2, s_bins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
-        )        
-    
-    xperiod, yperiod, zperiod = period 
+        )
+
+    xperiod, yperiod, zperiod = period
     rmax = np.max(s_bins)
-    
+
     #process mu_bins parameter separately
     mu_bins = convert_to_ndarray(mu_bins)
     try:
@@ -841,7 +839,7 @@ def s_mu_npairs(data1, data2, s_bins, mu_bins, period = None,\
         msg = ("\n Input `mu_bins` must be a monotonically increasing \n"
                "1D array with at least two entries")
         raise HalotoolsError(msg)
-    
+
     ### Compute the estimates for the cell sizes
     approx_cell1_size, approx_cell2_size = (
         _set_approximate_cell_sizes(approx_cell1_size, approx_cell2_size, rmax, period)
@@ -850,27 +848,27 @@ def s_mu_npairs(data1, data2, s_bins, mu_bins, period = None,\
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
 
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rmax, rmax, rmax, xperiod, yperiod, zperiod, PBCs=PBCs)
-    
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
 
     #create a function to call with only one argument
     engine = partial(_s_mu_npairs_engine, double_tree, s_bins, mu_bins, period, PBCs)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        cell1_chunk_list = np.array_split(xrange(Ncell1), num_threads)
+        cell1_chunk_list = np.array_split(range(Ncell1), num_threads)
         result = pool.map(engine,cell1_chunk_list)
         pool.close()
         counts = np.sum(np.array(result), axis=0)
     if num_threads == 1:
-        counts = engine(xrange(Ncell1))
+        counts = engine(range(Ncell1))
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
 
@@ -881,9 +879,9 @@ def _s_mu_npairs_engine(double_tree, s_bins, mu_bins, period, PBCs, cell1_list):
     pair counting engine for s_mu_npairs function.  This code calls a cython function.
     """
     # print("...working on icell1 = %i" % icell1)
-    
+
     counts = np.zeros((len(s_bins), len(mu_bins)))
-    
+
     for icell1 in cell1_list:
         #extract the points in the cell
         s1 = double_tree.tree1.slice_array[icell1]
@@ -891,28 +889,28 @@ def _s_mu_npairs_engine(double_tree, s_bins, mu_bins, period, PBCs, cell1_list):
             double_tree.tree1.x[s1],
             double_tree.tree1.y[s1],
             double_tree.tree1.z[s1])
-            
+
         xsearch_length = s_bins[-1]
         ysearch_length = s_bins[-1]
         zsearch_length = s_bins[-1]
         adj_cell_generator = double_tree.adjacent_cell_generator(
             icell1, xsearch_length, ysearch_length, zsearch_length)
-                
+
         for icell2, xshift, yshift, zshift in adj_cell_generator:
-                    
+
             #extract the points in the cell
             s2 = double_tree.tree2.slice_array[icell2]
             x_icell2 = double_tree.tree2.x[s2] + xshift
-            y_icell2 = double_tree.tree2.y[s2] + yshift 
+            y_icell2 = double_tree.tree2.y[s2] + yshift
             z_icell2 = double_tree.tree2.z[s2] + zshift
-            
-            
+
+
             #use cython functions to do pair counting
             counts += s_mu_npairs_no_pbc(
                 x_icell1, y_icell1, z_icell1,
                 x_icell2, y_icell2, z_icell2,
                 s_bins, mu_bins)
-                
+
     return counts
 
 

--- a/halotools/mock_observables/pair_counters/double_tree_per_object_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_per_object_pairs.py
@@ -156,11 +156,11 @@ def per_object_npairs(data1, data2, rbins, period = None,\
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         pool.close()
         counts = np.vstack(result)
     if num_threads == 1:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
         counts = np.vstack(result)
     
     if verbose==True:

--- a/halotools/mock_observables/pair_counters/double_tree_per_object_pairs.py
+++ b/halotools/mock_observables/pair_counters/double_tree_per_object_pairs.py
@@ -7,85 +7,82 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
-from copy import copy 
 
 import time
-import sys
 import multiprocessing
-from multiprocessing import Value, Lock
 from functools import partial
 from .double_tree import FlatRectanguloidDoubleTree
 from .double_tree_helpers import *
 from .cpairs import *
 from ...custom_exceptions import *
-from ...utils.array_utils import convert_to_ndarray, array_is_monotonic
 
 __all__ = ['per_object_npairs']
 __author__ = ['Duncan Campbell', 'Andrew Hearin']
 
 ##########################################################################
 
-def per_object_npairs(data1, data2, rbins, period = None,\
-                     verbose = False, num_threads = 1,\
-                     approx_cell1_size = None, approx_cell2_size = None):
-    """    
-    Function counts the number of times the pair count between two samples exceeds a 
+
+def per_object_npairs(data1, data2, rbins, period=None,
+                      verbose=False, num_threads=1,
+                      approx_cell1_size=None, approx_cell2_size=None):
+    """
+    Function counts the number of times the pair count between two samples exceeds a
     threshold value as a function of the 3d spatial separation *r*.
-    
+
     Parameters
     ----------
     data1 : array_like
-        N1 by 3 numpy array of 3-dimensional positions. 
-        Values of each dimension should be between zero and the corresponding dimension 
+        N1 by 3 numpy array of 3-dimensional positions.
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     data2 : array_like
         N2 by 3 numpy array of 3-dimensional positions.
-        Values of each dimension should be between zero and the corresponding dimension 
+        Values of each dimension should be between zero and the corresponding dimension
         of the input period.
-            
+
     rbins : array_like
         Boundaries defining the bins in which pairs are counted.
-    
+
     n_thresh : int, optional
         positive integer number indicating the threshold pair count
-    
+
     period : array_like, optional
-        Length-3 array defining the periodic boundary conditions. 
-        If only one number is specified, the enclosing volume is assumed to 
-        be a periodic cube (by far the most common case). 
-        If period is set to None, the default option, 
-        PBCs are set to infinity.  
+        Length-3 array defining the periodic boundary conditions.
+        If only one number is specified, the enclosing volume is assumed to
+        be a periodic cube (by far the most common case).
+        If period is set to None, the default option,
+        PBCs are set to infinity.
 
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        Number of CPU cores to use in the pair counting. 
-        If ``num_threads`` is set to the string 'max', use all available cores. 
-        Default is 1 thread for a serial calculation that 
-        does not open a multiprocessing pool. 
+        Number of CPU cores to use in the pair counting.
+        If ``num_threads`` is set to the string 'max', use all available cores.
+        Default is 1 thread for a serial calculation that
+        does not open a multiprocessing pool.
 
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
 
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-    
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
-    num_pairs : array_like 
-        Numpy array of length len(rbins) storing the numbers of pairs in the input bins. 
+    num_pairs : array_like
+        Numpy array of length len(rbins) storing the numbers of pairs in the input bins.
 
-    Examples 
+    Examples
     --------
     For illustration purposes, we'll create some fake data and call the pair counter:
 
@@ -100,30 +97,30 @@ def per_object_npairs(data1, data2, rbins, period = None,\
     >>> y2 = np.random.uniform(0, Lbox, Npts2)
     >>> z2 = np.random.uniform(0, Lbox, Npts2)
 
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
 
-    >>> data1 = np.vstack([x1, y1, z1]).T 
-    >>> data2 = np.vstack([x2, y2, z2]).T 
+    >>> data1 = np.vstack([x1, y1, z1]).T
+    >>> data2 = np.vstack([x2, y2, z2]).T
 
     >>> result = per_object_npairs(data1, data2, rbins, period = period)
     """
 
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rbins, period, num_threads, PBCs = (
-        _npairs_process_args(data1, data2, rbins, period, 
+        _npairs_process_args(data1, data2, rbins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
         )
-    
-    xperiod, yperiod, zperiod = period 
+
+    xperiod, yperiod, zperiod = period
     rmax = np.max(rbins)
-    
+
     if verbose==True:
         print("running double_tree_pairs.xy_z_npairs on {0} x {1}\n"
               "points with PBCs={2}".format(len(data1), len(data2), PBCs))
         start = time.time()
-    
+
     ### Compute the estimates for the cell sizes
     approx_cell1_size, approx_cell2_size = (
         _set_approximate_cell_sizes(approx_cell1_size, approx_cell2_size, rmax, period)
@@ -132,15 +129,15 @@ def per_object_npairs(data1, data2, rbins, period = None,\
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
 
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rmax, rmax, rmax, xperiod, yperiod, zperiod, PBCs=PBCs)
 
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
-    
+
     if verbose==True:
         print("volume 1 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x1divs,\
@@ -148,11 +145,11 @@ def per_object_npairs(data1, data2, rbins, period = None,\
         print("volume 2 split {0},{1},{2} times along each dimension,\n"
               "resulting in {3} cells.".format(double_tree.num_x2divs,\
               double_tree.num_y2divs,double_tree.num_z2divs,Ncell2))
-    
+
     #create a function to call with only one argument
-    engine = partial(_per_object_npairs_engine, 
+    engine = partial(_per_object_npairs_engine,
         double_tree, rbins, period, PBCs)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
@@ -162,10 +159,10 @@ def per_object_npairs(data1, data2, rbins, period = None,\
     if num_threads == 1:
         result = list(map(engine,list(range(Ncell1))))
         counts = np.vstack(result)
-    
+
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
-    
+
     return counts
 
 
@@ -175,36 +172,36 @@ def _per_object_npairs_engine(double_tree, rbins, period, PBCs, icell1):
     This code calls a cython function.
     """
     # print("...working on icell1 = %i" % icell1)
-    
+
     #extract the points in the cell
     s1 = double_tree.tree1.slice_array[icell1]
     x_icell1, y_icell1, z_icell1 = (
         double_tree.tree1.x[s1],
         double_tree.tree1.y[s1],
         double_tree.tree1.z[s1])
-    
+
     counts = np.zeros((len(x_icell1), len(rbins)))
-        
+
     xsearch_length = rbins[-1]
     ysearch_length = rbins[-1]
     zsearch_length = rbins[-1]
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
-            
+
     adj_cell_counter = 0
     for icell2, xshift, yshift, zshift in adj_cell_generator:
-                
+
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
         x_icell2 = double_tree.tree2.x[s2] + xshift
-        y_icell2 = double_tree.tree2.y[s2] + yshift 
+        y_icell2 = double_tree.tree2.y[s2] + yshift
         z_icell2 = double_tree.tree2.z[s2] + zshift
-        
-        
+
+
         #use cython functions to do pair counting
         counts += per_object_npairs_no_pbc(
             x_icell1, y_icell1, z_icell1,
             x_icell2, y_icell2, z_icell2,
             rbins)
-    
+
     return counts

--- a/halotools/mock_observables/pair_counters/marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/marked_double_tree_pairs.py
@@ -10,109 +10,111 @@ for effecient pair coutning.
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
-import sys
 import multiprocessing
 from functools import partial
+
+from astropy.extern.six import xrange as range
+
 from .double_tree import FlatRectanguloidDoubleTree
 from .double_tree_helpers import *
 from .marked_double_tree_helpers import *
 from .marked_cpairs import *
 from ...custom_exceptions import *
-from ...utils.array_utils import convert_to_ndarray, array_is_monotonic
+from ...utils.array_utils import array_is_monotonic
 
-__all__ = ['marked_npairs',\
-           'xy_z_marked_npairs',\
-           'velocity_marked_npairs',\
+__all__ = ['marked_npairs',
+           'xy_z_marked_npairs',
+           'velocity_marked_npairs',
            'xy_z_velocity_marked_npairs']
 __author__ = ['Duncan Campbell', 'Andrew Hearin']
 
 
 def marked_npairs(data1, data2, rbins,
-                  period=None, weights1 = None, weights2 = None, 
+                  period=None, weights1 = None, weights2 = None,
                   wfunc = 0, verbose = False, num_threads = 1,
                   approx_cell1_size = None, approx_cell2_size = None):
     """
     Calculate the number of weighted pairs with seperations greater than or equal to r, :math:`W(>r)`.
-    
-    The weight given to each pair is determined by the weights for a pair, 
-    :math:`w_1`, :math:`w_2`, and a user-specified "weighting function", indicated 
+
+    The weight given to each pair is determined by the weights for a pair,
+    :math:`w_1`, :math:`w_2`, and a user-specified "weighting function", indicated
     by the ``wfunc`` parameter, :math:`f(w_1,w_2)`.
 
-    Note that if data1 == data2 that the `marked_npairs` function double-counts pairs. 
-    
+    Note that if data1 == data2 that the `marked_npairs` function double-counts pairs.
+
     Parameters
     ----------
     data1 : array_like
         *N1* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     data2 : array_like
         *N2* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     rbins : array_like
-        numpy array of length *Nrbins+1* defining the boundaries of bins in which 
-        pairs are counted. 
-    
+        numpy array of length *Nrbins+1* defining the boundaries of bins in which
+        pairs are counted.
+
     period : array_like, optional
-        Length-3 array defining axis-aligned periodic boundary conditions. If only 
+        Length-3 array defining axis-aligned periodic boundary conditions. If only
         one number, Lbox, is specified, the period is assumed to be np.array([Lbox]*3).
-    
+
     weights1 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-    
+
     weights2 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-        
+
     wfunc : int, optional
-        weighting function integer ID. Each weighting function requires a specific 
+        weighting function integer ID. Each weighting function requires a specific
         number of weights per point, *N_weights*.  See the Notes for a description of
         available weighting functions.
-    
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        number of 'threads' to use in the pair counting.  if set to 'max', use all
         available cores.  num_threads=0 is the default.
-    
+
     approx_cell1_size : array_like, optional
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-        
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
     approx_cell2_size : array_like, optional
         See comments for ``approx_cell1_size``.
-        
+
     Returns
     -------
     wN_pairs : numpy.array
         array of length *Nrbins* containing the weighted number counts of pairs
     """
-    
+
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rbins, period, num_threads, PBCs = (
-        _npairs_process_args(data1, data2, rbins, period, 
+        _npairs_process_args(data1, data2, rbins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
         )
-    xperiod, yperiod, zperiod = period 
+    xperiod, yperiod, zperiod = period
     rmax = np.max(rbins)
 
     # Process the input weights and with the helper function
     weights1, weights2 = (
-        _marked_npairs_process_weights(data1, data2, 
+        _marked_npairs_process_weights(data1, data2,
             weights1, weights2, wfunc))
 
     ### Compute the estimates for the cell sizes
@@ -123,49 +125,49 @@ def marked_npairs(data1, data2, rbins,
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
 
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rmax, rmax, rmax, xperiod, yperiod, zperiod, PBCs=PBCs)
 
     #sort the weights arrays
     weights1 = np.ascontiguousarray(weights1[double_tree.tree1.idx_sorted, :])
     weights2 = np.ascontiguousarray(weights2[double_tree.tree2.idx_sorted, :])
-    
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
 
     #create a function to call with only one argument
-    engine = partial(_marked_npairs_engine, double_tree, 
+    engine = partial(_marked_npairs_engine, double_tree,
         weights1, weights2, rbins, period, PBCs, wfunc)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        cell1_chunk_list = np.array_split(xrange(Ncell1), num_threads)
+        cell1_chunk_list = np.array_split(range(Ncell1), num_threads)
         result = pool.map(engine,cell1_chunk_list)
         pool.close()
         counts = np.sum(np.array(result), axis=0)
     if num_threads == 1:
-        counts = engine(xrange(Ncell1))
+        counts = engine(range(Ncell1))
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
 
     return counts
 
 
-def _marked_npairs_engine(double_tree, weights1, weights2, 
+def _marked_npairs_engine(double_tree, weights1, weights2,
                     rbins, period, PBCs, wfunc, cell1_list):
     """
-    private internal function for 
+    private internal function for
     `~halotools.mock_observables.pair_counters.marked_double_tree_pairs.marked_npairs`.
-    
+
     This is an engine that calls a cython module to count pairs
     """
-    
+
     counts = np.zeros(len(rbins))
-    
+
     for icell1 in cell1_list:
         #extract the points in the cell
         s1 = double_tree.tree1.slice_array[icell1]
@@ -182,175 +184,175 @@ def _marked_npairs_engine(double_tree, weights1, weights2,
         zsearch_length = rbins[-1]
         adj_cell_generator = double_tree.adjacent_cell_generator(
             icell1, xsearch_length, ysearch_length, zsearch_length)
-                
+
         for icell2, xshift, yshift, zshift in adj_cell_generator:
-            
+
             #set shift array as -1,1,0 depending on direction of/if cell shifted.
             shift = np.array([xshift,yshift,zshift]).astype(float)
-            
+
             #extract the points in the cell
             s2 = double_tree.tree2.slice_array[icell2]
             x_icell2 = double_tree.tree2.x[s2] + xshift
-            y_icell2 = double_tree.tree2.y[s2] + yshift 
+            y_icell2 = double_tree.tree2.y[s2] + yshift
             z_icell2 = double_tree.tree2.z[s2] + zshift
 
             #extract the weights in the cell
             w_icell2 = weights2[s2, :]
-                
+
             #use cython functions to do pair counting
             counts += marked_npairs_no_pbc(x_icell1, y_icell1, z_icell1,
                                            x_icell2, y_icell2, z_icell2,
-                                           w_icell1, w_icell2, 
+                                           w_icell1, w_icell2,
                                            rbins, wfunc, shift)
-                
+
     return counts
 
 
-def xy_z_marked_npairs(data1, data2, rp_bins, pi_bins, period=None, 
-                       weights1 = None, weights2 = None, 
+def xy_z_marked_npairs(data1, data2, rp_bins, pi_bins, period=None,
+                       weights1 = None, weights2 = None,
                        wfunc = 0, verbose = False, num_threads = 1,
                        approx_cell1_size = None, approx_cell2_size = None):
     """
     Calculate the number of weighted pairs with seperations greater than or equal to :math:`r_{\\perp}` and :math:`r_{\\parallel}`, :math:`W(>r_{\\perp},>r_{\\parallel})`.
-    
+
     :math:`r_{\\perp}` and :math:`r_{\\parallel}` are defined wrt the z-direction.
-    
-    The weight given to each pair is determined by the weights for a pair, 
-    :math:`w_1`, :math:`w_2`, and a user-specified "weighting function", indicated 
+
+    The weight given to each pair is determined by the weights for a pair,
+    :math:`w_1`, :math:`w_2`, and a user-specified "weighting function", indicated
     by the ``wfunc`` parameter, :math:`f(w_1,w_2)`.
-    
+
     Parameters
     ----------
     data1 : array_like
         *N1* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     data2 : array_like
         *N2* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-            
+
     rp_bins : array_like
-        numpy array of length Nrp_bins+1 defining the boundaries of bins of projected 
+        numpy array of length Nrp_bins+1 defining the boundaries of bins of projected
         separation, :math:`r_{\\rm p}`, in which pairs are counted.
-    
+
     pi_bins : array_like
         numpy array of length Npi_bins+1 defining the boundaries of bins of parallel
         separation, :math:`\\pi`, in which pairs are counted.
-    
+
     period : array_like, optional
-        Length-3 array defining axis-aligned periodic boundary conditions. If only 
+        Length-3 array defining axis-aligned periodic boundary conditions. If only
         one number, Lbox, is specified, the period is assumed to be np.array([Lbox]*3).
-    
+
     weights1 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-    
+
     weights2 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-        
+
     wfunc : int, optional
-        weighting function integer ID. Each weighting function requires a specific 
+        weighting function integer ID. Each weighting function requires a specific
         number of weights per point, *N_weights*.  See the Notes for a description of
         available weighting functions.
-    
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        number of 'threads' to use in the pair counting.  if set to 'max', use all
         available cores.  num_threads=0 is the default.
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-        
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-        
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
     wN_pairs : numpy.ndarray
-        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number 
+        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number
         counts of pairs
     """
-    
+
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rp_bins, pi_bins, period, num_threads, PBCs = (
-        _xy_z_npairs_process_args(data1, data2, rp_bins, pi_bins, period, 
+        _xy_z_npairs_process_args(data1, data2, rp_bins, pi_bins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
         )
-    xperiod, yperiod, zperiod = period 
+    xperiod, yperiod, zperiod = period
     rp_max = np.max(rp_bins)
     pi_max = np.max(pi_bins)
-    
+
     # Process the input weights and with the helper function
     weights1, weights2 = (
-        _marked_npairs_process_weights(data1, data2, 
+        _marked_npairs_process_weights(data1, data2,
             weights1, weights2, wfunc))
-    
+
     ### Compute the estimates for the cell sizes
     approx_cell1_size, approx_cell2_size = _set_approximate_xy_z_cell_sizes(
         approx_cell1_size, approx_cell2_size, rp_max, pi_max, period)
-    
+
     approx_x1cell_size, approx_y1cell_size, approx_z1cell_size = approx_cell1_size
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
-    
+
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rp_max, rp_max, pi_max, xperiod, yperiod, zperiod, PBCs=PBCs)
-    
+
     #sort the weights arrays
     weights1 = np.ascontiguousarray(weights1[double_tree.tree1.idx_sorted, :])
     weights2 = np.ascontiguousarray(weights2[double_tree.tree2.idx_sorted, :])
-    
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
-    
+
     #create a function to call with only one argument
-    engine = partial(_xy_z_marked_npairs_engine, double_tree, 
+    engine = partial(_xy_z_marked_npairs_engine, double_tree,
         weights1, weights2, rp_bins, pi_bins, period, PBCs, wfunc)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        cell1_chunk_list = np.array_split(xrange(Ncell1), num_threads)
+        cell1_chunk_list = np.array_split(range(Ncell1), num_threads)
         result = pool.map(engine,cell1_chunk_list)
         pool.close()
         counts = np.sum(np.array(result), axis=0)
     if num_threads == 1:
-        counts = engine(xrange(Ncell1))
+        counts = engine(range(Ncell1))
     if verbose==True:
         print("total run time: {0} seconds".format(time.time()-start))
 
     return counts
 
 
-def _xy_z_marked_npairs_engine(double_tree, weights1, weights2, 
+def _xy_z_marked_npairs_engine(double_tree, weights1, weights2,
                                rp_bins, pi_bins, period, PBCs, wfunc, cell1_list):
     """
-    private internal function for 
+    private internal function for
     `~halotools.mock_observables.pair_counters.marked_double_tree_pairs.xy_z_marked_npairs`.
-    
+
     This is an engine that calls a cython module to count pairs
     """
-    
+
     counts = np.zeros((len(rp_bins),len(pi_bins)))
-    
+
     for icell1 in cell1_list:
         #extract the points in the cell
         s1 = double_tree.tree1.slice_array[icell1]
@@ -358,135 +360,135 @@ def _xy_z_marked_npairs_engine(double_tree, weights1, weights2,
             double_tree.tree1.x[s1],
             double_tree.tree1.y[s1],
             double_tree.tree1.z[s1])
-        
+
         #extract the weights in the cell
         w_icell1 = weights1[s1, :]
-        
+
         xsearch_length = rp_bins[-1]
         ysearch_length = rp_bins[-1]
         zsearch_length = pi_bins[-1]
         adj_cell_generator = double_tree.adjacent_cell_generator(
             icell1, xsearch_length, ysearch_length, zsearch_length)
-                
+
         for icell2, xshift, yshift, zshift in adj_cell_generator:
-            
+
             #set shift array as -1,1,0 depending on direction of/if cell shifted.
             shift = np.array([xshift,yshift,zshift]).astype(float)
-            
+
             #extract the points in the cell
             s2 = double_tree.tree2.slice_array[icell2]
             x_icell2 = double_tree.tree2.x[s2] + xshift
-            y_icell2 = double_tree.tree2.y[s2] + yshift 
+            y_icell2 = double_tree.tree2.y[s2] + yshift
             z_icell2 = double_tree.tree2.z[s2] + zshift
-            
+
             #extract the weights in the cell
             w_icell2 = weights2[s2, :]
-            
+
             #use cython functions to do pair counting
             counts += xy_z_marked_npairs_no_pbc(x_icell1, y_icell1, z_icell1,
                                                 x_icell2, y_icell2, z_icell2,
-                                                w_icell1, w_icell2, 
+                                                w_icell1, w_icell2,
                                                 rp_bins, pi_bins, wfunc, shift)
-                
+
     return counts
 
 
-def velocity_marked_npairs(data1, data2, rbins, period=None, 
-    weights1 = None, weights2 = None, 
+def velocity_marked_npairs(data1, data2, rbins, period=None,
+    weights1 = None, weights2 = None,
     wfunc = 0, verbose = False, num_threads = 1,
     approx_cell1_size = None, approx_cell2_size = None):
     """
     Calculate the number of velocity weighted pairs with seperations greater than or equal to r, :math:`W(>r)`.
-    
-    The weight given to each pair is determined by the weights for a pair, 
-    :math:`w_1`, :math:`w_2`, and a user-specified "velocity weighting function", indicated 
+
+    The weight given to each pair is determined by the weights for a pair,
+    :math:`w_1`, :math:`w_2`, and a user-specified "velocity weighting function", indicated
     by the ``wfunc`` parameter, :math:`f(w_1,w_2)`.
-    
+
     Parameters
     ----------
     data1 : array_like
         *N1* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     data2 : array_like
         *N2* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     rbins : array_like
-        numpy array of length Nrbins+1 defining the boundaries of bins in which 
-        pairs are counted. 
-    
+        numpy array of length Nrbins+1 defining the boundaries of bins in which
+        pairs are counted.
+
     period : array_like, optional
-        Length-3 array defining axis-aligned periodic boundary conditions. If only 
+        Length-3 array defining axis-aligned periodic boundary conditions. If only
         one number, Lbox, is specified, the period is assumed to be np.array([Lbox]*3).
-    
+
     weights1 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-    
+
     weights2 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-    
+
     wfunc : int, optional
-        velocity weighting function integer ID. Each weighting function requires a specific 
+        velocity weighting function integer ID. Each weighting function requires a specific
         number of weights per point, *N_weights*.  See the Notes for a description of
         available weighting functions.
-    
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        number of 'threads' to use in the pair counting.  if set to 'max', use all
         available cores.  num_threads=0 is the default.
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-    
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-        
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
     w1N_pairs : numpy.array
         array of length *Nrbins* containing the weighted number counts of pairs
-        The exact values depend on ``weight_func_id`` 
+        The exact values depend on ``weight_func_id``
         (which weighting function was chosen).
-    
+
     w2N_pairs : numpy.array
         array of length *Nrbins* containing the weighted number counts of pairs
-        The exact values depend on ``weight_func_id`` 
+        The exact values depend on ``weight_func_id``
         (which weighting function was chosen).
-    
+
     w3N_pairs : numpy.array
         array of length *Nrbins* containing the weighted number counts of pairs
-        The exact values depend on ``weight_func_id`` 
+        The exact values depend on ``weight_func_id``
         (which weighting function was chosen).
     """
-    
+
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rbins, period, num_threads, PBCs = (
-        _npairs_process_args(data1, data2, rbins, period, 
+        _npairs_process_args(data1, data2, rbins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
         )
-    xperiod, yperiod, zperiod = period 
+    xperiod, yperiod, zperiod = period
     rmax = np.max(rbins)
 
     # Process the input weights and with the helper function
     weights1, weights2 = (
-        _velocity_marked_npairs_process_weights(data1, data2, 
+        _velocity_marked_npairs_process_weights(data1, data2,
             weights1, weights2, wfunc))
 
     ### Compute the estimates for the cell sizes
@@ -497,27 +499,27 @@ def velocity_marked_npairs(data1, data2, rbins, period=None,
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
 
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rmax, rmax, rmax, xperiod, yperiod, zperiod, PBCs=PBCs)
 
     #sort the weights arrays
     weights1 = np.ascontiguousarray(weights1[double_tree.tree1.idx_sorted, :])
     weights2 = np.ascontiguousarray(weights2[double_tree.tree2.idx_sorted, :])
-    
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
 
     #create a function to call with only one argument
-    engine = partial(_velocity_marked_npairs_engine, double_tree, 
+    engine = partial(_velocity_marked_npairs_engine, double_tree,
         weights1, weights2, rbins, period, PBCs, wfunc)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         result = np.array(result)
         counts1, counts2, counts3 = (result[:,0],result[:,1],result[:,2])
         counts1 = np.sum(counts1,axis=0)
@@ -525,29 +527,29 @@ def velocity_marked_npairs(data1, data2, rbins, period=None,
         counts3 = np.sum(counts3,axis=0)
         pool.close()
     else:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
         result = np.array(result)
         counts1, counts2, counts3= (result[:,0],result[:,1],result[:,2])
         counts1 = np.sum(counts1,axis=0)
         counts2 = np.sum(counts2,axis=0)
         counts3 = np.sum(counts3,axis=0)
-    
+
     return counts1, counts2, counts3
 
 
-def _velocity_marked_npairs_engine(double_tree, weights1, weights2, 
+def _velocity_marked_npairs_engine(double_tree, weights1, weights2,
                              rbins, period, PBCs, wfunc, icell1):
     """
-    private internal function for 
+    private internal function for
     `~halotools.mock_observables.pair_counters.marked_double_tree_pairs.velocity_marked_npairs`.
-    
+
     This is an engine that calls a cython module to count pairs
     """
-    
+
     counts1 = np.zeros(len(rbins))
     counts2 = np.zeros(len(rbins))
     counts3 = np.zeros(len(rbins))
-    
+
     #extract the points in the cell
     s1 = double_tree.tree1.slice_array[icell1]
     x_icell1, y_icell1, z_icell1 = (
@@ -563,167 +565,167 @@ def _velocity_marked_npairs_engine(double_tree, weights1, weights2,
     zsearch_length = rbins[-1]
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
-            
+
     for icell2, xshift, yshift, zshift in adj_cell_generator:
-        
+
         #set shift array as -1,1,0 depending on direction of/if cell shifted.
         shift = np.array([xshift,yshift,zshift]).astype(float)
-        
+
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
         x_icell2 = double_tree.tree2.x[s2] + xshift
-        y_icell2 = double_tree.tree2.y[s2] + yshift 
+        y_icell2 = double_tree.tree2.y[s2] + yshift
         z_icell2 = double_tree.tree2.z[s2] + zshift
 
         #extract the weights in the cell
         w_icell2 = weights2[s2, :]
-            
+
         #use cython functions to do pair counting
         holder1, holder2, holder3 = velocity_marked_npairs_no_pbc(
                                        x_icell1, y_icell1, z_icell1,
                                        x_icell2, y_icell2, z_icell2,
-                                       w_icell1, w_icell2, 
+                                       w_icell1, w_icell2,
                                        rbins, wfunc, shift)
-        counts1 += holder1 
+        counts1 += holder1
         counts2 += holder2
         counts3 += holder3
-            
-    return counts1, counts2, counts3 
+
+    return counts1, counts2, counts3
 
 
-def xy_z_velocity_marked_npairs(data1, data2, rp_bins, pi_bins, period=None, 
-    weights1 = None, weights2 = None, 
+def xy_z_velocity_marked_npairs(data1, data2, rp_bins, pi_bins, period=None,
+    weights1 = None, weights2 = None,
     wfunc = 0, verbose = False, num_threads = 1,
     approx_cell1_size = None, approx_cell2_size = None):
     """
     Calculate the number of velocity weighted pairs with seperations greater than or equal to :math:`r_{\\perp}` and :math:`r_{\\parallel}`, :math:`W(>r_{\\perp},>r_{\\parallel})`.
-    
+
     :math:`r_{\\perp}` and :math:`r_{\\parallel}` are defined wrt the z-direction.
-    
-    The weight given to each pair is determined by the weights for a pair, 
-    :math:`w_1`, :math:`w_2`, and a user-specified "velocity weighting function", indicated 
+
+    The weight given to each pair is determined by the weights for a pair,
+    :math:`w_1`, :math:`w_2`, and a user-specified "velocity weighting function", indicated
     by the ``wfunc`` parameter, :math:`f(w_1,w_2)`.
-    
+
     Parameters
     ----------
     data1 : array_like
         *N1* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     data2 : array_like
         *N2* by 3 array of 3-D positions.  If the ``period`` parameter is set, each
         component of the coordinates should be bounded between zero and the corresponding
         periodic boundary.
-    
+
     rp_bins : array_like
-        numpy array of length Nrp_bins+1 defining the boundaries of bins of projected 
+        numpy array of length Nrp_bins+1 defining the boundaries of bins of projected
         separation, :math:`r_{\\rm p}`, in which pairs are counted.
-    
+
     pi_bins : array_like
         numpy array of length Npi_bins+1 defining the boundaries of bins of parallel
         separation, :math:`\\pi`, in which pairs are counted.
-    
+
     period : array_like, optional
-        Length-3 array defining axis-aligned periodic boundary conditions. If only 
+        Length-3 array defining axis-aligned periodic boundary conditions. If only
         one number, Lbox, is specified, the period is assumed to be np.array([Lbox]*3).
-    
+
     weights1 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-    
+
     weights2 : array_like, optional
-        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*, 
+        Either a 1-D array of length *N1*, or a 2-D array of length *N1* x *N_weights*,
         containing the weights used for the weighted pair counts. If this parameter is
         None, the weights are set to np.ones(*(N1,N_weights)*).
-    
+
     wfunc : int, optional
-        velocity weighting function integer ID. Each weighting function requires a specific 
+        velocity weighting function integer ID. Each weighting function requires a specific
         number of weights per point, *N_weights*.  See the Notes for a description of
         available weighting functions.
-    
+
     verbose : Boolean, optional
         If True, print out information and progress.
-    
+
     num_threads : int, optional
-        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        number of 'threads' to use in the pair counting.  if set to 'max', use all
         available cores.  num_threads=0 is the default.
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``data`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use 1/10 of the box size in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-        
-    approx_cell2_size : array_like, optional 
-        See comments for ``approx_cell1_size``. 
-        
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``data`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use 1/10 of the box size in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        See comments for ``approx_cell1_size``.
+
     Returns
     -------
     w1N_pairs : numpy.array
-        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number counts 
-        of pairs. The exact values depend on ``weight_func_id`` 
+        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number counts
+        of pairs. The exact values depend on ``weight_func_id``
         (which weighting function was chosen).
-    
+
     w2N_pairs : numpy.array
-        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number counts 
-        of pairs. The exact values depend on ``weight_func_id`` 
+        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number counts
+        of pairs. The exact values depend on ``weight_func_id``
         (which weighting function was chosen).
-    
+
     w3N_pairs : numpy.array
-        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number counts 
-        of pairs. The exact values depend on ``weight_func_id`` 
+        2-D array of shape *(Nrp_bins,Npi_bins)* containing the weighted number counts
+        of pairs. The exact values depend on ``weight_func_id``
         (which weighting function was chosen).
     """
-    
+
     ### Process the inputs with the helper function
     x1, y1, z1, x2, y2, z2, rp_bins, pi_bins, period, num_threads, PBCs = (
-        _xy_z_npairs_process_args(data1, data2, rp_bins, pi_bins, period, 
+        _xy_z_npairs_process_args(data1, data2, rp_bins, pi_bins, period,
             verbose, num_threads, approx_cell1_size, approx_cell2_size)
         )
-    xperiod, yperiod, zperiod = period 
+    xperiod, yperiod, zperiod = period
     rp_max = np.max(rp_bins)
     pi_max = np.max(pi_bins)
-    
+
     # Process the input weights and with the helper function
     weights1, weights2 = (
-        _velocity_marked_npairs_process_weights(data1, data2, 
+        _velocity_marked_npairs_process_weights(data1, data2,
             weights1, weights2, wfunc))
-    
+
     ### Compute the estimates for the cell sizes
     approx_cell1_size, approx_cell2_size = _set_approximate_xy_z_cell_sizes(
         approx_cell1_size, approx_cell2_size, rp_max, pi_max, period)
     approx_x1cell_size, approx_y1cell_size, approx_z1cell_size = approx_cell1_size
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
-    
+
     double_tree = FlatRectanguloidDoubleTree(
-        x1, y1, z1, x2, y2, z2,  
-        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size, 
-        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size, 
+        x1, y1, z1, x2, y2, z2,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
         rp_max, rp_max, pi_max, xperiod, yperiod, zperiod, PBCs=PBCs)
 
     #sort the weights arrays
     weights1 = np.ascontiguousarray(weights1[double_tree.tree1.idx_sorted, :])
     weights2 = np.ascontiguousarray(weights2[double_tree.tree2.idx_sorted, :])
-    
+
     #number of cells
     Ncell1 = double_tree.num_x1divs*double_tree.num_y1divs*double_tree.num_z1divs
     Ncell2 = double_tree.num_x2divs*double_tree.num_y2divs*double_tree.num_z2divs
-    
+
     #create a function to call with only one argument
-    engine = partial(_xy_z_velocity_marked_npairs_engine, double_tree, 
+    engine = partial(_xy_z_velocity_marked_npairs_engine, double_tree,
         weights1, weights2, rp_bins, pi_bins, period, PBCs, wfunc)
-    
+
     #do the pair counting
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
-        result = pool.map(engine,range(Ncell1))
+        result = pool.map(engine,list(range(Ncell1)))
         result = np.array(result)
         counts1, counts2, counts3 = (result[:,0],result[:,1],result[:,2])
         counts1 = np.sum(counts1,axis=0)
@@ -731,7 +733,7 @@ def xy_z_velocity_marked_npairs(data1, data2, rp_bins, pi_bins, period=None,
         counts3 = np.sum(counts3,axis=0)
         pool.close()
     else:
-        result = map(engine,range(Ncell1))
+        result = list(map(engine,list(range(Ncell1))))
         result = np.array(result)
         counts1, counts2, counts3= (result[:,0],result[:,1],result[:,2])
         counts1 = np.sum(counts1,axis=0)
@@ -740,19 +742,19 @@ def xy_z_velocity_marked_npairs(data1, data2, rp_bins, pi_bins, period=None,
     return counts1, counts2, counts3
 
 
-def _xy_z_velocity_marked_npairs_engine(double_tree, weights1, weights2, 
+def _xy_z_velocity_marked_npairs_engine(double_tree, weights1, weights2,
                                   rp_bins, pi_bins, period, PBCs, wfunc, icell1):
     """
-    private internal function for 
+    private internal function for
     `~halotools.mock_observables.pair_counters.marked_double_tree_pairs.xy_z_velocity_marked_npairs`.
-    
+
     This is an engine that calls a cython module to count pairs
     """
-    
+
     counts1 = np.zeros((len(rp_bins), len(pi_bins)))
     counts2 = np.zeros((len(rp_bins), len(pi_bins)))
     counts3 = np.zeros((len(rp_bins), len(pi_bins)))
-    
+
     #extract the points in the cell
     s1 = double_tree.tree1.slice_array[icell1]
     x_icell1, y_icell1, z_icell1 = (
@@ -768,29 +770,29 @@ def _xy_z_velocity_marked_npairs_engine(double_tree, weights1, weights2,
     zsearch_length = pi_bins[-1]
     adj_cell_generator = double_tree.adjacent_cell_generator(
         icell1, xsearch_length, ysearch_length, zsearch_length)
-            
+
     for icell2, xshift, yshift, zshift in adj_cell_generator:
-        
+
         #set shift array as -1,1,0 depending on direction of/if cell shifted.
         shift = np.array([xshift,yshift,zshift]).astype(float)
-        
+
         #extract the points in the cell
         s2 = double_tree.tree2.slice_array[icell2]
         x_icell2 = double_tree.tree2.x[s2] + xshift
-        y_icell2 = double_tree.tree2.y[s2] + yshift 
+        y_icell2 = double_tree.tree2.y[s2] + yshift
         z_icell2 = double_tree.tree2.z[s2] + zshift
 
         #extract the weights in the cell
         w_icell2 = weights2[s2, :]
-            
+
         #use cython functions to do pair counting
         holder1, holder2, holder3 = xy_z_velocity_marked_npairs_no_pbc(
                                        x_icell1, y_icell1, z_icell1,
                                        x_icell2, y_icell2, z_icell2,
-                                       w_icell1, w_icell2, 
+                                       w_icell1, w_icell2,
                                        rp_bins, pi_bins, wfunc, shift)
-        counts1 += holder1 
+        counts1 += holder1
         counts2 += holder2
         counts3 += holder3
-    return counts1, counts2, counts3 
+    return counts1, counts2, counts3
 

--- a/halotools/mock_observables/pair_counters/marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/marked_double_tree_pairs.py
@@ -13,7 +13,7 @@ import numpy as np
 import multiprocessing
 from functools import partial
 
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 from .double_tree import FlatRectanguloidDoubleTree
 from .double_tree_helpers import *

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 #load pair counters
 from ..double_tree_pairs import npairs, jnpairs, xy_z_npairs, s_mu_npairs

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+from astropy.extern.six import xrange as range
 
 #load pair counters
 from ..double_tree_pairs import npairs, jnpairs, xy_z_npairs, s_mu_npairs
@@ -51,7 +52,7 @@ ixx, iyy, izz = np.array(np.meshgrid(ix, iy, iz))
 ixx = ixx.flatten()
 iyy = iyy.flatten()
 izz = izz.flatten()
-grid_indices = np.ravel_multi_index([ixx, iyy, izz], 
+grid_indices = np.ravel_multi_index([ixx, iyy, izz],
     [grid_jackknife_ncells, grid_jackknife_ncells, grid_jackknife_ncells])
 grid_indices += 1
 
@@ -59,17 +60,17 @@ def test_npairs_periodic():
     """
     Function tests npairs with periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
+
     result = npairs(random_sample, random_sample, rbins, period=period,\
                     num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(len(rbins),), msg
-    
+
     test_result = simp_npairs(random_sample, random_sample, rbins, period=period)
-    
+
     msg = "The double tree's result(s) are not equivalent to simple pair counter's."
     assert np.all(test_result==result), msg
 
@@ -78,17 +79,17 @@ def test_npairs_nonperiodic():
     """
     test npairs without periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
+
     result = npairs(random_sample, random_sample, rbins, period=None,\
                     num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(len(rbins),), msg
-    
+
     test_result = simp_npairs(random_sample, random_sample, rbins, period=None)
-    
+
     msg = "The double tree's result(s) are not equivalent to simple pair counter's."
     assert np.all(test_result==result), msg
 
@@ -97,19 +98,19 @@ def test_xy_z_npairs_periodic():
     """
     test xy_z_npairs with periodic boundary conditions.
     """
-    
+
     rp_bins = np.arange(0,0.31,0.1)
     pi_bins = np.arange(0,0.31,0.1)
-    
+
     result = xy_z_npairs(random_sample, random_sample, rp_bins, pi_bins, period=period,\
                          num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(len(rp_bins),len(pi_bins)), msg
-    
+
     test_result = simp_xy_z_npairs(random_sample, random_sample, rp_bins, pi_bins,\
                                    period=period)
-    
+
     msg = "The double tree's result(s) are not equivalent to simple pair counter's."
     assert np.all(result == test_result), msg
 
@@ -118,19 +119,19 @@ def test_xy_z_npairs_nonperiodic():
     """
     test xy_z_npairs without periodic boundary conditions.
     """
-    
+
     rp_bins = np.arange(0,0.31,0.1)
     pi_bins = np.arange(0,0.31,0.1)
-    
+
     result = xy_z_npairs(random_sample, random_sample, rp_bins, pi_bins, period=None,\
                          num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(len(rp_bins),len(pi_bins)), msg
-    
+
     test_result = simp_xy_z_npairs(random_sample, random_sample, rp_bins, pi_bins,\
                                    period=None)
-    
+
     msg = "The double tree's result(s) are not equivalent to simple pair counter's."
     assert np.all(result == test_result), msg
 
@@ -139,24 +140,24 @@ def test_s_mu_npairs_periodic():
     """
     test s_mu_npairs with periodic boundary conditions.
     """
-    
+
     s_bins = np.array([0.0,0.1,0.2,0.3])
     N_mu_bins=100
     mu_bins = np.linspace(0,1.0,N_mu_bins)
     Npts = len(random_sample)
-    
+
     result = s_mu_npairs(random_sample, random_sample, s_bins, mu_bins, period=period,\
                          num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(len(s_bins),N_mu_bins), msg
-    
+
     result = np.diff(result,axis=1)
     result = np.sum(result, axis=1)+ Npts
-    
+
     test_result = npairs(random_sample, random_sample, s_bins, period=period,\
                          num_threads=num_threads)
-        
+
     msg = "The double tree's result(s) are not equivalent to simple pair counter's."
     assert np.all(result == test_result), msg
 
@@ -165,22 +166,22 @@ def test_s_mu_npairs_nonperiodic():
     """
     test s_mu_npairs without periodic boundary conditions.
     """
-    
+
     s_bins = np.array([0.0,0.1,0.2,0.3])
     N_mu_bins=100
     mu_bins = np.linspace(0,1.0,N_mu_bins)
-    
+
     result = s_mu_npairs(random_sample, random_sample, s_bins, mu_bins,\
                          num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(len(s_bins),N_mu_bins), msg
-    
+
     result = np.diff(result,axis=1)
     result = np.sum(result, axis=1)+ Npts
-    
+
     test_result = npairs(random_sample, random_sample, s_bins, num_threads=num_threads)
-    
+
     msg = "The double tree's result(s) are not equivalent to simple pair counter's."
     assert np.all(result == test_result), msg
 
@@ -189,32 +190,32 @@ def test_jnpairs_periodic():
     """
     test jnpairs with periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
+
     #define the jackknife sample labels
     Npts = len(random_sample)
     N_jsamples=10
     jtags1 = np.sort(np.random.random_integers(1, N_jsamples, size=Npts))
-    
+
     #define weights
     weights1 = np.random.random(Npts)
-    
+
     result = jnpairs(random_sample, random_sample, rbins, period=period,\
                      jtags1=jtags1, jtags2=jtags1, N_samples=10,\
                      weights1=weights1, weights2=weights1, num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(N_jsamples+1,len(rbins)), msg
 
-    # Now verify that when computing jackknife pairs on a regularly spaced grid, 
+    # Now verify that when computing jackknife pairs on a regularly spaced grid,
     # the counts in all subvolumes are identical
 
     grid_result = jnpairs(grid_points, grid_points, rbins, period=period,
         jtags1=grid_indices, jtags2=grid_indices, N_samples=grid_jackknife_ncells**3,
         num_threads=num_threads)
 
-    for icell in xrange(1, grid_jackknife_ncells**3-1):
+    for icell in range(1, grid_jackknife_ncells**3-1):
         assert np.all(grid_result[icell, :] == grid_result[icell+1, :])
 
 
@@ -222,21 +223,21 @@ def test_jnpairs_nonperiodic():
     """
     test jnpairs without periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
+
     #define the jackknife sample labels
     Npts = len(random_sample)
     N_jsamples=10
     jtags1 = np.sort(np.random.random_integers(1, N_jsamples, size=Npts))
-    
+
     #define weights
     weights1 = np.random.random(Npts)
-    
+
     result = jnpairs(random_sample, random_sample, rbins, period=None,\
                      jtags1=jtags1, jtags2=jtags1, N_samples=10,\
                      weights1=weights1, weights2=weights1, num_threads=num_threads)
-    
+
     msg = 'The returned result is an unexpected shape.'
     assert np.shape(result)==(N_jsamples+1,len(rbins)), msg
 
@@ -244,7 +245,7 @@ def test_jnpairs_nonperiodic():
         jtags1=grid_indices, jtags2=grid_indices, N_samples=grid_jackknife_ncells**3,
         num_threads=num_threads)
 
-    for icell in xrange(1, grid_jackknife_ncells**3-1):
+    for icell in range(1, grid_jackknife_ncells**3-1):
         assert np.all(grid_result[icell, :] == grid_result[icell+1, :])
 
 
@@ -253,15 +254,15 @@ def test_jnpairs_nonperiodic():
 #            approx_cell1_size = None, approx_cell2_size = None):
 
 def test_tight_locus1():
-    """ Verify that the pair counters return the correct results 
-    when operating on a tight locus of points. 
+    """ Verify that the pair counters return the correct results
+    when operating on a tight locus of points.
 
-    For this test, PBCs have no impact. 
+    For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, 
+    points1 = generate_locus_of_3d_points(npts1,
         xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, 
+    points2 = generate_locus_of_3d_points(npts2,
         xc=0.1, yc=0.1, zc=0.25)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2,npts1*npts2])
@@ -269,18 +270,18 @@ def test_tight_locus1():
     counts1 = npairs(points1, points2, rbins, num_threads='max')
     counts2 = npairs(points1, points2, rbins, num_threads=1)
     counts3 = npairs(points1, points2, rbins, period=1.)
-    counts4 = npairs(points1, points2, rbins, 
+    counts4 = npairs(points1, points2, rbins,
         approx_cell1_size = [0.1, 0.1, 0.1])
-    counts5 = npairs(points1, points2, rbins, 
-        approx_cell1_size = [0.1, 0.1, 0.1], 
+    counts5 = npairs(points1, points2, rbins,
+        approx_cell1_size = [0.1, 0.1, 0.1],
         approx_cell2_size = [0.1, 0.1, 0.1])
-    counts6 = npairs(points1, points2, rbins, 
-        period=1, 
-        approx_cell1_size = [0.1, 0.1, 0.1], 
+    counts6 = npairs(points1, points2, rbins,
+        period=1,
+        approx_cell1_size = [0.1, 0.1, 0.1],
         approx_cell2_size = [0.1, 0.1, 0.1])
-    counts7 = npairs(points1, points2, rbins, 
-        period=1, 
-        approx_cell1_size = [0.2, 0.2, 0.2], 
+    counts7 = npairs(points1, points2, rbins,
+        period=1,
+        approx_cell1_size = [0.2, 0.2, 0.2],
         approx_cell2_size = [0.15, 0.15, 0.15])
 
     assert np.all(counts1 == correct_result)
@@ -293,33 +294,33 @@ def test_tight_locus1():
 
 
 def test_tight_locus2():
-    """ Verify that the pair counters return the correct results 
-    when operating on a tight locus of points. 
+    """ Verify that the pair counters return the correct results
+    when operating on a tight locus of points.
 
-    For this test, the PBC correction is important. 
+    For this test, the PBC correction is important.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, 
+    points1 = generate_locus_of_3d_points(npts1,
         xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, 
+    points2 = generate_locus_of_3d_points(npts2,
         xc=0.1, yc=0.1, zc=0.95)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
-    counts1 = npairs(points1, points2, rbins, 
+    counts1 = npairs(points1, points2, rbins,
         num_threads='max', period=1)
-    counts2 = npairs(points1, points2, rbins, 
+    counts2 = npairs(points1, points2, rbins,
         num_threads=1, period=1)
-    counts3 = npairs(points1, points2, rbins, 
+    counts3 = npairs(points1, points2, rbins,
         approx_cell1_size = [0.1, 0.1, 0.1], period=1)
-    counts4 = npairs(points1, points2, rbins, 
-        approx_cell1_size = [0.1, 0.1, 0.1], 
+    counts4 = npairs(points1, points2, rbins,
+        approx_cell1_size = [0.1, 0.1, 0.1],
         approx_cell2_size = [0.1, 0.1, 0.1], period=1)
-    counts5 = npairs(points1, points2, rbins, period=1, 
-        approx_cell1_size = [0.1, 0.1, 0.1], 
+    counts5 = npairs(points1, points2, rbins, period=1,
+        approx_cell1_size = [0.1, 0.1, 0.1],
         approx_cell2_size = [0.1, 0.1, 0.1])
-    counts6 = npairs(points1, points2, rbins, period=1, 
-        approx_cell1_size = [0.2, 0.2, 0.2], 
+    counts6 = npairs(points1, points2, rbins, period=1,
+        approx_cell1_size = [0.2, 0.2, 0.2],
         approx_cell2_size = [0.15, 0.15, 0.15])
 
     assert np.all(counts1 == correct_result)

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_double_tree_pairs.py
@@ -5,32 +5,31 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 from astropy.extern.six.moves import xrange as range
 
-#load pair counters
+# load pair counters
 from ..double_tree_pairs import npairs, jnpairs, xy_z_npairs, s_mu_npairs
-#load comparison simple pair counters
+# load comparison simple pair counters
 from ..pairs import npairs as simp_npairs
-from ..pairs import wnpairs as simp_wnpairs
 from ..pairs import xy_z_npairs as simp_xy_z_npairs
 
 from ...tests.cf_helpers import generate_locus_of_3d_points
 
-from ....custom_exceptions import HalotoolsError
-
 import pytest
 slow = pytest.mark.slow
 
-__all__=['test_npairs_periodic','test_npairs_nonperiodic','test_xy_z_npairs_periodic',\
-         'test_xy_z_npairs_nonperiodic','test_s_mu_npairs_periodic',\
-         'test_s_mu_npairs_nonperiodic','test_jnpairs_periodic','test_jnpairs_nonperiodic']
+__all__ = ['test_npairs_periodic', 'test_npairs_nonperiodic',
+           'test_xy_z_npairs_periodic',
+           'test_xy_z_npairs_nonperiodic', 'test_s_mu_npairs_periodic',
+           'test_s_mu_npairs_nonperiodic', 'test_jnpairs_periodic',
+           'test_jnpairs_nonperiodic']
 
-#set up random points to test pair counters
+# set up random points to test pair counters
 np.random.seed(1)
 Npts = 1000
-random_sample = np.random.random((Npts,3))
-period = np.array([1.0,1.0,1.0])
-num_threads=2
+random_sample = np.random.random((Npts, 3))
+period = np.array([1.0, 1.0, 1.0])
+num_threads = 2
 
-#set up a regular grid of points to test pair counters
+# set up a regular grid of points to test pair counters
 Npts2 = 10
 epsilon = 0.001
 gridx = np.linspace(0, 1-epsilon, Npts2)
@@ -55,6 +54,7 @@ izz = izz.flatten()
 grid_indices = np.ravel_multi_index([ixx, iyy, izz],
     [grid_jackknife_ncells, grid_jackknife_ncells, grid_jackknife_ncells])
 grid_indices += 1
+
 
 def test_npairs_periodic():
     """
@@ -308,7 +308,7 @@ def test_tight_locus2():
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
     counts1 = npairs(points1, points2, rbins,
-        num_threads='max', period=1)
+                     num_threads='max', period=1)
     counts2 = npairs(points1, points2, rbins,
         num_threads=1, period=1)
     counts3 = npairs(points1, points2, rbins,

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
@@ -2,29 +2,31 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
-import pytest 
-slow = pytest.mark.slow
+import pytest
 
-from copy import copy 
+from copy import copy
+
+from astropy.extern.six import xrange as range
 
 from ..pairs import wnpairs as pure_python_weighted_pairs
 from ..pairs import xy_z_wnpairs as pure_python_xy_z_weighted_pairs
 from ..marked_double_tree_pairs import marked_npairs, xy_z_marked_npairs
 from ..marked_double_tree_helpers import _func_signature_int_from_wfunc
-from ..double_tree_pairs import npairs
 
 from ....custom_exceptions import HalotoolsError
 
-__all__ = ['test_marked_npairs_periodic','test_marked_npairs_nonperiodic',\
-           'test_xy_z_marked_npairs_periodic','test_xy_z_marked_npairs_nonperiodic',\
-           'test_marked_npairs_wfuncs_signatures','test_marked_npairs_wfuncs_behavior']
+slow = pytest.mark.slow
+
+__all__ = ['test_marked_npairs_periodic', 'test_marked_npairs_nonperiodic',
+           'test_xy_z_marked_npairs_periodic', 'test_xy_z_marked_npairs_nonperiodic',
+           'test_marked_npairs_wfuncs_signatures', 'test_marked_npairs_wfuncs_behavior']
 
 #set up random points to test pair counters
 np.random.seed(1)
 Npts = 1000
-random_sample = np.random.random((Npts,3))
-period = np.array([1.0,1.0,1.0])
-num_threads=2
+random_sample = np.random.random((Npts, 3))
+period = np.array([1.0, 1.0, 1.0])
+num_threads = 2
 
 #set up a regular grid of points to test pair counters
 Npts2 = 10
@@ -46,31 +48,31 @@ def test_marked_npairs_periodic():
     """
     Function tests marked_npairs with periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
-    result = marked_npairs(random_sample, random_sample, 
+
+    result = marked_npairs(random_sample, random_sample,
         rbins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
-    
-    test_result = pure_python_weighted_pairs(random_sample, random_sample, rbins, 
+
+    test_result = pure_python_weighted_pairs(random_sample, random_sample, rbins,
         period=period, weights1=ran_weights1, weights2=ran_weights1)
-    
+
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
 
 def test_marked_npairs_parallelization():
     """
     Function tests marked_npairs with periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
-    serial_result = marked_npairs(random_sample, random_sample, 
+
+    serial_result = marked_npairs(random_sample, random_sample,
         rbins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
 
-    parallel_result = marked_npairs(random_sample, random_sample, 
-        rbins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1, 
+    parallel_result = marked_npairs(random_sample, random_sample,
+        rbins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1,
         num_threads = 'max')
-    
+
     assert np.allclose(serial_result,parallel_result,rtol=1e-09), "pair counts are incorrect"
 
 
@@ -78,49 +80,49 @@ def test_marked_npairs_nonperiodic():
     """
     Function tests marked_npairs with without periodic boundary conditions.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
-    
+
     result = marked_npairs(random_sample, random_sample,
-        rbins, period=None, 
+        rbins, period=None,
         weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
-    
+
     test_result = pure_python_weighted_pairs(random_sample, random_sample,
         rbins, period=None, weights1=ran_weights1, weights2=ran_weights1)
-    
+
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
 
 def test_xy_z_marked_npairs_periodic():
     """
     Function tests xy_z_marked_npairs with periodic boundary conditions.
     """
-    
+
     rp_bins = np.array([0.0,0.1,0.2,0.3])
     pi_bins = np.array([0.0,0.1,0.2,0.3])
-    
-    result = xy_z_marked_npairs(random_sample, random_sample, 
+
+    result = xy_z_marked_npairs(random_sample, random_sample,
         rp_bins, pi_bins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
-    
+
     test_result = pure_python_xy_z_weighted_pairs(random_sample, random_sample, rp_bins, pi_bins,
         period=period, weights1=ran_weights1, weights2=ran_weights1)
-    
+
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
 
 def test_xy_z_marked_npairs_parallelization():
     """
     Function tests xy_z_marked_npairs with periodic boundary conditions.
     """
-    
+
     rp_bins = np.array([0.0,0.1,0.2,0.3])
     pi_bins = np.array([0.0,0.1,0.2,0.3])
-    
-    serial_result = xy_z_marked_npairs(random_sample, random_sample, 
+
+    serial_result = xy_z_marked_npairs(random_sample, random_sample,
         rp_bins, pi_bins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
 
-    parallel_result = xy_z_marked_npairs(random_sample, random_sample, 
-        rp_bins, pi_bins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1, 
+    parallel_result = xy_z_marked_npairs(random_sample, random_sample,
+        rp_bins, pi_bins, period=period, weights1=ran_weights1, weights2=ran_weights1, wfunc=1,
         num_threads = 'max')
-            
+
     assert np.allclose(serial_result,parallel_result,rtol=1e-09), "pair counts are incorrect"
 
 
@@ -128,28 +130,28 @@ def test_xy_z_marked_npairs_nonperiodic():
     """
     Function tests xy_z_marked_npairs with without periodic boundary conditions.
     """
-    
+
     rp_bins = np.array([0.0,0.1,0.2,0.3])
     pi_bins = np.array([0.0,0.1,0.2,0.3])
-    
+
     result = xy_z_marked_npairs(random_sample, random_sample,
-        rp_bins, pi_bins, period=None, 
+        rp_bins, pi_bins, period=None,
         weights1=ran_weights1, weights2=ran_weights1, wfunc=1)
-    
+
     test_result = pure_python_xy_z_weighted_pairs(random_sample, random_sample,
         rp_bins, pi_bins, period=None, weights1=ran_weights1, weights2=ran_weights1)
-    
+
     assert np.allclose(test_result,result,rtol=1e-09), "pair counts are incorrect"
 
 @slow
 def test_marked_npairs_wfuncs_signatures():
-    """ 
+    """
     Loop over all wfuncs and ensure that the wfunc signature is handled correctly.
     """
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
     rmax = rbins.max()
-    
+
     # Determine how many wfuncs have currently been implemented
     wfunc_index = 1
     while True:
@@ -161,46 +163,46 @@ def test_marked_npairs_wfuncs_signatures():
     num_wfuncs = copy(wfunc_index)
 
     # Now loop over all all available wfunc indices
-    for wfunc_index in xrange(1, num_wfuncs):
+    for wfunc_index in range(1, num_wfuncs):
         signature = _func_signature_int_from_wfunc(wfunc_index)
         weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
-        result = marked_npairs(random_sample, random_sample, rbins, period=period, 
-            weights1=weights, weights2=weights, wfunc=wfunc_index, 
+        result = marked_npairs(random_sample, random_sample, rbins, period=period,
+            weights1=weights, weights2=weights, wfunc=wfunc_index,
             approx_cell1_size = [rmax, rmax, rmax])
 
         with pytest.raises(HalotoolsError):
             signature = _func_signature_int_from_wfunc(wfunc_index) + 1
             weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
-            result = marked_npairs(random_sample, random_sample, rbins, period=period, 
+            result = marked_npairs(random_sample, random_sample, rbins, period=period,
                 weights1=weights, weights2=weights, wfunc=wfunc_index)
 
 @slow
 def test_marked_npairs_wfuncs_behavior():
-    """ 
-    Verify the behavior of a few wfunc-weighted counters by comparing pure python, 
-    unmarked pairs to the returned result from a uniformly weighted set of points.  
     """
-    
+    Verify the behavior of a few wfunc-weighted counters by comparing pure python,
+    unmarked pairs to the returned result from a uniformly weighted set of points.
+    """
+
     error_msg = ("\nThe `test_marked_npairs_wfuncs_behavior` function performs \n"
         "non-trivial checks on the returned values of marked correlation functions\n"
         "calculated on a set of points with uniform weights.\n"
         "One such check failed.\n")
-    
+
     rbins = np.array([0.0,0.1,0.2,0.3])
     rmax = rbins.max()
-    
+
     test_result = pure_python_weighted_pairs(grid_points, grid_points,
         rbins, period=period)
 
     # wfunc = 1
     weights = np.ones(Npts)*3
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=1, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 9.*test_result), error_msg
 
     # wfunc = 2
     weights = np.ones(Npts)*3
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=2, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 6.*test_result), error_msg
 
@@ -209,12 +211,12 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=3, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 9.*test_result), error_msg
 
     weights = np.vstack([weights3, weights2]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=3, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 4.*test_result), error_msg
 
@@ -223,7 +225,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=4, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
@@ -232,7 +234,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=5, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
@@ -241,7 +243,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=6, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
@@ -250,7 +252,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.zeros(Npts)-1
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=7, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == -test_result), error_msg
 
@@ -259,7 +261,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=8, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 3*test_result), error_msg
 
@@ -268,7 +270,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=9, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 3*test_result), error_msg
 
@@ -277,7 +279,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=10, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == 0), error_msg
 
@@ -285,7 +287,7 @@ def test_marked_npairs_wfuncs_behavior():
     weights3 = -np.ones(Npts)*3
 
     weights = np.vstack([weights2, weights3]).T
-    result = marked_npairs(grid_points, grid_points, rbins, period=period, 
+    result = marked_npairs(grid_points, grid_points, rbins, period=period,
     weights1=weights, weights2=weights, wfunc=10, approx_cell1_size = [rmax, rmax, rmax])
     assert np.all(result == -3*test_result), error_msg
 

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_double_tree_pairs.py
@@ -6,7 +6,7 @@ import pytest
 
 from copy import copy
 
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 from ..pairs import wnpairs as pure_python_weighted_pairs
 from ..pairs import xy_z_wnpairs as pure_python_xy_z_weighted_pairs

--- a/halotools/mock_observables/test_clustering/test_tpcf.py
+++ b/halotools/mock_observables/test_clustering/test_tpcf.py
@@ -298,7 +298,7 @@ def test_RR_precomputed_exception_handling1():
             approx_cell1_size = [rmax, rmax, rmax], 
             RR_precomputed = RR_precomputed)
     substr = "``RR_precomputed`` and ``NR_precomputed`` arguments, or neither\n"
-    assert substr in err.value.message
+    assert substr in err.value.args[0]
 
 
 def test_RR_precomputed_exception_handling2():
@@ -319,7 +319,7 @@ def test_RR_precomputed_exception_handling2():
             approx_cell1_size = [rmax, rmax, rmax], 
             RR_precomputed = RR_precomputed, NR_precomputed = NR_precomputed)
     substr = "\nLength of ``RR_precomputed`` must match length of ``rbins``\n"
-    assert substr in err.value.message
+    assert substr in err.value.args[0]
 
 
 def test_RR_precomputed_exception_handling3():
@@ -340,7 +340,7 @@ def test_RR_precomputed_exception_handling3():
             approx_cell1_size = [rmax, rmax, rmax], 
             RR_precomputed = RR_precomputed, NR_precomputed = NR_precomputed)
     substr = "the value of NR_precomputed must agree with the number of randoms"
-    assert substr in err.value.message
+    assert substr in err.value.args[0]
 
 
 @slow

--- a/halotools/mock_observables/test_clustering/test_tpcf.py
+++ b/halotools/mock_observables/test_clustering/test_tpcf.py
@@ -26,7 +26,7 @@ def test_tpcf_auto():
     """
     test the tpcf auto-correlation functionality
     """
-    
+
     sample1 = np.random.random((100,3))
     sample2 = np.random.random((100,3))
     randoms = np.random.random((100,3))
@@ -41,7 +41,7 @@ def test_tpcf_auto():
                   approx_cell1_size = [rmax, rmax, rmax], 
                   approx_cellran_size = [rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
-    
+
     #with out randoms
     result = tpcf(sample1, rbins, sample2 = None, 
                   randoms=None, period = period, 
@@ -55,7 +55,7 @@ def test_tpcf_cross():
     """
     test the tpcf cross-correlation functionality
     """
-    
+
     sample1 = np.random.random((100,3))
     sample2 = np.random.random((100,3))
     randoms = np.random.random((100,3))
@@ -69,7 +69,7 @@ def test_tpcf_cross():
                   max_sample_size=int(1e4), estimator='Natural', do_auto=False, 
                   approx_cell1_size = [rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
-    
+
     #with out randoms
     result = tpcf(sample1, rbins, sample2 = sample2, 
                   randoms=None, period = period, 
@@ -82,7 +82,7 @@ def test_tpcf_estimators():
     """
     test the tpcf different estimators functionality
     """
-    
+
     sample1 = np.random.random((100,3))
     sample2 = np.random.random((100,3))
     randoms = np.random.random((100,3))
@@ -115,8 +115,8 @@ def test_tpcf_estimators():
                     max_sample_size=int(1e4), estimator='Landy-Szalay', 
                     approx_cell1_size = [rmax, rmax, rmax], 
                     approx_cellran_size = [rmax, rmax, rmax])
-                                            
-    
+
+
     assert len(result_1)==3, "wrong number of correlation functions returned erroneously."
     assert len(result_2)==3, "wrong number of  correlation functions returned erroneously."
     assert len(result_3)==3, "wrong number of correlation functions returned erroneously."
@@ -128,7 +128,7 @@ def test_tpcf_sample_size_limit():
     """
     test the tpcf sample size limit functionality functionality
     """
-    
+
     sample1 = np.random.random((1000,3))
     sample2 = np.random.random((1000,3))
     randoms = np.random.random((1000,3))
@@ -140,7 +140,7 @@ def test_tpcf_sample_size_limit():
                     randoms=randoms, period = None, 
                     max_sample_size=int(1e2), estimator='Natural', 
                     approx_cell1_size = [rmax, rmax, rmax])
-    
+
     assert len(result_1)==3, "wrong number of correlation functions returned erroneously."
 
 @slow
@@ -148,7 +148,7 @@ def test_tpcf_randoms():
     """
     test the tpcf possible randoms + PBCs combinations
     """
-    
+
     sample1 = np.random.random((100,3))
     sample2 = np.random.random((100,3))
     randoms = np.random.random((100,3))
@@ -174,7 +174,7 @@ def test_tpcf_randoms():
                     max_sample_size=int(1e4), estimator='Natural', 
                     approx_cell1_size = [rmax, rmax, rmax], 
                     approx_cellran_size = [rmax, rmax, rmax])
-    
+
     #No PBCs and no randoms should throw an error.
     try:
         tpcf(sample1, rbins, sample2 = sample2, 
@@ -184,7 +184,7 @@ def test_tpcf_randoms():
              approx_cellran_size = [rmax, rmax, rmax])
     except HalotoolsError:
         pass
-    
+
     assert len(result_1)==3, "wrong number of correlation functions returned erroneously."
     assert len(result_2)==3, "wrong number of correlation functions returned erroneously."
     assert len(result_3)==3, "wrong number of correlation functions returned erroneously."
@@ -194,25 +194,25 @@ def test_tpcf_period_API():
     """
     test the tpcf period API functionality.
     """
-    
+
     sample1 = np.random.random((1000,3))
     sample2 = np.random.random((100,3))
     randoms = np.random.random((100,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
     rmax = rbins.max()
-    
+
     result_1 = tpcf(sample1, rbins, sample2 = sample2,
                     randoms=randoms, period = period, 
                     max_sample_size=int(1e4), estimator='Natural', 
                     approx_cell1_size = [rmax, rmax, rmax])
-    
+
     period = 1.0
     result_2 = tpcf(sample1, rbins, sample2 = sample2, 
                     randoms=randoms, period = period, 
                     max_sample_size=int(1e4), estimator='Natural', 
                     approx_cell1_size = [rmax, rmax, rmax])
-    
+
     #should throw an error.  period must be positive!
     period = np.array([1.0,1.0,-1.0])
     try:
@@ -222,7 +222,7 @@ def test_tpcf_period_API():
              approx_cell1_size = [rmax, rmax, rmax])
     except HalotoolsError:
         pass
-    
+
     assert len(result_1)==3, "wrong number of correlation functions returned erroneously."
     assert len(result_2)==3, "wrong number of correlation functions returned erroneously."
 
@@ -232,51 +232,51 @@ def test_tpcf_cross_consistency_w_auto():
     """
     test the tpcf cross-correlation mode consistency with auto-correlation mode
     """
-    
+
     sample1 = np.random.random((200,3))
     sample2 = np.random.random((100,3))
     randoms = np.random.random((300,3))
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
     rmax = rbins.max()
-    
+
     #with out randoms
     result1 = tpcf(sample1, rbins, sample2 = None, 
                    randoms=None, period = period, 
                    max_sample_size=int(1e4), estimator='Natural', 
                    approx_cell1_size = [rmax, rmax, rmax])
-    
+
     result2 = tpcf(sample2, rbins, sample2 = None, 
                    randoms=None, period = period, 
                    max_sample_size=int(1e4), estimator='Natural', 
                    approx_cell1_size = [rmax, rmax, rmax])
-    
+
     result1_p, result12, result2_p = tpcf(sample1, rbins, sample2 = sample2, 
                                           randoms=None, period = period, 
                                           max_sample_size=int(1e4),
                                           estimator='Natural', 
                                           approx_cell1_size=[rmax, rmax, rmax])
-    
+
     assert np.allclose(result1,result1_p), "cross mode and auto mode are not the same"
     assert np.allclose(result2,result2_p), "cross mode and auto mode are not the same"
-    
+
     #with randoms
     result1 = tpcf(sample1, rbins, sample2 = None, 
                    randoms=randoms, period = period, 
                    max_sample_size=int(1e4), estimator='Natural', 
                    approx_cell1_size = [rmax, rmax, rmax])
-    
+
     result2 = tpcf(sample2, rbins, sample2 = None, 
                    randoms=randoms, period = period, 
                    max_sample_size=int(1e4), estimator='Natural', 
                    approx_cell1_size = [rmax, rmax, rmax])
-    
+
     result1_p, result12, result2_p = tpcf(sample1, rbins, sample2 = sample2, 
                                           randoms=randoms, period = period, 
                                           max_sample_size=int(1e4),
                                           estimator='Natural', 
                                           approx_cell1_size=[rmax, rmax, rmax])
-                                          
+
     assert np.allclose(result1,result1_p), "cross mode and auto mode are not the same"
     assert np.allclose(result2,result2_p), "cross mode and auto mode are not the same"
 
@@ -292,11 +292,11 @@ def test_RR_precomputed_exception_handling1():
 
     RR_precomputed = rmax
     with pytest.raises(HalotoolsError) as err:
-      result_1 = tpcf(sample1, rbins, sample2 = sample2,
-          randoms=randoms, period = period, 
-          max_sample_size=int(1e4), estimator='Natural', 
-          approx_cell1_size = [rmax, rmax, rmax], 
-          RR_precomputed = RR_precomputed)
+        result_1 = tpcf(sample1, rbins, sample2 = sample2,
+            randoms=randoms, period = period, 
+            max_sample_size=int(1e4), estimator='Natural', 
+            approx_cell1_size = [rmax, rmax, rmax], 
+            RR_precomputed = RR_precomputed)
     substr = "``RR_precomputed`` and ``NR_precomputed`` arguments, or neither\n"
     assert substr in err.value.message
 
@@ -309,7 +309,7 @@ def test_RR_precomputed_exception_handling2():
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
     rmax = rbins.max()
-    
+
     RR_precomputed = rbins[:-2]
     NR_precomputed = randoms.shape[0]
     with pytest.raises(HalotoolsError) as err:
@@ -330,7 +330,7 @@ def test_RR_precomputed_exception_handling3():
     period = np.array([1.0,1.0,1.0])
     rbins = np.linspace(0,0.3,5)
     rmax = rbins.max()
-    
+
     RR_precomputed = rbins[:-1]
     NR_precomputed = 5
     with pytest.raises(HalotoolsError) as err:

--- a/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
+++ b/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
@@ -44,7 +44,7 @@ class TestCatalogAnalysisHelpers(TestCase):
                 self.halo_table['halo_mvir'], self.halo_table['halo_spin'], 
                 error_estimator = 'Jose Canseco')
         substr = "Input ``error_estimator`` must be either"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_return_xyz_formatted_array1(self):
         x, y, z = (self.halo_table['halo_x'], 

--- a/halotools/mock_observables/tests/test_large_scale_density.py
+++ b/halotools/mock_observables/tests/test_large_scale_density.py
@@ -21,19 +21,19 @@ def test_large_scale_density_spherical_volume_exception_handling():
 		result = large_scale_density_spherical_volume(
 			sample, tracers, radius)
 	substr = "If period is None, you must pass in ``sample_volume``."
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 	with pytest.raises(HalotoolsError) as err:
 		result = large_scale_density_spherical_volume(
 			sample, tracers, radius, period=[1,1])
 	substr = "Input ``period`` must either be a float or length-3 sequence"
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 	with pytest.raises(HalotoolsError) as err:
 		result = large_scale_density_spherical_volume(
 			sample, tracers, radius, period=1, sample_volume=0.4)
 	substr = "If period is not None, do not pass in sample_volume"
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 def test_large_scale_density_spherical_volume1():
 	"""
@@ -77,25 +77,25 @@ def test_large_scale_density_spherical_annulus_exception_handling():
 		result = large_scale_density_spherical_annulus(
 			sample, tracers, inner_radius, outer_radius)
 	substr = "If period is None, you must pass in ``sample_volume``."
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 	with pytest.raises(HalotoolsError) as err:
 		result = large_scale_density_spherical_annulus(
 			sample, tracers, inner_radius, outer_radius, period=[1,1])
 	substr = "Input ``period`` must either be a float or length-3 sequence"
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 	with pytest.raises(HalotoolsError) as err:
 		result = large_scale_density_spherical_annulus(
 			sample, tracers, inner_radius, outer_radius, period=1, sample_volume=0.4)
 	substr = "If period is not None, do not pass in sample_volume"
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 	with pytest.raises(HalotoolsError) as err:
 		result = large_scale_density_spherical_annulus(
 			sample, tracers, 0.5, outer_radius, period=1, sample_volume=0.4)
 	substr = "Input ``outer_radius`` must be larger than input ``inner_radius``"
-	assert substr in err.value.message
+	assert substr in err.value.args[0]
 
 def test_large_scale_density_spherical_annulus1():
 	"""

--- a/halotools/mock_observables/void_stats.py
+++ b/halotools/mock_observables/void_stats.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function,
 ####import modules########################################################################
 import numpy as np
 
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 from .pair_counters.double_tree_per_object_pairs import *
 from ..custom_exceptions import *

--- a/halotools/mock_observables/void_stats.py
+++ b/halotools/mock_observables/void_stats.py
@@ -8,9 +8,11 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 ####import modules########################################################################
 import numpy as np
+
+from astropy.extern.six import xrange as range
+
 from .pair_counters.double_tree_per_object_pairs import *
 from ..custom_exceptions import *
-from warnings import warn
 
 from ..utils import convert_to_ndarray
 from .void_stats_helpers import *
@@ -24,17 +26,17 @@ __author__ = ['Duncan Campbell', 'Andrew Hearin']
 np.seterr(divide='ignore', invalid='ignore') #ignore divide by zero in e.g. DD/RR
 
 
-def void_prob_func(sample1, rbins, n_ran=None, random_sphere_centers=None, 
+def void_prob_func(sample1, rbins, n_ran=None, random_sphere_centers=None,
     period=None, num_threads=1,
     approx_cell1_size=None, approx_cellran_size=None):
     """
-    Calculate the void probability function (VPF), :math:`P_0(r)`, 
-    defined as the probability that a random 
-    sphere of radius *r* contains zero points in the input sample. 
-    
-    See the :ref:`mock_obs_pos_formatting` documentation page for 
-    instructions on how to transform your coordinate position arrays into the 
-    format accepted by the ``sample1`` argument.   
+    Calculate the void probability function (VPF), :math:`P_0(r)`,
+    defined as the probability that a random
+    sphere of radius *r* contains zero points in the input sample.
+
+    See the :ref:`mock_obs_pos_formatting` documentation page for
+    instructions on how to transform your coordinate position arrays into the
+    format accepted by the ``sample1`` argument.
 
     See also :ref:`galaxy_catalog_analysis_tutorial8`
 
@@ -42,92 +44,92 @@ def void_prob_func(sample1, rbins, n_ran=None, random_sphere_centers=None,
     ----------
     sample1 : array_like
         Npts x 3 numpy array containing 3-D positions of points.
-        See `~halotools.mock_observables.return_xyz_formatted_array` for 
-        a convenience function that can be used to transform a set of x, y, z 
-        1d arrays into the required form. 
+        See `~halotools.mock_observables.return_xyz_formatted_array` for
+        a convenience function that can be used to transform a set of x, y, z
+        1d arrays into the required form.
 
     rbins : float
         size of spheres to search for neighbors
-    
-    n_ran : int, optional 
-        integer number of randoms to use to search for voids. 
+
+    n_ran : int, optional
+        integer number of randoms to use to search for voids.
         If ``n_ran`` is not passed, you must pass ``random_sphere_centers``.
 
-    random_sphere_centers : array_like, optional 
-        Npts x 3 array of randomly selected positions to drop down spheres 
-        to use to measure the `void_prob_func`. If ``random_sphere_centers`` 
-        is not passed, ``n_ran`` must be passed. 
-    
-    period : array_like, optional 
+    random_sphere_centers : array_like, optional
+        Npts x 3 array of randomly selected positions to drop down spheres
+        to use to measure the `void_prob_func`. If ``random_sphere_centers``
+        is not passed, ``n_ran`` must be passed.
+
+    period : array_like, optional
         length 3 array defining axis-aligned periodic boundary conditions. If only
         one number, Lbox, is specified, period is assumed to be np.array([Lbox]*3).
-        If set to None, PBCs are set to infinity. Even in this case, it is still necessary 
-        to drop down randomly placed spheres in order to compute the VPF. To do so, 
-        the spheres will be dropped inside a cubical box whose sides are defined by  
-        the smallest/largest coordinate distance of the input ``sample1``. 
-    
+        If set to None, PBCs are set to infinity. Even in this case, it is still necessary
+        to drop down randomly placed spheres in order to compute the VPF. To do so,
+        the spheres will be dropped inside a cubical box whose sides are defined by
+        the smallest/largest coordinate distance of the input ``sample1``.
+
     num_threads : int, optional
-        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        number of 'threads' to use in the pair counting.  if set to 'max', use all
         available cores.  num_threads=0 is the default.
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``sample1`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use *max(rbins)* in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-    
-    approx_cellran_size : array_like, optional 
-        Analogous to ``approx_cell1_size``, but for used for randoms.  See comments for 
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``sample1`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use *max(rbins)* in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cellran_size : array_like, optional
+        Analogous to ``approx_cell1_size``, but for used for randoms.  See comments for
         ``approx_cell1_size`` for details.
-    
+
     Returns
     -------
     vpf : numpy.array
-        *len(rbins)* length array containing the void probability function 
+        *len(rbins)* length array containing the void probability function
         :math:`P_0(r)` computed for each :math:`r` defined by input ``rbins``.
-    
+
     Notes
     -----
-    This function requires the calculation of the number of pairs per randomly placed 
-    sphere, and thus storage of an array of shape(n_ran,len(rbins)).  This can be a 
+    This function requires the calculation of the number of pairs per randomly placed
+    sphere, and thus storage of an array of shape(n_ran,len(rbins)).  This can be a
     memory intensive process as this array becomes large.
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    periodic unit cube.
+
     >>> Npts = 10000
     >>> Lbox = 1.0
     >>> period = np.array([Lbox,Lbox,Lbox])
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
-    
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
-    
+
     >>> coords = np.vstack((x,y,z)).T
-    
+
     >>> rbins = np.logspace(-2,-1,20)
     >>> n_ran = 1000
     >>> vpf = void_prob_func(coords, rbins, n_ran=n_ran, period=period)
 
-    See also 
+    See also
     ----------
     :ref:`galaxy_catalog_analysis_tutorial8`
 
     """
-    (sample1, rbins, n_ran, random_sphere_centers, 
+    (sample1, rbins, n_ran, random_sphere_centers,
         period, num_threads, approx_cell1_size, approx_cellran_size) = (
-        _void_prob_func_process_args(sample1, rbins, n_ran, random_sphere_centers, 
+        _void_prob_func_process_args(sample1, rbins, n_ran, random_sphere_centers,
             period, num_threads, approx_cell1_size, approx_cellran_size))
 
     result = per_object_npairs(random_sphere_centers, sample1, rbins, period = period,\
@@ -136,130 +138,130 @@ def void_prob_func(sample1, rbins, n_ran=None, random_sphere_centers=None,
                               approx_cell2_size = approx_cellran_size)
 
     num_empty_spheres = np.array(
-        [sum(result[:,i] == 0) for i in xrange(result.shape[1])])
+        [sum(result[:,i] == 0) for i in range(result.shape[1])])
     return num_empty_spheres/n_ran
 
 
-def underdensity_prob_func(sample1, rbins, n_ran=None, 
-    random_sphere_centers=None, period=None, 
+def underdensity_prob_func(sample1, rbins, n_ran=None,
+    random_sphere_centers=None, period=None,
     sample_volume = None, u=0.2, num_threads=1,
     approx_cell1_size=None, approx_cellran_size=None):
     """
     Calculate the underdensity probability function (UPF), :math:`P_U(r)`.
-    
-    :math:`P_U(r)` is defined as the probability that a randomly placed sphere of size 
+
+    :math:`P_U(r)` is defined as the probability that a randomly placed sphere of size
     :math:`r` encompases a volume with less than a specified number density.
 
-    See the :ref:`mock_obs_pos_formatting` documentation page for 
-    instructions on how to transform your coordinate position arrays into the 
-    format accepted by the ``sample1`` argument.   
+    See the :ref:`mock_obs_pos_formatting` documentation page for
+    instructions on how to transform your coordinate position arrays into the
+    format accepted by the ``sample1`` argument.
 
-    See also :ref:`galaxy_catalog_analysis_tutorial8`. 
+    See also :ref:`galaxy_catalog_analysis_tutorial8`.
 
     Parameters
     ----------
     sample1 : array_like
         Npts x 3 numpy array containing 3-D positions of points.
-        See `~halotools.mock_observables.return_xyz_formatted_array` for 
-        a convenience function that can be used to transform a set of x, y, z 
-        1d arrays into the required form. 
+        See `~halotools.mock_observables.return_xyz_formatted_array` for
+        a convenience function that can be used to transform a set of x, y, z
+        1d arrays into the required form.
 
     rbins : float
         size of spheres to search for neighbors
-    
-    n_ran : int, optional 
-        integer number of randoms to use to search for voids. 
+
+    n_ran : int, optional
+        integer number of randoms to use to search for voids.
         If ``n_ran`` is not passed, you must pass ``random_sphere_centers``.
 
-    random_sphere_centers : array_like, optional 
-        Npts x 3 array of randomly selected positions to drop down spheres 
-        to use to measure the `void_prob_func`. If ``random_sphere_centers`` 
-        is not passed, ``n_ran`` must be passed. 
-    
-    period : array_like, optional 
+    random_sphere_centers : array_like, optional
+        Npts x 3 array of randomly selected positions to drop down spheres
+        to use to measure the `void_prob_func`. If ``random_sphere_centers``
+        is not passed, ``n_ran`` must be passed.
+
+    period : array_like, optional
         length 3 array defining axis-aligned periodic boundary conditions. If only
         one number, Lbox, is specified, period is assumed to be np.array([Lbox]*3).
-        If set to None, PBCs are set to infinity. Even in this case, it is still necessary 
-        to drop down randomly placed spheres in order to compute the VPF. To do so, 
-        the spheres will be dropped inside a cubical box whose sides are defined by  
-        the smallest/largest coordinate distance of the input ``sample1``. 
-    
-    sample_volume : float, optional 
-        If period is set to None, you must specify the effective volume of the sample. 
+        If set to None, PBCs are set to infinity. Even in this case, it is still necessary
+        to drop down randomly placed spheres in order to compute the VPF. To do so,
+        the spheres will be dropped inside a cubical box whose sides are defined by
+        the smallest/largest coordinate distance of the input ``sample1``.
+
+    sample_volume : float, optional
+        If period is set to None, you must specify the effective volume of the sample.
 
     u : float, optional
         density threshold in units of the mean object density
-    
+
     num_threads : int, optional
-        number of 'threads' to use in the pair counting.  if set to 'max', use all 
+        number of 'threads' to use in the pair counting.  if set to 'max', use all
         available cores.  num_threads=0 is the default.
-    
-    approx_cell1_size : array_like, optional 
-        Length-3 array serving as a guess for the optimal manner by which 
-        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree` 
-        will apportion the ``sample1`` points into subvolumes of the simulation box. 
-        The optimum choice unavoidably depends on the specs of your machine. 
-        Default choice is to use *max(rbins)* in each dimension, 
-        which will return reasonable result performance for most use-cases. 
-        Performance can vary sensitively with this parameter, so it is highly 
-        recommended that you experiment with this parameter when carrying out  
-        performance-critical calculations. 
-    
-    approx_cellran_size : array_like, optional 
-        Analogous to ``approx_cell1_size``, but for used for randoms.  See comments for 
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by which
+        the `~halotools.mock_observables.pair_counters.FlatRectanguloidDoubleTree`
+        will apportion the ``sample1`` points into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use *max(rbins)* in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cellran_size : array_like, optional
+        Analogous to ``approx_cell1_size``, but for used for randoms.  See comments for
         ``approx_cell1_size`` for details.
-    
+
     Returns
     -------
     upf : numpy.array
-        *len(rbins)* length array containing the underdensity probability function 
+        *len(rbins)* length array containing the underdensity probability function
         :math:`P_U(r)` computed for each :math:`r` defined by input ``rbins``.
-    
+
     Notes
     -----
-    This function requires the calculation of the number of pairs per randomly placed 
-    sphere, and thus storage of an array of shape(n_ran,len(rbins)).  This can be a 
+    This function requires the calculation of the number of pairs per randomly placed
+    sphere, and thus storage of an array of shape(n_ran,len(rbins)).  This can be a
     memory intensive process as this array becomes large.
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    periodic unit cube.
+
     >>> Npts = 10000
     >>> Lbox = 1.0
     >>> period = np.array([Lbox,Lbox,Lbox])
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
-    
-    We transform our *x, y, z* points into the array shape used by the pair-counter by 
-    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation 
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
     is used throughout the `~halotools.mock_observables` sub-package:
-    
+
     >>> coords = np.vstack((x,y,z)).T
-    
+
     >>> rbins = np.logspace(-2,-1,20)
     >>> n_ran = 1000
     >>> upf = underdensity_prob_func(coords, rbins, n_ran=n_ran, period=period, u=0.2)
 
-    See also 
+    See also
     ----------
     :ref:`galaxy_catalog_analysis_tutorial8`
     """
-    (sample1, rbins, n_ran, random_sphere_centers, period, 
+    (sample1, rbins, n_ran, random_sphere_centers, period,
         sample_volume, u, num_threads, approx_cell1_size, approx_cellran_size) = (
         _underdensity_prob_func_process_args(
-            sample1, rbins, n_ran, random_sphere_centers, 
-            period, sample_volume, u, 
+            sample1, rbins, n_ran, random_sphere_centers,
+            period, sample_volume, u,
             num_threads, approx_cell1_size, approx_cellran_size))
-    
+
     result = per_object_npairs(random_sphere_centers, sample1, rbins, period = period,\
                                num_threads = num_threads,\
                                approx_cell1_size = approx_cell1_size,\
                                approx_cell2_size = approx_cellran_size)
-    
+
     # calculate the number of galaxies as a
     # function of r that corresponds to the
     # specified under-density
@@ -268,7 +270,7 @@ def underdensity_prob_func(sample1, rbins, n_ran=None,
     N_max = mean_rho*vol*u
 
     num_underdense_spheres = np.array(
-        [sum(result[:,i] <= N_max[i]) for i in xrange(len(N_max))])
+        [sum(result[:,i] <= N_max[i]) for i in range(len(N_max))])
     return num_underdense_spheres/n_ran
 
 

--- a/halotools/sim_manager/__init__.py
+++ b/halotools/sim_manager/__init__.py
@@ -11,9 +11,9 @@ import os
 from astropy.config.paths import _find_home
 halotools_cache_dirname = os.path.join(_find_home(), '.astropy', 'cache', 'halotools')
 try:
-	os.makedirs(halotools_cache_dirname)
+    os.makedirs(halotools_cache_dirname)
 except OSError:
-	pass
+    pass
 
 from .supported_sims import *
 from .fake_sim import FakeSim

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -219,7 +219,7 @@ class CachedHaloCatalog(object):
             msg = ("\nCachedHaloCatalog only accepts keyword arguments, not position arguments. \n")
             raise HalotoolsError(msg)
 
-        for key in kwargs.keys():
+        for key in list(kwargs.keys()):
             try:
                 assert key in self.acceptable_kwargs
             except AssertionError:
@@ -541,10 +541,10 @@ class CachedHaloCatalog(object):
                 raise InvalidCacheLogEntry(self.log_entry._cache_safety_message)
 
     def _add_new_derived_columns(self, t):
-        if 'halo_hostid' not in t.keys():
+        if 'halo_hostid' not in list(t.keys()):
             add_halo_hostid(t)
 
-        if 'halo_mvir_host_halo' not in t.keys():
+        if 'halo_mvir_host_halo' not in list(t.keys()):
             broadcast_host_halo_property(t, 'halo_mvir')
 
     def _bind_additional_metadata(self):
@@ -556,7 +556,7 @@ class CachedHaloCatalog(object):
             raise InvalidCacheLogEntry(msg)
 
         f = self.h5py.File(self.log_entry.fname)
-        for attr_key in f.attrs.keys():
+        for attr_key in list(f.attrs.keys()):
             if attr_key == 'redshift':
                 setattr(self, attr_key, float(get_redshift_string(f.attrs[attr_key])))
             else:

--- a/halotools/sim_manager/download_manager.py
+++ b/halotools/sim_manager/download_manager.py
@@ -24,7 +24,7 @@ except ImportError:
     raise HalotoolsError("Must have requests package installed to use the DownloadManager")
 
 import posixpath
-import urlparse
+import urllib.parse
 
 import os, fnmatch, re
 
@@ -217,7 +217,7 @@ class DownloadManager(object):
             msg = ("\nThere already exists a halo catalog in your cache log with \n"
                 "specifications that exactly match your inputs.\n")
             if overwrite == False:
-                if 'initial_download_script_msg' in kwargs.keys():
+                if 'initial_download_script_msg' in list(kwargs.keys()):
                     msg = kwargs['initial_download_script_msg']
                     raise HalotoolsError(msg % output_fname)
                 else:
@@ -260,7 +260,7 @@ class DownloadManager(object):
         # initial download script (hidden feature for developers only)
         if (overwrite == False) & (os.path.isfile(output_fname)):
 
-            if 'initial_download_script_msg' in kwargs.keys():
+            if 'initial_download_script_msg' in list(kwargs.keys()):
                 msg = kwargs['initial_download_script_msg']
             else:
                 msg = ("The following filename already exists "
@@ -274,8 +274,8 @@ class DownloadManager(object):
         download_file_from_url(url, output_fname)
         end = time()
         runtime = (end - start)
-        print("\nTotal runtime to download pre-processed "
-            "halo catalog = %.1f seconds\n" % runtime)
+        print(("\nTotal runtime to download pre-processed "
+            "halo catalog = %.1f seconds\n" % runtime))
 
 
         # overwrite the fname metadata so that 
@@ -346,7 +346,7 @@ class DownloadManager(object):
                 "You can accomplish this with the ``update_cached_file_location``"
                 "method \nof the HaloTableCache class.\n\n")
 
-        if 'initial_download_script_msg' in kwargs.keys():
+        if 'initial_download_script_msg' in list(kwargs.keys()):
             return new_log_entry
         else:
             print(success_msg)
@@ -500,7 +500,7 @@ class DownloadManager(object):
             msg = ("\nThere already exists a particle catalog in your cache log with \n"
                 "specifications that exactly match your inputs.\n")
             if overwrite == False:
-                if 'initial_download_script_msg' in kwargs.keys():
+                if 'initial_download_script_msg' in list(kwargs.keys()):
                     msg = kwargs['initial_download_script_msg']
                     raise HalotoolsError(msg % output_fname)
                 else:
@@ -543,7 +543,7 @@ class DownloadManager(object):
         # initial download script (hidden feature for developers only)
         if (overwrite == False) & (os.path.isfile(output_fname)):
 
-            if 'initial_download_script_msg' in kwargs.keys():
+            if 'initial_download_script_msg' in list(kwargs.keys()):
                 msg = kwargs['initial_download_script_msg']
             else:
                 msg = ("The following filename already exists "
@@ -608,7 +608,7 @@ class DownloadManager(object):
                 "You can accomplish this with the ``update_cached_file_location``"
                 "method \nof the PtclTableCache class.\n\n")
         
-        if 'initial_download_script_msg' in kwargs.keys():
+        if 'initial_download_script_msg' in list(kwargs.keys()):
             return new_log_entry
         else:
             print(success_msg)
@@ -764,7 +764,7 @@ class DownloadManager(object):
         >>> webloc_closest_match = catman._closest_catalog_on_web(catalog_type='particles', simname='bolplanck', desired_redshift=0.5)  # doctest: +REMOTE_DATA
 
         """
-        if 'redshift' in kwargs.keys():
+        if 'redshift' in list(kwargs.keys()):
             msg = ("\nThe correct argument to use to specify the redshift \n"
                 "you are searching for is with the ``desired_redshift`` keyword, \n"
                 "not the ``redshift`` keyword.\n")
@@ -783,7 +783,7 @@ class DownloadManager(object):
                 raise HalotoolsError("\nIf input catalog_type is ``halos``, "
                     "must pass ``halo_finder`` argument")
         else:
-            if 'halo_finder' in kwargs.keys():
+            if 'halo_finder' in list(kwargs.keys()):
                 warn("There is no need to specify a halo-finder "
                     "when requesting particle data")
 
@@ -858,7 +858,7 @@ class DownloadManager(object):
         soup = BeautifulSoup(requests.get(baseurl).text)
         simloclist = []
         for a in soup.find_all('a', href=True):
-            dirpath = posixpath.dirname(urlparse.urlparse(a['href']).path)
+            dirpath = posixpath.dirname(urllib.parse.urlparse(a['href']).path)
             if dirpath and dirpath[0] != '/':
                 simloclist.append(baseurl + '/' + dirpath)
 
@@ -871,7 +871,7 @@ class DownloadManager(object):
         file_pattern = version_name
         all_ptcl_tables = fnmatch.filter(catlist, '*'+file_pattern + '*.hdf5')
 
-        if 'simname' in kwargs.keys():
+        if 'simname' in list(kwargs.keys()):
             simname = kwargs['simname']
             file_pattern = '*'+simname+'*'
             output = fnmatch.filter(all_ptcl_tables, file_pattern)
@@ -935,7 +935,7 @@ class DownloadManager(object):
         soup = BeautifulSoup(requests.get(baseurl).text)
         simloclist = []
         for a in soup.find_all('a', href=True):
-            dirpath = posixpath.dirname(urlparse.urlparse(a['href']).path)
+            dirpath = posixpath.dirname(urllib.parse.urlparse(a['href']).path)
             if dirpath and dirpath[0] != '/':
                 simloclist.append(baseurl + '/' + dirpath)
 
@@ -943,7 +943,7 @@ class DownloadManager(object):
         for simloc in simloclist:
             soup = BeautifulSoup(requests.get(simloc).text)
             for a in soup.find_all('a', href=True):
-                dirpath = posixpath.dirname(urlparse.urlparse(a['href']).path)
+                dirpath = posixpath.dirname(urllib.parse.urlparse(a['href']).path)
                 if dirpath and dirpath[0] != '/':
                     halocatloclist.append(simloc + '/' + dirpath)
 
@@ -959,16 +959,16 @@ class DownloadManager(object):
         # all_halocats a list of all pre-processed catalogs on the web
         # Now we apply our filter, if applicable
 
-        if ('simname' in kwargs.keys()) & ('halo_finder' in kwargs.keys()):
+        if ('simname' in list(kwargs.keys())) & ('halo_finder' in list(kwargs.keys())):
             simname = kwargs['simname']
             halo_finder = kwargs['halo_finder']
             file_pattern = '*'+simname+'/'+halo_finder+'/*' + file_pattern
             output = fnmatch.filter(all_halocats, file_pattern)
-        elif 'simname' in kwargs.keys():
+        elif 'simname' in list(kwargs.keys()):
             simname = kwargs['simname']
             file_pattern = '*'+simname+'/*' + file_pattern
             output = fnmatch.filter(all_halocats, file_pattern)
-        elif 'halo_finder' in kwargs.keys():
+        elif 'halo_finder' in list(kwargs.keys()):
             halo_finder = kwargs['halo_finder']
             file_pattern = '*/' + halo_finder + '/*' + file_pattern
             output = fnmatch.filter(all_halocats, file_pattern)

--- a/halotools/sim_manager/halo_table_cache.py
+++ b/halotools/sim_manager/halo_table_cache.py
@@ -137,7 +137,7 @@ class HaloTableCache(object):
 
         for entry in self.log:
             yield_entry = True
-            for key in kwargs.keys():
+            for key in list(kwargs.keys()):
                 if key == 'redshift':
                     requested_redshift = float(kwargs[key])
                     redshift_of_entry = float(getattr(entry, key))

--- a/halotools/sim_manager/halo_table_cache.py
+++ b/halotools/sim_manager/halo_table_cache.py
@@ -1,15 +1,14 @@
 import os
-from copy import copy, deepcopy
-from astropy.config.paths import _find_home
+from copy import copy
 from astropy.table import Table
 from warnings import warn
-import numpy as np 
+import numpy as np
 
 try:
     import h5py
 except ImportError:
     warn("Some of the functionality of the HaloTableCache class"
-        "requires h5py to be installed.")
+         "requires h5py to be installed.")
 
 from .halo_table_cache_log_entry import HaloTableCacheLogEntry
 
@@ -18,65 +17,66 @@ from ..custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 
 __all__ = ('HaloTableCache', )
 
-class HaloTableCache(object):
-    """ Object providing a collection of halo catalogs for use with Halotools. 
-    """ 
 
-    def __init__(self, read_log_from_standard_loc = True, **kwargs):
+class HaloTableCache(object):
+    """ Object providing a collection of halo catalogs for use with Halotools.
+    """
+
+    def __init__(self, read_log_from_standard_loc=True, **kwargs):
         self._standard_log_dirname = halotools_cache_dirname
         try:
             os.makedirs(os.path.dirname(self._standard_log_dirname))
         except OSError:
             pass
         self._standard_log_fname = os.path.join(self._standard_log_dirname, 'halo_table_cache_log.txt')
-        
+
         try:
             self.cache_log_fname = kwargs['cache_log_fname']
         except KeyError:
             self.cache_log_fname = copy(self._standard_log_fname)
         self._cache_log_fname_exists = os.path.isfile(self.cache_log_fname)
-        
-        if read_log_from_standard_loc == True:
+
+        if read_log_from_standard_loc is True:
             self.log = self.retrieve_log_from_ascii()
         else:
             self.log = []
-        
+
     def _overwrite_log_ascii(self, new_log):
         new_log.sort()
         log_table = self._log_table_from_log(new_log)
         log_table.write(self.cache_log_fname, format='ascii')
-        
+
     def _clean_log_of_repeated_entries(self, input_log):
         cleaned_log = list(set(input_log))
-        
+
         if len(cleaned_log) < len(input_log):
             msg = ("Detected multiple entries of the "
                 "halo table cache log with identical entries.\n"
                 "This is harmless. The log will be now be cleaned.\n")
             warn(msg)
             self._overwrite_log_ascii(cleaned_log)
-        
+
         return cleaned_log
-        
+
     def update_log_from_current_ascii(self):
         self.log = self.retrieve_log_from_ascii()
 
     def retrieve_log_from_ascii(self):
-        """ Read '$HOME/.astropy/cache/halotools/halo_table_cache_log.txt', 
-        clean the log of any repeated entries, sort the log, and return the resulting 
-        list of `~halotools.sim_manager.HaloTableCacheLogEntry` instances. 
+        """ Read '$HOME/.astropy/cache/halotools/halo_table_cache_log.txt',
+        clean the log of any repeated entries, sort the log, and return the resulting
+        list of `~halotools.sim_manager.HaloTableCacheLogEntry` instances.
         """
-        
+
         log_table = self._read_log_table_from_ascii()
         log_inferred_from_ascii = self._log_from_log_table(log_table)
         cleaned_log = self._clean_log_of_repeated_entries(log_inferred_from_ascii)
         cleaned_log.sort()
         return cleaned_log
-        
+
     def _read_log_table_from_ascii(self):
-            
+
         self._cache_log_fname_exists = os.path.isfile(self.cache_log_fname)
-        
+
         if self._cache_log_fname_exists:
             try:
                 log_table = Table.read(self.cache_log_fname, format='ascii')
@@ -88,9 +88,9 @@ class HaloTableCache(object):
                 self._cache_log_fname_is_kosher = False
         else:
             log_table = self._get_empty_log_table()
-        
+
         return log_table
-    
+
     def _log_from_log_table(self, log_table):
         result = []
         for entry in log_table:
@@ -99,29 +99,29 @@ class HaloTableCache(object):
             result.append(HaloTableCacheLogEntry(**constructor_kwargs))
         return result
 
-            
+
     def _log_table_from_log(self, log):
         log_table = self._get_empty_log_table(len(log))
         for ii, entry in enumerate(log):
             for attr in HaloTableCacheLogEntry.log_attributes:
                 log_table[attr][ii] = getattr(entry, attr)
         return log_table
-        
-    def _get_empty_log_table(self, num_entries = 0):
+
+    def _get_empty_log_table(self, num_entries=0):
         if num_entries == 0:
             return Table(
-                {'simname': [], 'halo_finder': [], 
-                'redshift': [], 'version_name': [], 
+                {'simname': [], 'halo_finder': [],
+                'redshift': [], 'version_name': [],
                 'fname': []}
                 )
         else:
-            return Table({'simname': np.zeros(num_entries, dtype=object), 
-                'halo_finder': np.zeros(num_entries, dtype=object), 
-                'redshift': np.zeros(num_entries, dtype=float), 
-                'version_name': np.zeros(num_entries, dtype=object), 
+            return Table({'simname': np.zeros(num_entries, dtype=object),
+                'halo_finder': np.zeros(num_entries, dtype=object),
+                'redshift': np.zeros(num_entries, dtype=float),
+                'version_name': np.zeros(num_entries, dtype=object),
                 'fname': np.zeros(num_entries, dtype=object)})
 
-    def matching_log_entry_generator(self, dz_tol = 0.0, **kwargs):
+    def matching_log_entry_generator(self, dz_tol=0.0, **kwargs):
         """
         """
 
@@ -144,14 +144,14 @@ class HaloTableCache(object):
                     yield_entry *=  abs(redshift_of_entry - requested_redshift) <= dz_tol
                 else:
                     yield_entry *= kwargs[key] == getattr(entry, key)
-            if yield_entry == True:
+            if yield_entry is True:
                 yield entry
 
-    def add_entry_to_cache_log(self, log_entry, update_ascii = True):
+    def add_entry_to_cache_log(self, log_entry, update_ascii=True):
         """
         """
         try:
-            import h5py 
+            import h5py
         except ImportError:
             msg = ("\nCannot add_entry_to_cache_log without h5py installed.\n")
             raise HalotoolsError(msg)
@@ -162,7 +162,7 @@ class HaloTableCache(object):
             msg = ("\nYou can only add instances of HaloTableCacheLogEntry to the cache log")
             raise TypeError(msg)
 
-        if log_entry.safe_for_cache == False:
+        if log_entry.safe_for_cache is False:
             raise InvalidCacheLogEntry(log_entry._cache_safety_message)
 
         self.log.append(log_entry)
@@ -170,72 +170,72 @@ class HaloTableCache(object):
             warn("The cache log already contains the entry")
         self.log = list(set(self.log))
         self.log.sort()
-        if update_ascii == True:
+        if update_ascii is True:
             self._overwrite_log_ascii(self.log)
 
-    def remove_entry_from_cache_log(self, simname, halo_finder, 
-        version_name, redshift, fname, 
-        raise_non_existence_exception = True, 
-        update_ascii = True, delete_corresponding_halo_catalog = False):
+    def remove_entry_from_cache_log(self, simname, halo_finder,
+        version_name, redshift, fname,
+        raise_non_existence_exception=True,
+        update_ascii=True, delete_corresponding_halo_catalog=False):
         """
-        If the log stores an entry matching the input metadata, the entry will be deleted and 
-        the ascii file storing the log will be updated. If there is no match, 
-        an exception will be raised according to the value of the input 
-        ``raise_non_existence_exception``.  
+        If the log stores an entry matching the input metadata, the entry will be deleted and
+        the ascii file storing the log will be updated. If there is no match,
+        an exception will be raised according to the value of the input
+        ``raise_non_existence_exception``.
 
-        Parameters 
+        Parameters
         -----------
-        simname : string 
-            Nickname of the simulation used as a shorthand way to keep track 
-            of the halo catalogs in your cache. The simnames processed by Halotools are 
-            'bolshoi', 'bolplanck', 'consuelo' and 'multidark'. 
+        simname : string
+            Nickname of the simulation used as a shorthand way to keep track
+            of the halo catalogs in your cache. The simnames processed by Halotools are
+            'bolshoi', 'bolplanck', 'consuelo' and 'multidark'.
 
-        halo_finder : string 
-            Nickname of the halo-finder, e.g., 'rockstar' or 'bdm'. 
+        halo_finder : string
+            Nickname of the halo-finder, e.g., 'rockstar' or 'bdm'.
 
-        version_name : string 
-            Nickname of the version of the halo catalog used to differentiate 
-            between the same halo catalog processed in different ways. 
+        version_name : string
+            Nickname of the version of the halo catalog used to differentiate
+            between the same halo catalog processed in different ways.
 
-        redshift : string or float  
-            Redshift of the halo catalog, rounded to 4 decimal places. 
+        redshift : string or float
+            Redshift of the halo catalog, rounded to 4 decimal places.
 
-        fname : string 
-            Name of the hdf5 file storing the table of halos. 
+        fname : string
+            Name of the hdf5 file storing the table of halos.
 
-        raise_non_existence_exception : bool, optional 
-            If True, an exception will be raised if this function is called 
-            and there is no matching entry in the log. Default is True. 
+        raise_non_existence_exception : bool, optional
+            If True, an exception will be raised if this function is called
+            and there is no matching entry in the log. Default is True.
 
-        delete_corresponding_halo_catalog : bool, optional 
-            If set to True, when the log entry is deleted, 
-            the corresponding hdf5 file will be deleted from your disk. 
-            Default is False. 
+        delete_corresponding_halo_catalog : bool, optional
+            If set to True, when the log entry is deleted,
+            the corresponding hdf5 file will be deleted from your disk.
+            Default is False.
         """
         try:
-            import h5py 
+            import h5py
         except ImportError:
             msg = ("\nCannot remove_entry_from_cache_log without h5py installed.\n")
             raise HalotoolsError(msg)
         ######################################################
-        # update_ascii kwarg is for unit-testing only 
+        # update_ascii kwarg is for unit-testing only
         # this feature is intentionally hidden from the docstring
-        if (update_ascii == False) & (delete_corresponding_halo_catalog == True):
+        if (update_ascii is False) & (delete_corresponding_halo_catalog is True):
             msg = ("\nIf ``delete_corresponding_halo_catalog`` is True, \n"
                 "``update_ascii`` must also be set to True.\n")
             raise HalotoolsError(msg)
         ######################################################
-        
-        log_entry = HaloTableCacheLogEntry(simname = simname, 
-            halo_finder = halo_finder, version_name = version_name, 
-            redshift = redshift, fname = fname)
+
+        log_entry = HaloTableCacheLogEntry(simname=simname,
+            halo_finder=halo_finder, version_name=version_name,
+            redshift=redshift, fname=fname)
 
         msg = ''
         try:
             self.log.remove(log_entry)
             _existing_log_entry_detected = True
 
-            if update_ascii == True:
+            if update_ascii is True:
                 self._overwrite_log_ascii(self.log)
                 msg += ("\nThe log has been updated on disk and in memory.\n")
             else:
@@ -244,9 +244,9 @@ class HaloTableCache(object):
                     "the update_ascii argument is set to False.\n")
 
         except ValueError:
-            _existing_log_entry_detected = False 
+            _existing_log_entry_detected = False
 
-            if raise_non_existence_exception == False:
+            if raise_non_existence_exception is False:
                 pass
             else:
                 msg += ("\nYou requested that the following entry "
@@ -263,7 +263,7 @@ class HaloTableCache(object):
                 raise HalotoolsError(msg)
 
 
-        if delete_corresponding_halo_catalog == True:
+        if delete_corresponding_halo_catalog is True:
             try:
                 os.remove(fname)
                 msg += (
@@ -283,19 +283,19 @@ class HaloTableCache(object):
         print(msg)
 
 
-    def determine_log_entry_from_fname(self, fname, overwrite_fname_metadata = False):
-        """ Method tries to construct a `~halotools.sim_manager.HaloTableCacheLogEntry` 
-        using the metadata that may be stored in the input file. An exception will be raised 
-        if the determination is not possible. 
+    def determine_log_entry_from_fname(self, fname, overwrite_fname_metadata=False):
+        """ Method tries to construct a `~halotools.sim_manager.HaloTableCacheLogEntry`
+        using the metadata that may be stored in the input file. An exception will be raised
+        if the determination is not possible.
 
-        Parameters 
+        Parameters
         -----------
-        fname : string 
-            Name of the file 
+        fname : string
+            Name of the file
 
-        Returns 
+        Returns
         ---------
-        log_entry : `~halotools.sim_manager.HaloTableCacheLogEntry` instance 
+        log_entry : `~halotools.sim_manager.HaloTableCacheLogEntry` instance
         """
         try:
             import h5py
@@ -321,7 +321,7 @@ class HaloTableCache(object):
             missing_metadata = required_set - actual_set
             msg = ("The hdf5 file is missing the following metadata:\n")
             for elt in missing_metadata:
-                msg += "``"+elt + "``\n"
+                msg += "``" + elt + "``\n"
             msg += "\n"
             return str(msg)
         finally:
@@ -331,26 +331,34 @@ class HaloTableCache(object):
                 pass
 
         f = h5py.File(fname)
-        constructor_kwargs = ({key: f.attrs[key] 
-            for key in HaloTableCacheLogEntry.log_attributes})
-        if overwrite_fname_metadata == True:
+        constructor_kwargs = {}
+
+        # We need to get rid of the byte attributes here to avoid failures
+        # later in the definition of PtclTableCacheLogEntry.__lt__
+        for key in HaloTableCacheLogEntry.log_attributes:
+            try:
+                constructor_kwargs[key] = f.attrs[key].decode()
+            except AttributeError:
+                constructor_kwargs[key] = f.attrs[key]
+
+        if overwrite_fname_metadata is True:
             constructor_kwargs['fname'] = fname
-            f.attrs['fname'] = fname 
+            f.attrs['fname'] = fname
         f.close()
 
         log_entry = HaloTableCacheLogEntry(**constructor_kwargs)
-            
+
         return log_entry
 
     def update_cached_file_location(self, new_fname, old_fname, **kwargs):
         """
-        Parameters 
+        Parameters
         -----------
-        new_fname : string 
-            Name of the new location of the file 
+        new_fname : string
+            Name of the new location of the file
 
-        old_fname : string 
-            Name of the old location of the file 
+        old_fname : string
+            Name of the old location of the file
         """
         try:
             import h5py
@@ -359,7 +367,7 @@ class HaloTableCache(object):
                 "to use the update_cached_file_location method. ")
 
         ######################################################
-        # update_ascii kwarg is for unit-testing only 
+        # update_ascii kwarg is for unit-testing only
         # this feature is intentionally hidden from the docstring
         try:
             update_ascii = kwargs['update_ascii']
@@ -368,29 +376,15 @@ class HaloTableCache(object):
         ######################################################
 
         new_log_entry = self.determine_log_entry_from_fname(
-            new_fname, overwrite_fname_metadata = True)
+            new_fname, overwrite_fname_metadata=True)
 
-        self.add_entry_to_cache_log(new_log_entry, update_ascii = update_ascii)
+        self.add_entry_to_cache_log(new_log_entry, update_ascii=update_ascii)
         self.remove_entry_from_cache_log(
-            simname = new_log_entry.simname, 
-            halo_finder = new_log_entry.halo_finder, 
-            version_name = new_log_entry.version_name, 
-            redshift = new_log_entry.redshift, 
-            fname = old_fname, 
-            raise_non_existence_exception = False, 
-            update_ascii = update_ascii, 
-            delete_corresponding_halo_catalog = False
-            )
-
-
-
-
-
-
-
-
-
-
-
-
-        
+            simname=new_log_entry.simname,
+            halo_finder=new_log_entry.halo_finder,
+            version_name=new_log_entry.version_name,
+            redshift=new_log_entry.redshift,
+            fname=old_fname,
+            raise_non_existence_exception=False,
+            update_ascii=update_ascii,
+            delete_corresponding_halo_catalog=False)

--- a/halotools/sim_manager/halo_table_cache.py
+++ b/halotools/sim_manager/halo_table_cache.py
@@ -144,7 +144,7 @@ class HaloTableCache(object):
                     yield_entry *=  abs(redshift_of_entry - requested_redshift) <= dz_tol
                 else:
                     yield_entry *= kwargs[key] == getattr(entry, key)
-            if yield_entry is True:
+            if bool(yield_entry) is True:
                 yield entry
 
     def add_entry_to_cache_log(self, log_entry, update_ascii=True):

--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -256,7 +256,7 @@ class HaloTableCacheLogEntry(object):
 
         try:
             data = Table.read(self.fname, path='data')
-            for key in data.keys():
+            for key in list(data.keys()):
                 try:
                     assert key[0:5] == 'halo_'
                 except AssertionError:
@@ -276,7 +276,7 @@ class HaloTableCacheLogEntry(object):
 
         try:
             data = Table.read(self.fname, path='data')
-            keys = data.keys()
+            keys = list(data.keys())
             try:
                 assert 'halo_x' in keys
                 assert 'halo_y' in keys

--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -1,17 +1,18 @@
-from collections import OrderedDict
 import os
-from astropy.table import Table 
-import numpy as np 
+from astropy.table import Table
+import numpy as np
 
-from ..custom_exceptions import InvalidCacheLogEntry, HalotoolsError
+from ..custom_exceptions import HalotoolsError
 
 __all__ = ('HaloTableCacheLogEntry', )
+
 
 def get_redshift_string(redshift):
     return str('{0:.4f}'.format(float(redshift)))
 
+
 class HaloTableCacheLogEntry(object):
-    """ Object serving as an entry in the `~halotools.sim_manager.HaloTableCache`. 
+    """ Object serving as an entry in the `~halotools.sim_manager.HaloTableCache`.
     """
 
     log_attributes = ['simname', 'halo_finder', 'version_name', 'redshift', 'fname']
@@ -20,36 +21,36 @@ class HaloTableCacheLogEntry(object):
 
     def __init__(self, simname, halo_finder, version_name, redshift, fname):
         """
-        Parameters 
+        Parameters
         -----------
-        simname : string 
-            Nickname of the simulation used as a shorthand way to keep track 
-            of the halo catalogs in your cache. The simnames processed by Halotools are 
-            'bolshoi', 'bolplanck', 'consuelo' and 'multidark'. 
+        simname : string
+            Nickname of the simulation used as a shorthand way to keep track
+            of the halo catalogs in your cache. The simnames processed by Halotools are
+            'bolshoi', 'bolplanck', 'consuelo' and 'multidark'.
 
-        halo_finder : string 
-            Nickname of the halo-finder, e.g., 'rockstar' or 'bdm'. 
+        halo_finder : string
+            Nickname of the halo-finder, e.g., 'rockstar' or 'bdm'.
 
-        version_name : string 
-            Nickname of the version of the halo catalog used to differentiate 
-            between the same halo catalog processed in different ways. 
+        version_name : string
+            Nickname of the version of the halo catalog used to differentiate
+            between the same halo catalog processed in different ways.
 
-        redshift : string or float  
-            Redshift of the halo catalog, rounded to 4 decimal places. 
+        redshift : string or float
+            Redshift of the halo catalog, rounded to 4 decimal places.
 
-        fname : string 
-            Name of the hdf5 file storing the table of halos. 
+        fname : string
+            Name of the hdf5 file storing the table of halos.
 
-        Notes 
+        Notes
         ------
-        This class overrides the python built-in comparison functions __eq__, __lt__, etc. 
-        Equality holds only if all of the five constructor inputs are equal. 
-        Two class instances are compared by using a dictionary order 
-        defined by the same sequence as the constructor input positional arguments. 
+        This class overrides the python built-in comparison functions __eq__, __lt__, etc.
+        Equality holds only if all of the five constructor inputs are equal.
+        Two class instances are compared by using a dictionary order
+        defined by the same sequence as the constructor input positional arguments.
 
-        See also 
+        See also
         ----------
-        `~halotools.sim_manager.tests.TestHaloTableCacheLogEntry`. 
+        `~halotools.sim_manager.tests.TestHaloTableCacheLogEntry`.
         """
         try:
             import h5py
@@ -64,10 +65,10 @@ class HaloTableCacheLogEntry(object):
         self.version_name = version_name
         self.redshift = get_redshift_string(redshift)
         self.fname = fname
-    
+
     def __eq__(self, other):
         if type(other) is type(self):
-            comparison_generator = (getattr(self, attr) == getattr(other, attr) 
+            comparison_generator = (getattr(self, attr) == getattr(other, attr)
                 for attr in HaloTableCacheLogEntry.log_attributes)
             return False not in tuple(comparison_generator)
         else:
@@ -96,7 +97,7 @@ class HaloTableCacheLogEntry(object):
     def __hash__(self):
         return hash(self._key)
 
-    def __str__(self): 
+    def __str__(self):
 
         msg = "("
         for attr in HaloTableCacheLogEntry.log_attributes:
@@ -106,48 +107,48 @@ class HaloTableCacheLogEntry(object):
 
     @property
     def _key(self):
-        """ Private property needed for the python built-in ``set`` 
-        function to operate properly with the custom-defined 
-        comparison methods. 
+        """ Private property needed for the python built-in ``set``
+        function to operate properly with the custom-defined
+        comparison methods.
         """
-        return (type(self), self.simname, 
-            self.halo_finder, self.version_name, 
+        return (type(self), self.simname,
+            self.halo_finder, self.version_name,
             self.redshift, self.fname)
 
-    @property 
+    @property
     def safe_for_cache(self):
-        """ Boolean determining whether the 
-        `~halotools.sim_manager.HaloTableCacheLogEntry` instance stores a valid 
-        halo catalog that can safely be added to the cache for future use. 
-        `safe_for_cache` is implemented as a property method, so that each request 
-        performs all the checks from scratch. A log entry is considered valid 
+        """ Boolean determining whether the
+        `~halotools.sim_manager.HaloTableCacheLogEntry` instance stores a valid
+        halo catalog that can safely be added to the cache for future use.
+        `safe_for_cache` is implemented as a property method, so that each request
+        performs all the checks from scratch. A log entry is considered valid
         if it passes the following tests:
 
-        1. The file exists. 
+        1. The file exists.
 
-        2. The filename has .hdf5 extension. 
+        2. The filename has .hdf5 extension.
 
-        3. The hdf5 file has ``simname``, ``halo_finder``, ``version_name``, ``redshift``, ``fname``, ``Lbox`` and ``particle_mass`` metadata attributes. 
+        3. The hdf5 file has ``simname``, ``halo_finder``, ``version_name``, ``redshift``, ``fname``, ``Lbox`` and ``particle_mass`` metadata attributes.
 
-        4. Each value in the above metadata is consistent with the corresponding value bound to the `~halotools.sim_manager.HaloTableCacheLogEntry` instance. 
+        4. Each value in the above metadata is consistent with the corresponding value bound to the `~halotools.sim_manager.HaloTableCacheLogEntry` instance.
 
-        5. The halo table data can be read in using the `~astropy.table.Table.read` method of the `~astropy.table.Table` class. 
+        5. The halo table data can be read in using the `~astropy.table.Table.read` method of the `~astropy.table.Table` class.
 
         6. The halo table has the following columns ``halo_id``, ``halo_x``, ``halo_y``, ``halo_z``, plus at least one additional column storing a mass-like variable.
 
-        7. The name of each column of the halo table begins with the substring ``halo_``. 
+        7. The name of each column of the halo table begins with the substring ``halo_``.
 
-        8. Values for each of the ``halo_x``, ``halo_y``, ``halo_z`` columns are all in the range [0, Lbox]. 
+        8. Values for each of the ``halo_x``, ``halo_y``, ``halo_z`` columns are all in the range [0, Lbox].
 
-        9. The ``halo_id`` column stores a set of unique integers. 
+        9. The ``halo_id`` column stores a set of unique integers.
 
-        Note in particular that `safe_for_cache` performs no checks whatsoever concerning 
-        the log other entries that may or may not be stored in the cache. Such checks are 
-        the responsibility of the `~halotools.sim_manager.HaloTableCache` class. 
+        Note in particular that `safe_for_cache` performs no checks whatsoever concerning
+        the log other entries that may or may not be stored in the cache. Such checks are
+        the responsibility of the `~halotools.sim_manager.HaloTableCache` class.
 
         """
         try:
-            import h5py 
+            import h5py
         except ImportError:
             msg = ("\nCannot determine whether an hdf5 file "
                 "is safe_for_cache without h5py installed.\n")
@@ -165,23 +166,23 @@ class HaloTableCacheLogEntry(object):
             return False
         else:
 
-            verification_sequence = ('_verify_h5py_extension', 
-                '_verify_hdf5_has_complete_metadata', 
-                '_verify_metadata_consistency', 
-                '_verify_table_read', 
-                '_verify_has_required_data_columns', 
-                '_verify_all_keys_begin_with_halo', 
-                '_verify_all_positions_inside_box', 
-                '_verify_halo_ids_are_unique', 
+            verification_sequence = ('_verify_h5py_extension',
+                '_verify_hdf5_has_complete_metadata',
+                '_verify_metadata_consistency',
+                '_verify_table_read',
+                '_verify_has_required_data_columns',
+                '_verify_all_keys_begin_with_halo',
+                '_verify_all_positions_inside_box',
+                '_verify_halo_ids_are_unique',
                 '_verify_halo_rvir_mpc_units')
 
             for verification_function in verification_sequence:
                 func = getattr(self, verification_function)
                 tmp_msg, num_failures = func(num_failures)
                 msg += tmp_msg
-            
+
             if num_failures > 0: self._cache_safety_message = message_preamble + msg
-                
+
             self._num_failures = num_failures
             return num_failures == 0
 
@@ -202,23 +203,27 @@ class HaloTableCacheLogEntry(object):
 
 
     def _verify_metadata_consistency(self, num_failures):
-        """ Enforce that the hdf5 metadata agrees with the 
-        values in the log entry. 
+        """ Enforce that the hdf5 metadata agrees with the
+        values in the log entry.
 
-        Note that we actually accept floats for the redshift hdf5 metadata, 
-        even though this should technically be a string. 
+        Note that we actually accept floats for the redshift hdf5 metadata,
+        even though this should technically be a string.
         """
         msg = ''
 
         try:
             f = self.h5py.File(self.fname)
-            
+
             for key in HaloTableCacheLogEntry.log_attributes:
                 try:
-
                     metadata = f.attrs[key]
                     if key != 'redshift':
-                        assert metadata == getattr(self, key)
+                        # In python3 some of the metadata are stored as
+                        # bytes rather than strings, check for both
+                        try:
+                            assert metadata == getattr(self, key)
+                        except AssertionError:
+                            assert metadata == getattr(self, key).encode('ascii')
                     else:
                         metadata = float(get_redshift_string(metadata))
                         assert metadata == float(getattr(self, key))
@@ -236,7 +241,7 @@ class HaloTableCacheLogEntry(object):
 
                     pass
         except IOError:
-            
+
             pass
 
         finally:
@@ -267,7 +272,7 @@ class HaloTableCacheLogEntry(object):
         except:
             pass
 
-        return msg, num_failures 
+        return msg, num_failures
 
     def _verify_has_required_data_columns(self, num_failures):
         """
@@ -293,7 +298,7 @@ class HaloTableCacheLogEntry(object):
         except:
             pass
 
-        return msg, num_failures 
+        return msg, num_failures
 
     def _verify_all_positions_inside_box(self, num_failures):
         """
@@ -326,7 +331,7 @@ class HaloTableCacheLogEntry(object):
         except:
             pass
 
-        return msg, num_failures 
+        return msg, num_failures
 
     def _verify_halo_ids_are_unique(self, num_failures):
         """
@@ -347,7 +352,7 @@ class HaloTableCacheLogEntry(object):
         except:
             pass
 
-        return msg, num_failures 
+        return msg, num_failures
 
     def _verify_file_exists(self):
         """
@@ -375,8 +380,8 @@ class HaloTableCacheLogEntry(object):
         return msg, num_failures
 
     def _verify_halo_rvir_mpc_units(self, num_failures):
-        """ Require that all values stored in the halo_rvir column 
-        are less than 50, a crude way to ensure that units are not kpc. 
+        """ Require that all values stored in the halo_rvir column
+        are less than 50, a crude way to ensure that units are not kpc.
         """
         msg = ''
 
@@ -394,7 +399,7 @@ class HaloTableCacheLogEntry(object):
         except:
             pass
 
-        return msg, num_failures 
+        return msg, num_failures
 
     def _verify_hdf5_has_complete_metadata(self, num_failures):
         """
@@ -411,7 +416,7 @@ class HaloTableCacheLogEntry(object):
             else:
                 missing_metadata = required_set - actual_set
                 num_failures += 1
-                msg += (str(num_failures) + 
+                msg += (str(num_failures) +
                     ". The hdf5 file is missing the following metadata:\n")
                 for elt in missing_metadata:
                     msg += "``"+elt + "``\n"
@@ -419,7 +424,7 @@ class HaloTableCacheLogEntry(object):
 
         except IOError:
             num_failures += 1
-            msg += (str(num_failures) + 
+            msg += (str(num_failures) +
                 ". Attempting to access the hdf5 metadata raised an exception.\n\n")
             pass
 

--- a/halotools/sim_manager/ptcl_table_cache.py
+++ b/halotools/sim_manager/ptcl_table_cache.py
@@ -130,7 +130,7 @@ class PtclTableCache(object):
 
         for entry in self.log:
             yield_entry = True
-            for key in kwargs.keys():
+            for key in list(kwargs.keys()):
                 if key == 'redshift':
                     requested_redshift = float(kwargs[key])
                     redshift_of_entry = float(getattr(entry, key))

--- a/halotools/sim_manager/ptcl_table_cache.py
+++ b/halotools/sim_manager/ptcl_table_cache.py
@@ -1,9 +1,8 @@
 import os
 from copy import copy
-from astropy.config.paths import _find_home
 from astropy.table import Table
 from warnings import warn
-import numpy as np 
+import numpy as np
 
 from .ptcl_table_cache_log_entry import PtclTableCacheLogEntry
 
@@ -12,25 +11,27 @@ from ..custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 
 __all__ = ('PtclTableCache', )
 
-class PtclTableCache(object):
-    """ Object providing a collection of particle catalogs for use with Halotools. 
-    """ 
 
-    def __init__(self, read_log_from_standard_loc = True, **kwargs):
+class PtclTableCache(object):
+    """ Object providing a collection of particle catalogs for use with Halotools.
+    """
+
+    def __init__(self, read_log_from_standard_loc=True, **kwargs):
         self._standard_log_dirname = halotools_cache_dirname
         try:
             os.makedirs(os.path.dirname(self._standard_log_dirname))
         except OSError:
             pass
-        self._standard_log_fname = os.path.join(self._standard_log_dirname, 'ptcl_table_cache_log.txt')
-        
+        self._standard_log_fname = os.path.join(self._standard_log_dirname,
+                                                'ptcl_table_cache_log.txt')
+
         try:
             self.cache_log_fname = kwargs['cache_log_fname']
         except KeyError:
             self.cache_log_fname = copy(self._standard_log_fname)
         self._cache_log_fname_exists = os.path.isfile(self.cache_log_fname)
-        
-        if read_log_from_standard_loc == True:
+
+        if read_log_from_standard_loc is True:
             self.log = self.retrieve_log_from_ascii()
         else:
             self.log = []
@@ -42,35 +43,35 @@ class PtclTableCache(object):
         new_log.sort()
         log_table = self._log_table_from_log(new_log)
         log_table.write(self.cache_log_fname, format='ascii')
-        
+
     def _clean_log_of_repeated_entries(self, input_log):
         cleaned_log = list(set(input_log))
-        
+
         if len(cleaned_log) < len(input_log):
             msg = ("Detected multiple entries of the "
-                "particle table cache log with identical entries.\n"
-                "This is harmless. The log will be now be cleaned.\n")
+                   "particle table cache log with identical entries.\n"
+                   "This is harmless. The log will be now be cleaned.\n")
             warn(msg)
             self._overwrite_log_ascii(cleaned_log)
-        
+
         return cleaned_log
-        
+
     def retrieve_log_from_ascii(self):
-        """ Read '$HOME/.astropy/cache/halotools/ptcl_table_cache_log.txt', 
-        clean the log of any repeated entries, sort the log, and return the resulting 
-        list of `~halotools.sim_manager.PtclTableCacheLogEntry` instances. 
+        """ Read '$HOME/.astropy/cache/halotools/ptcl_table_cache_log.txt',
+        clean the log of any repeated entries, sort the log, and return the resulting
+        list of `~halotools.sim_manager.PtclTableCacheLogEntry` instances.
         """
-        
+
         log_table = self._read_log_table_from_ascii()
         log_inferred_from_ascii = self._log_from_log_table(log_table)
         cleaned_log = self._clean_log_of_repeated_entries(log_inferred_from_ascii)
         cleaned_log.sort()
         return cleaned_log
-        
+
     def _read_log_table_from_ascii(self):
-            
+
         self._cache_log_fname_exists = os.path.isfile(self.cache_log_fname)
-        
+
         if self._cache_log_fname_exists:
             try:
                 log_table = Table.read(self.cache_log_fname, format='ascii')
@@ -82,9 +83,9 @@ class PtclTableCache(object):
                 self._cache_log_fname_is_kosher = False
         else:
             log_table = self._get_empty_log_table()
-        
+
         return log_table
-    
+
     def _log_from_log_table(self, log_table):
         result = []
         for entry in log_table:
@@ -93,28 +94,27 @@ class PtclTableCache(object):
             result.append(PtclTableCacheLogEntry(**constructor_kwargs))
         return result
 
-            
     def _log_table_from_log(self, log):
         log_table = self._get_empty_log_table(len(log))
         for ii, entry in enumerate(log):
             for attr in PtclTableCacheLogEntry.log_attributes:
                 log_table[attr][ii] = getattr(entry, attr)
         return log_table
-        
-    def _get_empty_log_table(self, num_entries = 0):
+
+    def _get_empty_log_table(self, num_entries=0):
         if num_entries == 0:
             return Table(
-                {'simname': [], 
-                'redshift': [], 'version_name': [], 
-                'fname': []}
+                {'simname': [],
+                 'redshift': [], 'version_name': [],
+                 'fname': []}
                 )
         else:
-            return Table({'simname': np.zeros(num_entries, dtype=object), 
-                'redshift': np.zeros(num_entries, dtype=float), 
-                'version_name': np.zeros(num_entries, dtype=object), 
-                'fname': np.zeros(num_entries, dtype=object)})
+            return Table({'simname': np.zeros(num_entries, dtype=object),
+                          'redshift': np.zeros(num_entries, dtype=float),
+                          'version_name': np.zeros(num_entries, dtype=object),
+                          'fname': np.zeros(num_entries, dtype=object)})
 
-    def matching_log_entry_generator(self, dz_tol = 0.0, **kwargs):
+    def matching_log_entry_generator(self, dz_tol=0.0, **kwargs):
         """
         """
 
@@ -137,10 +137,10 @@ class PtclTableCache(object):
                     yield_entry *=  abs(redshift_of_entry - requested_redshift) <= dz_tol
                 else:
                     yield_entry *= kwargs[key] == getattr(entry, key)
-            if yield_entry == True:
+            if yield_entry is True:
                 yield entry
 
-    def add_entry_to_cache_log(self, log_entry, update_ascii = True):
+    def add_entry_to_cache_log(self, log_entry, update_ascii=True):
         """
         """
 
@@ -150,7 +150,7 @@ class PtclTableCache(object):
             msg = ("You can only add instances of PtclTableCacheLogEntry to the cache log")
             raise TypeError(msg)
 
-        if log_entry.safe_for_cache == False:
+        if log_entry.safe_for_cache is False:
             raise InvalidCacheLogEntry(log_entry._cache_safety_message)
 
         if log_entry in self.log:
@@ -158,62 +158,63 @@ class PtclTableCache(object):
         else:
             self.log.append(log_entry)
             self.log.sort()
-            if update_ascii == True:
+            if update_ascii is True:
                 self._overwrite_log_ascii(self.log)
 
+    def remove_entry_from_cache_log(self, simname, version_name,
+                                    redshift, fname,
+                                    raise_non_existence_exception=True,
+                                    update_ascii=True,
+                                    delete_corresponding_ptcl_catalog=False):
 
-    def remove_entry_from_cache_log(self, simname, version_name, 
-        redshift, fname, 
-        raise_non_existence_exception = True, 
-        update_ascii = True, delete_corresponding_ptcl_catalog = False):
         """
-        If the log stores an entry matching the input metadata, the entry will be deleted and 
-        the ascii file storing the log will be updated. If there is no match, 
-        an exception will be raised according to the value of the input 
-        ``raise_non_existence_exception``.  
+        If the log stores an entry matching the input metadata, the entry
+        will be deleted and the ascii file storing the log will be
+        updated. If there is no match, an exception will be raised according
+        to the value of the input ``raise_non_existence_exception``.
 
-        Parameters 
+        Parameters
         -----------
-        simname : string 
-            Nickname of the simulation used as a shorthand way to keep track 
-            of the particle catalogs in your cache. The simnames processed by Halotools are 
-            'bolshoi', 'bolplanck', 'consuelo' and 'multidark'. 
+        simname : string
+            Nickname of the simulation used as a shorthand way to keep track
+            of the particle catalogs in your cache. The simnames processed by Halotools are
+            'bolshoi', 'bolplanck', 'consuelo' and 'multidark'.
 
-        version_name : string 
-            Nickname of the version of the particle catalog. 
+        version_name : string
+            Nickname of the version of the particle catalog.
 
-        redshift : string or float  
-            Redshift of the particle catalog, rounded to 4 decimal places. 
+        redshift : string or float
+            Redshift of the particle catalog, rounded to 4 decimal places.
 
-        fname : string 
-            Name of the hdf5 file storing the table of particles. 
+        fname : string
+            Name of the hdf5 file storing the table of particles.
 
-        raise_non_existence_exception : bool, optional 
-            If True, an exception will be raised if this function is called 
-            and there is no matching entry in the log. Default is True. 
+        raise_non_existence_exception : bool, optional
+            If True, an exception will be raised if this function is called
+            and there is no matching entry in the log. Default is True.
 
-        delete_corresponding_ptcl_catalog : bool, optional 
-            If set to True, when the log entry is deleted, 
-            the corresponding hdf5 file will be deleted from your disk. 
-            Default is False. 
+        delete_corresponding_ptcl_catalog : bool, optional
+            If set to True, when the log entry is deleted,
+            the corresponding hdf5 file will be deleted from your disk.
+            Default is False.
         """
         ######################################################
-        # update_ascii kwarg is for unit-testing only 
+        # update_ascii kwarg is for unit-testing only
         # this feature is intentionally hidden from the docstring
-        if (update_ascii == False) & (delete_corresponding_ptcl_catalog == True):
+        if (update_ascii is False) & (delete_corresponding_ptcl_catalog is True):
             msg = ("\nIf ``delete_corresponding_ptcl_catalog`` is True, \n"
                 "``update_ascii`` must also be set to True.\n")
             raise HalotoolsError(msg)
         ######################################################
 
-        log_entry = PtclTableCacheLogEntry(simname = simname, 
-            version_name = version_name, 
-            redshift = redshift, fname = fname)
+        log_entry = PtclTableCacheLogEntry(simname=simname,
+            version_name=version_name,
+            redshift=redshift, fname=fname)
 
         try:
             self.log.remove(log_entry)
 
-            if update_ascii == True:
+            if update_ascii is True:
                 self._overwrite_log_ascii(self.log)
                 msg = ("\nThe log has been updated on disk and in memory.\n")
             else:
@@ -221,7 +222,7 @@ class PtclTableCache(object):
                     "but not on disk because \n"
                     "the update_ascii argument is set to False.\n")
 
-            if delete_corresponding_ptcl_catalog == True:
+            if delete_corresponding_ptcl_catalog is True:
                 try:
                     os.remove(log_entry.fname)
                     msg += (
@@ -232,7 +233,7 @@ class PtclTableCache(object):
                     pass
 
         except ValueError:
-            if raise_non_existence_exception == False:
+            if raise_non_existence_exception is False:
                 pass
             else:
                 msg = ("\nYou requested that the following entry "
@@ -248,24 +249,25 @@ class PtclTableCache(object):
                 raise HalotoolsError(msg)
 
 
-    def determine_log_entry_from_fname(self, fname, overwrite_fname_metadata = False):
-        """ Method tries to construct a `~halotools.sim_manager.PtclTableCacheLogEntry` 
-        using the metadata that may be stored in the input file. An exception will be raised 
-        if the determination is not possible. 
+    def determine_log_entry_from_fname(self, fname, overwrite_fname_metadata=False):
+        """ Method tries to construct a `~halotools.sim_manager.PtclTableCacheLogEntry`
+        using the metadata that may be stored in the input file. An exception will be raised
+        if the determination is not possible.
 
-        Parameters 
+        Parameters
         -----------
-        fname : string 
-            Name of the file 
+        fname : string
+            Name of the file
 
-        Returns 
+        Returns
         ---------
-        log_entry : `~halotools.sim_manager.PtclTableCacheLogEntry` instance 
+        log_entry : `~halotools.sim_manager.PtclTableCacheLogEntry` instance
         """
         try:
             import h5py
         except ImportError:
-            raise HalotoolsError("Must have h5py package installed \n"
+            raise HalotoolsError(
+                "Must have h5py package installed \n"
                 "to use the determine_log_entry_from_fname method "
                 "of the PtclTableCache class.\n")
 
@@ -296,9 +298,17 @@ class PtclTableCache(object):
                 pass
 
         f = h5py.File(fname)
-        constructor_kwargs = ({key: f.attrs[key] 
-            for key in PtclTableCacheLogEntry.log_attributes})
-        if overwrite_fname_metadata == True:
+        constructor_kwargs = {}
+
+        # We need to get rid of the byte attributes here to avoid failures
+        # later in the definition of PtclTableCacheLogEntry.__lt__
+        for key in PtclTableCacheLogEntry.log_attributes:
+            try:
+                constructor_kwargs[key] = f.attrs[key].decode()
+            except AttributeError:
+                constructor_kwargs[key] = f.attrs[key]
+
+        if overwrite_fname_metadata is True:
             constructor_kwargs['fname'] = fname
             f.attrs['fname'] = fname
         log_entry = PtclTableCacheLogEntry(**constructor_kwargs)
@@ -307,17 +317,17 @@ class PtclTableCache(object):
 
     def update_cached_file_location(self, new_fname, old_fname, **kwargs):
         """
-        Parameters 
+        Parameters
         -----------
-        new_fname : string 
-            Name of the new location of the file 
+        new_fname : string
+            Name of the new location of the file
 
-        old_fname : string 
-            Name of the old location of the file 
+        old_fname : string
+            Name of the old location of the file
         """
 
         ######################################################
-        # update_ascii kwarg is for unit-testing only 
+        # update_ascii kwarg is for unit-testing only
         # this feature is intentionally hidden from the docstring
         try:
             update_ascii = kwargs['update_ascii']
@@ -326,18 +336,17 @@ class PtclTableCache(object):
         ######################################################
 
         new_log_entry = self.determine_log_entry_from_fname(
-            new_fname, overwrite_fname_metadata = True)
+            new_fname, overwrite_fname_metadata=True)
 
-        self.add_entry_to_cache_log(new_log_entry, update_ascii = update_ascii)
+        self.add_entry_to_cache_log(new_log_entry, update_ascii=update_ascii)
         self.remove_entry_from_cache_log(
-            simname = new_log_entry.simname, 
-            version_name = new_log_entry.version_name, 
-            redshift = new_log_entry.redshift, 
-            fname = old_fname, 
-            raise_non_existence_exception = False, 
-            update_ascii = update_ascii, 
-            delete_corresponding_ptcl_catalog = False
-            )
+            simname=new_log_entry.simname,
+            version_name=new_log_entry.version_name,
+            redshift=new_log_entry.redshift,
+            fname=old_fname,
+            raise_non_existence_exception=False,
+            update_ascii=update_ascii,
+            delete_corresponding_ptcl_catalog=False)
 
 
 
@@ -352,5 +361,3 @@ class PtclTableCache(object):
 
 
 
-
-        

--- a/halotools/sim_manager/ptcl_table_cache.py
+++ b/halotools/sim_manager/ptcl_table_cache.py
@@ -137,7 +137,7 @@ class PtclTableCache(object):
                     yield_entry *=  abs(redshift_of_entry - requested_redshift) <= dz_tol
                 else:
                     yield_entry *= kwargs[key] == getattr(entry, key)
-            if yield_entry is True:
+            if bool(yield_entry) is True:
                 yield entry
 
     def add_entry_to_cache_log(self, log_entry, update_ascii=True):

--- a/halotools/sim_manager/ptcl_table_cache_log_entry.py
+++ b/halotools/sim_manager/ptcl_table_cache_log_entry.py
@@ -229,7 +229,7 @@ class PtclTableCacheLogEntry(object):
         """
         try:
             data = Table.read(self.fname, path='data')
-            keys = data.keys()
+            keys = list(data.keys())
             try:
                 assert 'x' in keys
                 assert 'y' in keys

--- a/halotools/sim_manager/rockstar_hlist_reader.py
+++ b/halotools/sim_manager/rockstar_hlist_reader.py
@@ -663,19 +663,19 @@ class RockstarHlistReader(TabularAsciiReader):
             f.attrs.create('processing_notes', str(self.processing_notes))
 
         # Store all the choices for row cuts as metadata
-        for haloprop_key, cut_value in self.row_cut_min_dict.iteritems():
+        for haloprop_key, cut_value in self.row_cut_min_dict.items():
             attrname = haloprop_key + '_row_cut_min'
             f.attrs.create(attrname, cut_value)
 
-        for haloprop_key, cut_value in self.row_cut_max_dict.iteritems():
+        for haloprop_key, cut_value in self.row_cut_max_dict.items():
             attrname = haloprop_key + '_row_cut_max'
             f.attrs.create(attrname, cut_value)
 
-        for haloprop_key, cut_value in self.row_cut_eq_dict.iteritems():
+        for haloprop_key, cut_value in self.row_cut_eq_dict.items():
             attrname = haloprop_key + '_row_cut_eq'
             f.attrs.create(attrname, cut_value)
 
-        for haloprop_key, cut_value in self.row_cut_neq_dict.iteritems():
+        for haloprop_key, cut_value in self.row_cut_neq_dict.items():
             attrname = haloprop_key + '_row_cut_neq'
             f.attrs.create(attrname, cut_value)
 
@@ -695,7 +695,7 @@ class RockstarHlistReader(TabularAsciiReader):
         more flexible. 
         """
         ### Add the halo_nfw_conc column
-        if ('halo_rvir' in self.halo_table.keys()) & ('halo_rs' in self.halo_table.keys()):
+        if ('halo_rvir' in list(self.halo_table.keys())) & ('halo_rs' in list(self.halo_table.keys())):
             self.halo_table['halo_nfw_conc'] = (
                 self.halo_table['halo_rvir'] / self.halo_table['halo_rs']
                 )

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
-""" Module containing container classes for 
-the simulations provided by Halotools. 
-The attributes of the classes defined below 
-are used to attach metadata to the Halotools-provided 
-halo catalogs as they are loaded into memory. 
+""" Module containing container classes for
+the simulations provided by Halotools.
+The attributes of the classes defined below
+are used to attach metadata to the Halotools-provided
+halo catalogs as they are loaded into memory.
 """
-import numpy as np
-import os, sys, urllib.request, urllib.error, urllib.parse, fnmatch
-from warnings import warn 
-
 try:
     from bs4 import BeautifulSoup
     HAS_SOUP = True
@@ -21,66 +17,56 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
-import posixpath
-import urllib.parse
-
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta
 from astropy.extern import six
 from astropy import cosmology
-from astropy import units as u
-from astropy.table import Table
-
-from ..sim_manager import sim_defaults
-
-from ..utils.array_utils import find_idx_nearest_val
-from ..utils.array_utils import custom_len
 
 from ..custom_exceptions import *
 
 
-__all__ = ('NbodySimulation', 
-    'Bolshoi', 'BolPlanck', 'MultiDark', 'Consuelo')
+__all__ = ('NbodySimulation',
+           'Bolshoi', 'BolPlanck', 'MultiDark', 'Consuelo')
 
 supported_sim_list = ('bolshoi', 'bolplanck', 'consuelo', 'multidark')
 
 ######################################################
-########## Simulation classes defined below ########## 
+########## Simulation classes defined below ##########
 ######################################################
 
 @six.add_metaclass(ABCMeta)
 class NbodySimulation(object):
-    """ Abstract base class for any object used as a container for 
-    simulation specs. 
+    """ Abstract base class for any object used as a container for
+    simulation specs.
     """
 
-    def __init__(self, simname, Lbox, particle_mass, num_ptcl_per_dim, 
+    def __init__(self, simname, Lbox, particle_mass, num_ptcl_per_dim,
         softening_length, initial_redshift, cosmology):
         """
-        Parameters 
+        Parameters
         -----------
-        simname : string 
-            Nickname of the simulation. Currently supported simulations are 
-            Bolshoi  (simname = ``bolshoi``), Consuelo (simname = ``consuelo``), 
-            MultiDark (simname = ``multidark``), and Bolshoi-Planck (simname = ``bolplanck``). 
-            
+        simname : string
+            Nickname of the simulation. Currently supported simulations are
+            Bolshoi  (simname = ``bolshoi``), Consuelo (simname = ``consuelo``),
+            MultiDark (simname = ``multidark``), and Bolshoi-Planck (simname = ``bolplanck``).
+
         Lbox : float
-            Size of the simulated box in Mpc with h=1 units. 
+            Size of the simulated box in Mpc with h=1 units.
 
         particle_mass : float
-            Mass of the dark matter particles in Msun with h=1 units. 
+            Mass of the dark matter particles in Msun with h=1 units.
 
-        num_ptcl_per_dim : int 
-            Number of particles per dimension. 
+        num_ptcl_per_dim : int
+            Number of particles per dimension.
 
-        softening_length : float 
-            Softening scale of the particle interactions in kpc with h=1 units. 
+        softening_length : float
+            Softening scale of the particle interactions in kpc with h=1 units.
 
-        initial_redshift : float 
-            Redshift at which the initial conditions were generated. 
+        initial_redshift : float
+            Redshift at which the initial conditions were generated.
 
-        cosmology : object 
-            `astropy.cosmology` instance giving the cosmological parameters 
-            with which the simulation was run. 
+        cosmology : object
+            `astropy.cosmology` instance giving the cosmological parameters
+            with which the simulation was run.
 
         """
         self.simname = simname
@@ -97,35 +83,35 @@ class NbodySimulation(object):
             )
 
 class Bolshoi(NbodySimulation):
-    """ Cosmological N-body simulation of WMAP5 cosmology 
-    with Lbox = 250 Mpc/h and particle mass of ~1e8 Msun/h. 
+    """ Cosmological N-body simulation of WMAP5 cosmology
+    with Lbox = 250 Mpc/h and particle mass of ~1e8 Msun/h.
 
-    For a detailed description of the 
-    simulation specs, see http://www.cosmosim.org/cms/simulations/multidark-project/bolshoi. 
+    For a detailed description of the
+    simulation specs, see http://www.cosmosim.org/cms/simulations/multidark-project/bolshoi.
     """
 
     def __init__(self):
 
-        super(Bolshoi, self).__init__(simname = 'bolshoi', Lbox = 250., 
-            particle_mass = 1.35e8, num_ptcl_per_dim = 2048, 
+        super(Bolshoi, self).__init__(simname = 'bolshoi', Lbox = 250.,
+            particle_mass = 1.35e8, num_ptcl_per_dim = 2048,
             softening_length = 1., initial_redshift = 80., cosmology = cosmology.WMAP5)
 
         self.orig_ascii_web_location = (
             'http://www.slac.stanford.edu/~behroozi/Bolshoi_Catalogs/')
 
 class BolPlanck(NbodySimulation):
-    """ Cosmological N-body simulation of Planck 2013 cosmology 
-    with Lbox = 250 Mpc/h and 
-    particle mass of ~1e8 Msun/h. 
+    """ Cosmological N-body simulation of Planck 2013 cosmology
+    with Lbox = 250 Mpc/h and
+    particle mass of ~1e8 Msun/h.
 
-    For a detailed description of the 
-    simulation specs, see http://www.cosmosim.org/cms/simulations/bolshoip-project/bolshoip/. 
+    For a detailed description of the
+    simulation specs, see http://www.cosmosim.org/cms/simulations/bolshoip-project/bolshoip/.
     """
 
     def __init__(self):
 
-        super(BolPlanck, self).__init__(simname = 'bolplanck', Lbox = 250., 
-            particle_mass = 1.35e8, num_ptcl_per_dim = 2048, 
+        super(BolPlanck, self).__init__(simname = 'bolplanck', Lbox = 250.,
+            particle_mass = 1.35e8, num_ptcl_per_dim = 2048,
             softening_length = 1., initial_redshift = 80., cosmology = cosmology.Planck13)
 
         self.orig_ascii_web_location = (
@@ -133,34 +119,34 @@ class BolPlanck(NbodySimulation):
 
 
 class MultiDark(NbodySimulation):
-    """ Cosmological N-body simulation of WMAP5 cosmology 
-    with Lbox = 1Gpc/h and particle mass of ~1e10 Msun/h. 
+    """ Cosmological N-body simulation of WMAP5 cosmology
+    with Lbox = 1Gpc/h and particle mass of ~1e10 Msun/h.
 
-    For a detailed description of the 
-    simulation specs, see http://www.cosmosim.org/cms/simulations/multidark-project/mdr1. 
+    For a detailed description of the
+    simulation specs, see http://www.cosmosim.org/cms/simulations/multidark-project/mdr1.
     """
 
     def __init__(self):
 
-        super(MultiDark, self).__init__(simname = 'multidark', Lbox = 1000., 
-            particle_mass = 8.721e9, num_ptcl_per_dim = 2048, 
+        super(MultiDark, self).__init__(simname = 'multidark', Lbox = 1000.,
+            particle_mass = 8.721e9, num_ptcl_per_dim = 2048,
             softening_length = 7., initial_redshift = 65., cosmology = cosmology.WMAP5)
 
         self.orig_ascii_web_location = (
             'http://slac.stanford.edu/~behroozi/MultiDark_Hlists_Rockstar/')
 
 class Consuelo(NbodySimulation):
-    """ Cosmological N-body simulation of WMAP5-like cosmology 
-    with Lbox = 420 Mpc/h and particle mass of 4e8 Msun/h. 
+    """ Cosmological N-body simulation of WMAP5-like cosmology
+    with Lbox = 420 Mpc/h and particle mass of 4e8 Msun/h.
 
-    For a detailed description of the 
-    simulation specs, see http://lss.phy.vanderbilt.edu/lasdamas/simulations.html. 
+    For a detailed description of the
+    simulation specs, see http://lss.phy.vanderbilt.edu/lasdamas/simulations.html.
     """
 
     def __init__(self):
 
-        super(Consuelo, self).__init__(simname = 'consuelo', Lbox = 420., 
-            particle_mass = 1.87e9, num_ptcl_per_dim = 1400, 
+        super(Consuelo, self).__init__(simname = 'consuelo', Lbox = 420.,
+            particle_mass = 1.87e9, num_ptcl_per_dim = 1400,
             softening_length = 8., initial_redshift = 99., cosmology = cosmology.WMAP5)
 
         self.orig_ascii_web_location = (

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -6,7 +6,7 @@ are used to attach metadata to the Halotools-provided
 halo catalogs as they are loaded into memory. 
 """
 import numpy as np
-import os, sys, urllib2, fnmatch
+import os, sys, urllib.request, urllib.error, urllib.parse, fnmatch
 from warnings import warn 
 
 try:
@@ -22,7 +22,7 @@ except ImportError:
     HAS_REQUESTS = False
 
 import posixpath
-import urlparse
+import urllib.parse
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 from astropy.extern import six

--- a/halotools/sim_manager/tabular_ascii_reader.py
+++ b/halotools/sim_manager/tabular_ascii_reader.py
@@ -11,7 +11,7 @@ import collections
 from time import time
 import numpy as np
 
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 __all__ = ('TabularAsciiReader', )
 

--- a/halotools/sim_manager/tabular_ascii_reader.py
+++ b/halotools/sim_manager/tabular_ascii_reader.py
@@ -1,11 +1,9 @@
 """
-Module storing the TabularAsciiReader, a class providing a memory-efficient 
-algorithm for reading a very large ascii file that stores tabular data 
-of a data type that is known in advance. 
+Module storing the TabularAsciiReader, a class providing a memory-efficient
+algorithm for reading a very large ascii file that stores tabular data
+of a data type that is known in advance.
 
 """
-
-__all__ = ('TabularAsciiReader', )
 
 import os
 import gzip
@@ -13,148 +11,153 @@ import collections
 from time import time
 import numpy as np
 
+from astropy.extern.six import xrange as range
+
+__all__ = ('TabularAsciiReader', )
+
+
 class TabularAsciiReader(object):
     """
-    Class providing a memory-efficient algorithm for 
-    reading a very large ascii file that stores tabular data 
-    of a data type that is known in advance. 
+    Class providing a memory-efficient algorithm for
+    reading a very large ascii file that stores tabular data
+    of a data type that is known in advance.
 
-    When reading ASCII data with 
-    `~halotools.sim_manager.TabularAsciiReader.read_ascii`, user-defined 
-    cuts on columns are applied on-the-fly using a python generator 
-    to yield only those columns whose indices appear in the 
-    input ``columns_to_keep_dict``. 
+    When reading ASCII data with
+    `~halotools.sim_manager.TabularAsciiReader.read_ascii`, user-defined
+    cuts on columns are applied on-the-fly using a python generator
+    to yield only those columns whose indices appear in the
+    input ``columns_to_keep_dict``.
 
-    As the file is read, the data is generated in chunks, 
-    and a customizable mask is applied to each newly generated chunk. 
-    The only aggregated data from each chunk are those rows  
-    passing all requested cuts, so that the 
-    `~halotools.sim_manager.TabularAsciiReader` 
-    only requires you to have enough RAM to store the *cut* catalog, 
-    not the entire ASCII file. 
+    As the file is read, the data is generated in chunks,
+    and a customizable mask is applied to each newly generated chunk.
+    The only aggregated data from each chunk are those rows
+    passing all requested cuts, so that the
+    `~halotools.sim_manager.TabularAsciiReader`
+    only requires you to have enough RAM to store the *cut* catalog,
+    not the entire ASCII file.
 
-    The primary method of the class is  
-    `~halotools.sim_manager.TabularAsciiReader.read_ascii`. 
-    The output of this method is a structured Numpy array, 
-    which can then be stored in your preferred binary format 
-    using the built-in Numpy methods, h5py, etc. If you wish to 
-    store the catalog in the Halotools cache, you should instead 
-    use the `~halotools.sim_manager.RockstarHlistReader` class. 
+    The primary method of the class is
+    `~halotools.sim_manager.TabularAsciiReader.read_ascii`.
+    The output of this method is a structured Numpy array,
+    which can then be stored in your preferred binary format
+    using the built-in Numpy methods, h5py, etc. If you wish to
+    store the catalog in the Halotools cache, you should instead
+    use the `~halotools.sim_manager.RockstarHlistReader` class.
 
-    The algorithm assumes that data of known, unchanging type is 
-    arranged in a consecutive sequence of lines within the ascii file, 
-    that the data stream begins with the first line that is not the ``header_char``, 
-    and that the first subsequent appearance of an empty line demarcates the end 
-    of the data stream. 
+    The algorithm assumes that data of known, unchanging type is
+    arranged in a consecutive sequence of lines within the ascii file,
+    that the data stream begins with the first line that is not the ``header_char``,
+    and that the first subsequent appearance of an empty line demarcates the end
+    of the data stream.
     """
-    def __init__(self, input_fname, columns_to_keep_dict, 
-        header_char='#', row_cut_min_dict = {}, row_cut_max_dict = {}, 
+    def __init__(self, input_fname, columns_to_keep_dict,
+        header_char='#', row_cut_min_dict = {}, row_cut_max_dict = {},
         row_cut_eq_dict = {}, row_cut_neq_dict = {}):
         """
-        Parameters 
+        Parameters
         -----------
-        input_fname : string 
-            Absolute path to the file storing the ASCII data. 
+        input_fname : string
+            Absolute path to the file storing the ASCII data.
 
-        columns_to_keep_dict : dict 
-            Dictionary used to define which columns 
+        columns_to_keep_dict : dict
+            Dictionary used to define which columns
             of the tabular ASCII data will be kept.
 
-            Each key of the dictionary will be the name of the 
-            column in the returned data table. The value bound to 
-            each key is a two-element tuple. 
-            The first tuple entry is an integer providing 
-            the *index* of the column to be kept, starting from 0. 
-            The second tuple entry is a string defining the Numpy dtype 
-            of the data in that column, 
-            e.g., 'f4' for a float, 'f8' for a double, 
-            or 'i8' for a long. 
+            Each key of the dictionary will be the name of the
+            column in the returned data table. The value bound to
+            each key is a two-element tuple.
+            The first tuple entry is an integer providing
+            the *index* of the column to be kept, starting from 0.
+            The second tuple entry is a string defining the Numpy dtype
+            of the data in that column,
+            e.g., 'f4' for a float, 'f8' for a double,
+            or 'i8' for a long.
 
-            Thus an example ``columns_to_keep_dict`` could be 
-            {'x': (1, 'f4'), 'y': (0, 'i8'), 'z': (9, 'f4')}. 
-            In this case, the structured array returned by the `read_ascii`  method 
-            would have three keys: 
-            ``x`` storing a float for the data in 
-            the second column of the ASCII file, 
-            ``y`` storing a long integer for the data in 
-            the first column of the ASCII file, and 
-            ``z`` storing a float for the data in 
-            the tenth column of the ASCII file. 
+            Thus an example ``columns_to_keep_dict`` could be
+            {'x': (1, 'f4'), 'y': (0, 'i8'), 'z': (9, 'f4')}.
+            In this case, the structured array returned by the `read_ascii`  method
+            would have three keys:
+            ``x`` storing a float for the data in
+            the second column of the ASCII file,
+            ``y`` storing a long integer for the data in
+            the first column of the ASCII file, and
+            ``z`` storing a float for the data in
+            the tenth column of the ASCII file.
 
         header_char : str, optional
-            String to be interpreted as a header line 
-            at the beginning of the ascii file. 
-            Default is '#'. 
+            String to be interpreted as a header line
+            at the beginning of the ascii file.
+            Default is '#'.
 
-        row_cut_min_dict : dict, optional 
-            Dictionary used to place a lower-bound cut on the rows 
-            of the tabular ASCII data. 
+        row_cut_min_dict : dict, optional
+            Dictionary used to place a lower-bound cut on the rows
+            of the tabular ASCII data.
 
-            Each key of the dictionary must also 
-            be a key of the input ``columns_to_keep_dict``; 
-            for purposes of good bookeeping, you are not permitted 
-            to place a cut on a column that you do not keep. The value 
-            bound to each key serves as the lower bound on the data stored 
-            in that row. A row with a smaller value than this lower bound for the 
-            corresponding column will not appear in the returned data table. 
+            Each key of the dictionary must also
+            be a key of the input ``columns_to_keep_dict``;
+            for purposes of good bookeeping, you are not permitted
+            to place a cut on a column that you do not keep. The value
+            bound to each key serves as the lower bound on the data stored
+            in that row. A row with a smaller value than this lower bound for the
+            corresponding column will not appear in the returned data table.
 
-            For example, if row_cut_min_dict = {'mass': 1e10}, then all rows of the 
-            returned data table will have a mass greater than 1e10. 
+            For example, if row_cut_min_dict = {'mass': 1e10}, then all rows of the
+            returned data table will have a mass greater than 1e10.
 
-        row_cut_max_dict : dict, optional 
-            Dictionary used to place an upper-bound cut on the rows 
-            of the tabular ASCII data. 
+        row_cut_max_dict : dict, optional
+            Dictionary used to place an upper-bound cut on the rows
+            of the tabular ASCII data.
 
-            Each key of the dictionary must also 
-            be a key of the input ``columns_to_keep_dict``; 
-            for purposes of good bookeeping, you are not permitted 
-            to place a cut on a column that you do not keep. The value 
-            bound to each key serves as the upper bound on the data stored 
-            in that row. A row with a larger value than this upper bound for the 
-            corresponding column will not appear in the returned data table. 
+            Each key of the dictionary must also
+            be a key of the input ``columns_to_keep_dict``;
+            for purposes of good bookeeping, you are not permitted
+            to place a cut on a column that you do not keep. The value
+            bound to each key serves as the upper bound on the data stored
+            in that row. A row with a larger value than this upper bound for the
+            corresponding column will not appear in the returned data table.
 
-            For example, if row_cut_min_dict = {'mass': 1e15}, then all rows of the 
-            returned data table will have a mass less than 1e15. 
+            For example, if row_cut_min_dict = {'mass': 1e15}, then all rows of the
+            returned data table will have a mass less than 1e15.
 
-        row_cut_eq_dict : dict, optional 
-            Dictionary used to place an equality cut on the rows 
-            of the tabular ASCII data. 
+        row_cut_eq_dict : dict, optional
+            Dictionary used to place an equality cut on the rows
+            of the tabular ASCII data.
 
-            Each key of the dictionary must also 
-            be a key of the input ``columns_to_keep_dict``; 
-            for purposes of good bookeeping, you are not permitted 
-            to place a cut on a column that you do not keep. The value 
-            bound to each key serves as the required value for the data stored 
-            in that row. Only rows with a value equal to this required value for the 
-            corresponding column will appear in the returned data table. 
+            Each key of the dictionary must also
+            be a key of the input ``columns_to_keep_dict``;
+            for purposes of good bookeeping, you are not permitted
+            to place a cut on a column that you do not keep. The value
+            bound to each key serves as the required value for the data stored
+            in that row. Only rows with a value equal to this required value for the
+            corresponding column will appear in the returned data table.
 
-            For example, if row_cut_eq_dict = {'upid': -1}, then *all* rows of the 
-            returned data table will have a upid of -1. 
+            For example, if row_cut_eq_dict = {'upid': -1}, then *all* rows of the
+            returned data table will have a upid of -1.
 
-        row_cut_neq_dict : dict, optional 
-            Dictionary used to place an inequality cut on the rows 
-            of the tabular ASCII data. 
+        row_cut_neq_dict : dict, optional
+            Dictionary used to place an inequality cut on the rows
+            of the tabular ASCII data.
 
-            Each key of the dictionary must also 
-            be a key of the input ``columns_to_keep_dict``; 
-            for purposes of good bookeeping, you are not permitted 
-            to place a cut on a column that you do not keep. The value 
-            bound to each key serves as a forbidden value for the data stored 
-            in that row. Rows with a value equal to this forbidden value for the 
-            corresponding column will not appear in the returned data table. 
+            Each key of the dictionary must also
+            be a key of the input ``columns_to_keep_dict``;
+            for purposes of good bookeeping, you are not permitted
+            to place a cut on a column that you do not keep. The value
+            bound to each key serves as a forbidden value for the data stored
+            in that row. Rows with a value equal to this forbidden value for the
+            corresponding column will not appear in the returned data table.
 
-            For example, if row_cut_neq_dict = {'upid': -1}, then *no* rows of the 
-            returned data table will have a upid of -1. 
+            For example, if row_cut_neq_dict = {'upid': -1}, then *no* rows of the
+            returned data table will have a upid of -1.
 
 
-        Examples 
+        Examples
         ---------
 
-        Suppose you are only interested in reading the tenth and fifth  
-        columns of data of your ascii file, and that these columns store 
-        a float variable you want to call *mass*, and a long integer variable 
-        you want to call *id*, respectively. If you want a Numpy structured array 
-        storing *all* rows of these two columns: 
+        Suppose you are only interested in reading the tenth and fifth
+        columns of data of your ascii file, and that these columns store
+        a float variable you want to call *mass*, and a long integer variable
+        you want to call *id*, respectively. If you want a Numpy structured array
+        storing *all* rows of these two columns:
 
         >>> cols = {'mass': (9, 'f4'), 'id': (4, 'i8')}
         >>> reader = TabularAsciiReader(fname, cols) # doctest: +SKIP
@@ -166,11 +169,11 @@ class TabularAsciiReader(object):
         >>> reader = TabularAsciiReader(fname, cols, row_cut_min_dict = row_cut_min_dict) # doctest: +SKIP
         >>> arr = reader.read_ascii() # doctest: +SKIP
 
-        Finally, suppose the fortieth column stores an integer called *resolved*, 
-        and in addition to the above mass cut, you do not wish to store 
-        any rows for which the *resolved* column value equals zero. 
-        As described above, you are not permitted to make a row-cut on a column 
-        that you do not keep, so in addition to defining the new row cut, 
+        Finally, suppose the fortieth column stores an integer called *resolved*,
+        and in addition to the above mass cut, you do not wish to store
+        any rows for which the *resolved* column value equals zero.
+        As described above, you are not permitted to make a row-cut on a column
+        that you do not keep, so in addition to defining the new row cut,
         you must also include the *resolved* column in your *columns_to_keep_dict*:
 
         >>> cols = {'mass': (9, 'f4'), 'id': (4, 'i8'), 'resolved': (39, 'i4')}
@@ -199,11 +202,11 @@ class TabularAsciiReader(object):
         self._enforce_no_repeated_columns()
 
     def _verify_input_row_cuts_keys(self, **kwargs):
-        """ Require all columns upon which a row-cut is placed to also appear in 
-        the input ``columns_to_keep_dict``. For purposes of good bookeeping, 
-        you are not permitted to place a cut on a column that you do not keep.        
+        """ Require all columns upon which a row-cut is placed to also appear in
+        the input ``columns_to_keep_dict``. For purposes of good bookeeping,
+        you are not permitted to place a cut on a column that you do not keep.
         """
-        potential_row_cuts = ('row_cut_min_dict', 'row_cut_max_dict', 
+        potential_row_cuts = ('row_cut_min_dict', 'row_cut_max_dict',
             'row_cut_eq_dict', 'row_cut_neq_dict')
         for row_cut_key in potential_row_cuts:
 
@@ -211,7 +214,7 @@ class TabularAsciiReader(object):
 
             for key in row_cut_dict:
                 try:
-                    assert key in self.columns_to_keep_dict.keys()
+                    assert key in list(self.columns_to_keep_dict.keys())
                 except AssertionError:
                     msg = ("\nThe ``"+key+"`` key does not appear in the input \n"
                         "``columns_to_keep_dict``, but it does appear in the "
@@ -221,12 +224,12 @@ class TabularAsciiReader(object):
                     raise KeyError(msg)
 
     def _verify_min_max_consistency(self, **kwargs):
-        """ Verify that no min_cut column has a value greater to the corresponding max_cut. 
+        """ Verify that no min_cut column has a value greater to the corresponding max_cut.
 
-        Such a choice would laboriously result in a final catalog with zero entries. 
+        Such a choice would laboriously result in a final catalog with zero entries.
         """
 
-        for row_cut_min_key, row_cut_min in self.row_cut_min_dict.iteritems():
+        for row_cut_min_key, row_cut_min in self.row_cut_min_dict.items():
             try:
                 row_cut_max = self.row_cut_max_dict[row_cut_min_key]
                 if row_cut_max <= row_cut_min:
@@ -239,7 +242,7 @@ class TabularAsciiReader(object):
             except KeyError:
                 pass
 
-        for row_cut_max_key, row_cut_max in self.row_cut_max_dict.iteritems():
+        for row_cut_max_key, row_cut_max in self.row_cut_max_dict.items():
             try:
                 row_cut_min = self.row_cut_min_dict[row_cut_max_key]
                 if row_cut_min >= row_cut_max:
@@ -254,12 +257,12 @@ class TabularAsciiReader(object):
 
 
     def _verify_eq_neq_consistency(self, **kwargs):
-        """ Verify that no neq_cut column has a value equal to the corresponding eq_cut. 
+        """ Verify that no neq_cut column has a value equal to the corresponding eq_cut.
 
-        Such a choice would laboriously result in a final catalog with zero entries. 
-        """ 
+        Such a choice would laboriously result in a final catalog with zero entries.
+        """
 
-        for row_cut_eq_key, row_cut_eq in self.row_cut_eq_dict.iteritems():
+        for row_cut_eq_key, row_cut_eq in self.row_cut_eq_dict.items():
             try:
                 row_cut_neq = self.row_cut_neq_dict[row_cut_eq_key]
                 if row_cut_neq == row_cut_eq:
@@ -272,7 +275,7 @@ class TabularAsciiReader(object):
             except KeyError:
                 pass
 
-        for row_cut_neq_key, row_cut_neq in self.row_cut_neq_dict.iteritems():
+        for row_cut_neq_key, row_cut_neq in self.row_cut_neq_dict.items():
             try:
                 row_cut_eq = self.row_cut_eq_dict[row_cut_neq_key]
                 if row_cut_eq == row_cut_neq:
@@ -286,12 +289,12 @@ class TabularAsciiReader(object):
                 pass
 
     def _process_columns_to_keep(self, columns_to_keep_dict):
-        """ Private method performs sanity checks in the input ``columns_to_keep_dict`` 
-        and uses this input to define two attributes used for future bookkeeping, 
-        ``self.column_indices_to_keep`` and ``self.dt``. 
+        """ Private method performs sanity checks in the input ``columns_to_keep_dict``
+        and uses this input to define two attributes used for future bookkeeping,
+        ``self.column_indices_to_keep`` and ``self.dt``.
         """
 
-        for key, value in columns_to_keep_dict.iteritems():
+        for key, value in columns_to_keep_dict.items():
             try:
                 assert type(value) == tuple
                 assert len(value) == 2
@@ -322,31 +325,31 @@ class TabularAsciiReader(object):
                 raise TypeError(msg)
         self.columns_to_keep_dict = columns_to_keep_dict
 
-        # Create a hard copy of the dict keys to ensure that 
-        # self.column_indices_to_keep and self.dt are defined 
+        # Create a hard copy of the dict keys to ensure that
+        # self.column_indices_to_keep and self.dt are defined
         # according to the same sequence
         column_key_list = list(columns_to_keep_dict.keys())
 
-        # Only data columns with indices in self.column_indices_to_keep 
+        # Only data columns with indices in self.column_indices_to_keep
         # will be yielded by the data_chunk_generator
         self.column_indices_to_keep = list(
             [columns_to_keep_dict[key][0] for key in column_key_list]
             )
 
-        # The rows of data yielded by the data_chunk_generator 
+        # The rows of data yielded by the data_chunk_generator
         # will be assumed to be the following Numpy dtype
         self.dt = np.dtype(
             [(key, columns_to_keep_dict[key][1]) for key in column_key_list]
             )
 
     def _get_fname(self, input_fname):
-        """ Verify that the input fname exists on disk. 
+        """ Verify that the input fname exists on disk.
         """
-        # Check whether input_fname exists. 
+        # Check whether input_fname exists.
         if not os.path.isfile(input_fname):
             # Check to see whether the uncompressed version is available instead
             if not os.path.isfile(input_fname[:-3]):
-                msg = "Input filename %s is not a file" 
+                msg = "Input filename %s is not a file"
                 raise IOError(msg % input_fname)
             else:
                 msg = ("Input filename ``%s`` is not a file. \n"
@@ -357,21 +360,21 @@ class TabularAsciiReader(object):
 
     def _enforce_no_repeated_columns(self):
         duplicates = list(
-            k for k, v in collections.Counter(self.column_indices_to_keep).items() if v>1
+            k for k, v in list(collections.Counter(self.column_indices_to_keep).items()) if v>1
             )
         if len(duplicates) > 0:
             example_repeated_column_index = str(duplicates[0])
-            msg = ("\nColumn number " + example_repeated_column_index + 
+            msg = ("\nColumn number " + example_repeated_column_index +
                 " appears more than once in your ``columns_to_keep_dict``.")
             raise ValueError(msg)
 
     def _get_header_char(self, header_char):
-        """ Verify that the input header_char is 
-        a one-character string or unicode variable. 
+        """ Verify that the input header_char is
+        a one-character string or unicode variable.
 
         """
         try:
-            assert (type(header_char) == str) or (type(header_char) == unicode)
+            assert (type(header_char) == str) or (type(header_char) == str)
             assert len(header_char) == 1
         except AssertionError:
             msg = ("\nThe input ``header_char`` must be a single string character.\n")
@@ -379,8 +382,8 @@ class TabularAsciiReader(object):
         return header_char
 
     def _determine_compression_safe_file_opener(self):
-        """ Determine whether to use *open* or *gzip.open* to read 
-        the input file, depending on whether or not the file is compressed. 
+        """ Determine whether to use *open* or *gzip.open* to read
+        the input file, depending on whether or not the file is compressed.
         """
         f = gzip.open(self.input_fname, 'r')
         try:
@@ -392,22 +395,22 @@ class TabularAsciiReader(object):
             f.close()
 
     def header_len(self):
-        """ Number of rows in the header of the ASCII file. 
+        """ Number of rows in the header of the ASCII file.
 
-        Parameters 
+        Parameters
         ----------
-        fname : string 
+        fname : string
 
-        Returns 
+        Returns
         -------
         Nheader : int
 
-        Notes 
+        Notes
         -----
-        The header is assumed to be those characters at the beginning of the file 
-        that begin with ``self.header_char``. 
+        The header is assumed to be those characters at the beginning of the file
+        that begin with ``self.header_char``.
 
-        All empty lines that appear in header will be included in the count. 
+        All empty lines that appear in header will be included in the count.
 
         """
         Nheader = 0
@@ -421,26 +424,26 @@ class TabularAsciiReader(object):
         return Nheader
 
     def data_len(self):
-        """ 
-        Number of rows of data in the input ASCII file. 
+        """
+        Number of rows of data in the input ASCII file.
 
-        Returns 
+        Returns
         --------
-        Nrows_data : int 
-            Total number of rows of data. 
+        Nrows_data : int
+            Total number of rows of data.
 
-        Notes 
+        Notes
         -------
-        The returned value is computed as the number of lines 
-        between the returned value of `header_len` and 
-        the next appearance of an empty line. 
+        The returned value is computed as the number of lines
+        between the returned value of `header_len` and
+        the next appearance of an empty line.
 
-        The `data_len` method is the particular section of code 
+        The `data_len` method is the particular section of code
         where where the following assumptions are made:
 
-            1. The data begins with the first appearance of a non-empty line that does not begin with the character defined by ``self.header_char``. 
+            1. The data begins with the first appearance of a non-empty line that does not begin with the character defined by ``self.header_char``.
 
-            2. The data ends with the next appearance of an empty line. 
+            2. The data ends with the next appearance of an empty line.
 
         """
         Nrows_data = 0
@@ -452,98 +455,98 @@ class TabularAsciiReader(object):
 
     def data_chunk_generator(self, chunk_size, f):
         """
-        Python generator uses f.readline() to march 
-        through an input open file object to yield 
-        a chunk of data with length equal to the input ``chunk_size``. 
-        The generator only yields columns that were included 
-        in the ``columns_to_keep_dict`` passed to the constructor. 
+        Python generator uses f.readline() to march
+        through an input open file object to yield
+        a chunk of data with length equal to the input ``chunk_size``.
+        The generator only yields columns that were included
+        in the ``columns_to_keep_dict`` passed to the constructor.
 
-        Parameters 
+        Parameters
         -----------
-        chunk_size : int 
-            Number of rows of data in the chunk being generated 
+        chunk_size : int
+            Number of rows of data in the chunk being generated
 
         f : File
             Open file object being read
 
-        Returns 
+        Returns
         --------
-        chunk : tuple 
-            Tuple of data from the ascii. 
-            Only data from ``column_indices_to_keep`` are yielded. 
+        chunk : tuple
+            Tuple of data from the ascii.
+            Only data from ``column_indices_to_keep`` are yielded.
 
         """
         cur = 0
         while cur < chunk_size:
-            line = f.readline()    
+            line = f.readline()
             parsed_line = line.strip().split()
             yield tuple(parsed_line[i] for i in self.column_indices_to_keep)
-            cur += 1 
+            cur += 1
 
     def apply_row_cut(self, array_chunk):
-        """ Method applies a boolean mask to the input array 
-        based on the row-cuts determined by the 
-        dictionaries passed to the constructor. 
+        """ Method applies a boolean mask to the input array
+        based on the row-cuts determined by the
+        dictionaries passed to the constructor.
 
-        Parameters 
+        Parameters
         -----------
-        array_chunk : Numpy array  
+        array_chunk : Numpy array
 
-        Returns 
+        Returns
         --------
-        cut_array : Numpy array             
-        """ 
+        cut_array : Numpy array
+        """
         mask = np.ones(len(array_chunk), dtype = bool)
 
-        for colname, lower_bound in self.row_cut_min_dict.iteritems():
+        for colname, lower_bound in self.row_cut_min_dict.items():
             mask *= array_chunk[colname] > lower_bound
 
-        for colname, upper_bound in self.row_cut_max_dict.iteritems():
+        for colname, upper_bound in self.row_cut_max_dict.items():
             mask *= array_chunk[colname] < upper_bound
 
-        for colname, equality_condition in self.row_cut_eq_dict.iteritems():
+        for colname, equality_condition in self.row_cut_eq_dict.items():
             mask *= array_chunk[colname] == equality_condition
 
-        for colname, inequality_condition in self.row_cut_neq_dict.iteritems():
+        for colname, inequality_condition in self.row_cut_neq_dict.items():
             mask *= array_chunk[colname] != inequality_condition
 
         return array_chunk[mask]
 
     def read_ascii(self, chunk_memory_size = 500.):
-        """ Method reads the input ascii and returns 
-        a structured Numpy array of the data 
-        that passes the row- and column-cuts. 
+        """ Method reads the input ascii and returns
+        a structured Numpy array of the data
+        that passes the row- and column-cuts.
 
-        Parameters 
+        Parameters
         ----------
-        chunk_memory_size : int, optional 
-            Determine the approximate amount of Megabytes of memory 
-            that will be processed in chunks. This variable 
-            must be smaller than the amount of RAM on your machine; 
-            choosing larger values typically improves performance. 
-            Default is 500 Mb. 
+        chunk_memory_size : int, optional
+            Determine the approximate amount of Megabytes of memory
+            that will be processed in chunks. This variable
+            must be smaller than the amount of RAM on your machine;
+            choosing larger values typically improves performance.
+            Default is 500 Mb.
 
-        Returns 
+        Returns
         --------
-        full_array : array_like 
-            Structured Numpy array storing the rows and columns 
-            that pass the input cuts. The columns of this array 
-            are those selected by the ``column_indices_to_keep`` 
-            argument passed to the constructor. 
+        full_array : array_like
+            Structured Numpy array storing the rows and columns
+            that pass the input cuts. The columns of this array
+            are those selected by the ``column_indices_to_keep``
+            argument passed to the constructor.
 
-        See also 
+        See also
         ----------
         data_chunk_generator
         """
-        print("\n...Processing ASCII data of file: \n%s\n " % self.input_fname)
+        print(("\n...Processing ASCII data of file: \n%s\n " % self.input_fname))
         start = time()
 
-        file_size = os.path.getsize(self.input_fname) 
+        file_size = os.path.getsize(self.input_fname)
         chunk_memory_size *= 1e6 # convert to bytes to match units of file_size
         num_data_rows = self.data_len()
-        print("Total number of rows in detected data = %i" % num_data_rows)
+        print(("Total number of rows in detected data = %i" % num_data_rows))
 
-        # Set the number of chunks to be filesize/chunk_memory, 
+        # Set the number of chunks to be filesize/chunk_memory,
         # but enforcing that 0 < Nchunks <= num_data_rows
         try:
             Nchunks = max(1, min(file_size / chunk_memory_size, num_data_rows))
@@ -556,16 +559,16 @@ class TabularAsciiReader(object):
         num_rows_in_chunk_remainder = num_data_rows - num_rows_in_chunk*Nchunks
 
         header_length = self.header_len()
-        print("Number of rows in detected header = %i \n" % header_length)
+        print(("Number of rows in detected header = %i \n" % header_length))
 
         chunklist = []
         with self._compression_safe_file_opener(self.input_fname, 'r') as f:
 
-            for skip_header_row in xrange(header_length):
+            for skip_header_row in range(header_length):
                 _s = f.readline()
 
-            for _i in xrange(num_full_chunks):
-                print("... working on chunk "+str(_i)+" of "+str(num_full_chunks))
+            for _i in range(num_full_chunks):
+                print(("... working on chunk "+str(_i)+" of "+str(num_full_chunks)))
 
                 chunk_array = np.array(list(
                     self.data_chunk_generator(num_rows_in_chunk, f)), dtype=self.dt)
@@ -579,7 +582,7 @@ class TabularAsciiReader(object):
             chunklist.append(cut_chunk)
 
         full_array = np.concatenate(chunklist)
-                
+
         end = time()
         runtime = (end-start)
 
@@ -588,7 +591,7 @@ class TabularAsciiReader(object):
             msg = "Total runtime to read in ASCII = %.1f minutes\n"
         else:
             msg = "Total runtime to read in ASCII = %.2f seconds\n"
-        print(msg % runtime)
+        print((msg % runtime))
         print("\a")
 
         return full_array

--- a/halotools/sim_manager/tabular_ascii_reader.py
+++ b/halotools/sim_manager/tabular_ascii_reader.py
@@ -512,7 +512,7 @@ class TabularAsciiReader(object):
 
         return array_chunk[mask]
 
-    def read_ascii(self, chunk_memory_size = 500.):
+    def read_ascii(self, chunk_memory_size=500):
         """ Method reads the input ascii and returns
         a structured Numpy array of the data
         that passes the row- and column-cuts.
@@ -538,11 +538,13 @@ class TabularAsciiReader(object):
         ----------
         data_chunk_generator
         """
-        print(("\n...Processing ASCII data of file: \n%s\n " % self.input_fname))
+        print(("\n...Processing ASCII data of file: \n%s\n "
+               % self.input_fname))
         start = time()
 
         file_size = os.path.getsize(self.input_fname)
-        chunk_memory_size *= 1e6 # convert to bytes to match units of file_size
+        # convert to bytes to match units of file_size
+        chunk_memory_size *= 1e6
         num_data_rows = self.data_len()
         print(("Total number of rows in detected data = %i" % num_data_rows))
 
@@ -551,11 +553,12 @@ class TabularAsciiReader(object):
         try:
             Nchunks = max(1, min(file_size / chunk_memory_size, num_data_rows))
         except ZeroDivisionError:
-            msg = ("\nMust choose non-zero size for input ``chunk_memory_size``")
+            msg = ("\nMust choose non-zero size for input "
+                   "``chunk_memory_size``")
             raise ValueError(msg)
 
-        num_rows_in_chunk = int(num_data_rows / float(Nchunks))
-        num_full_chunks = num_data_rows / num_rows_in_chunk
+        num_rows_in_chunk = num_data_rows // Nchunks
+        num_full_chunks = num_data_rows // num_rows_in_chunk
         num_rows_in_chunk_remainder = num_data_rows - num_rows_in_chunk*Nchunks
 
         header_length = self.header_len()
@@ -568,7 +571,8 @@ class TabularAsciiReader(object):
                 _s = f.readline()
 
             for _i in range(num_full_chunks):
-                print(("... working on chunk "+str(_i)+" of "+str(num_full_chunks)))
+                print(("... working on chunk " + str(_i) +
+                       " of " + str(num_full_chunks)))
 
                 chunk_array = np.array(list(
                     self.data_chunk_generator(num_rows_in_chunk, f)), dtype=self.dt)

--- a/halotools/sim_manager/tests/helper_functions.py
+++ b/halotools/sim_manager/tests/helper_functions.py
@@ -19,7 +19,7 @@ from ...custom_exceptions import HalotoolsError
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_cached_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_cached_halo_catalog.py
@@ -29,7 +29,7 @@ from ...custom_exceptions import HalotoolsError, InvalidCacheLogEntry
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_cached_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_cached_halo_catalog.py
@@ -57,13 +57,13 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(HalotoolsError) as err:
             _ = CachedHaloCatalog('bolshoi')
         substr = "CachedHaloCatalog only accepts keyword arguments,"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_raises_bad_constructor_args_exception2(self):
         with pytest.raises(HalotoolsError) as err:
             _ = CachedHaloCatalog(z = 0.04)
         substr = "CachedHaloCatalog got an unexpected keyword"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     @pytest.mark.skipif('not APH_MACHINE')
@@ -144,7 +144,7 @@ class TestCachedHaloCatalog(TestCase):
             halocat = CachedHaloCatalog(simname = 'bolshoi', 
                 halo_finder = 'bdm', version_name = 'halotools_alpha_version2', 
                 redshift = 5, dz_tol = 1)
-        assert 'The following entries in the cache log' in err.value.message
+        assert 'The following entries in the cache log' in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_load_bad_catalog2(self):
@@ -155,7 +155,7 @@ class TestCachedHaloCatalog(TestCase):
             halocat = CachedHaloCatalog(simname = 'bolshoi', 
                 halo_finder = 'bdm', version_name = 'halotools_alpha_version2', 
                 redshift = 5, dz_tol = 1)
-        assert 'The following entries in the cache log' in err.value.message
+        assert 'The following entries in the cache log' in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_load_bad_catalog3(self):
@@ -165,8 +165,8 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(InvalidCacheLogEntry) as err:
             halocat = CachedHaloCatalog(simname = 'bolshoi', 
                 halo_finder = 'bdm', version_name = 'Jose Canseco')
-        assert 'The following entries in the cache log' in err.value.message
-        assert '(set by sim_defaults.default_redshift)' in err.value.message
+        assert 'The following entries in the cache log' in err.value.args[0]
+        assert '(set by sim_defaults.default_redshift)' in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_load_bad_catalog4(self):
@@ -176,8 +176,8 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(InvalidCacheLogEntry) as err:
             halocat = CachedHaloCatalog(simname = 'bolshoi', 
                 halo_finder = 'Jose Canseco')
-        assert 'The following entries in the cache log' in err.value.message
-        assert '(set by sim_defaults.default_version_name)' in err.value.message
+        assert 'The following entries in the cache log' in err.value.args[0]
+        assert '(set by sim_defaults.default_version_name)' in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_load_bad_catalog5(self):
@@ -186,8 +186,8 @@ class TestCachedHaloCatalog(TestCase):
         """
         with pytest.raises(InvalidCacheLogEntry) as err:
             halocat = CachedHaloCatalog(simname = 'Jose Canseco')
-        assert 'There are no simulations matching your input simname' in err.value.message
-        assert '(set by sim_defaults.default_halo_finder)' in err.value.message
+        assert 'There are no simulations matching your input simname' in err.value.args[0]
+        assert '(set by sim_defaults.default_halo_finder)' in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_load_bad_catalog6(self):
@@ -198,7 +198,7 @@ class TestCachedHaloCatalog(TestCase):
             halocat = CachedHaloCatalog(simname = 'Jose Canseco', 
                 halo_finder = 'bdm', version_name = 'halotools_alpha_version2', 
                 redshift = 5, dz_tol = 1)
-        assert 'There are no simulations matching your input simname' in err.value.message
+        assert 'There are no simulations matching your input simname' in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_load_bad_catalog7(self):
@@ -207,8 +207,8 @@ class TestCachedHaloCatalog(TestCase):
         """
         with pytest.raises(InvalidCacheLogEntry) as err:
             halocat = CachedHaloCatalog(dz_tol = 100)
-        assert 'There are multiple entries in the cache log' in err.value.message
-        assert '(set by sim_defaults.default_simname)' in err.value.message
+        assert 'There are multiple entries in the cache log' in err.value.args[0]
+        assert '(set by sim_defaults.default_simname)' in err.value.args[0]
 
     @pytest.mark.slow
     @pytest.mark.skipif('not APH_MACHINE')
@@ -246,9 +246,9 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(HalotoolsError) as err:
             halocat = CachedHaloCatalog(fname = fname, simname = 'bolshoi')
         substr = "If you specify an input ``fname``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
         substr = "do not also specify ``simname``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_acceptable_arguments2(self):
@@ -259,9 +259,9 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(HalotoolsError) as err:
             halocat = CachedHaloCatalog(fname = fname, version_name = 'dummy')
         substr = "If you specify an input ``fname``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
         substr = "do not also specify ``version_name``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_acceptable_arguments3(self):
@@ -272,9 +272,9 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(HalotoolsError) as err:
             halocat = CachedHaloCatalog(fname = fname, halo_finder = 'dummy')
         substr = "If you specify an input ``fname``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
         substr = "do not also specify ``halo_finder``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_acceptable_arguments4(self):
@@ -285,9 +285,9 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(HalotoolsError) as err:
             halocat = CachedHaloCatalog(fname = fname, redshift = 0)
         substr = "If you specify an input ``fname``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
         substr = "do not also specify ``redshift``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_acceptable_arguments5(self):
@@ -296,7 +296,7 @@ class TestCachedHaloCatalog(TestCase):
         with pytest.raises(HalotoolsError) as err:
             halocat = CachedHaloCatalog(fname = fname, redshift = 0)
         substr = "non-existent path"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_acceptable_arguments6(self):
@@ -318,7 +318,7 @@ class TestCachedHaloCatalog(TestCase):
 
         with pytest.raises(HalotoolsError) as err:
             halocat = CachedHaloCatalog(fname = correct_fname)
-        print(err.value.message)
+        print(err.value.args[0])
 
         f = h5py.File(correct_fname)
         f.attrs['fname'] = correct_fname
@@ -397,8 +397,8 @@ class TestCachedHaloCatalog(TestCase):
                 halo_finder = 'rockstar', 
                 version_name = 'halotools_alpha_version2', redshift = 11.7632)
         substr = "The following input fname does not exist: "
-        assert substr in err.value.message
-        assert tmp_fname in err.value.message 
+        assert substr in err.value.args[0]
+        assert tmp_fname in err.value.args[0] 
         
         ######################################################
         ## Update the cache location using the CachedHaloCatalog

--- a/halotools/sim_manager/tests/test_download_manager.py
+++ b/halotools/sim_manager/tests/test_download_manager.py
@@ -278,7 +278,7 @@ class TestDownloadManager(TestCase):
             fname, redshift = self.downman._closest_catalog_on_web(simname = 'bolshoi', 
                 halo_finder = 'bdm', desired_redshift = 0., catalog_type = 'Jose Canseco')
         substr = "Input ``catalog_type`` must be either ``particles`` or ``halos``" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @remote_data
     def test_closest_ptcl_catalog_on_web(self):
@@ -322,7 +322,7 @@ class TestDownloadManager(TestCase):
                 redshift = 11.7, 
                 download_dirname=self.halocat_dir)
         substr = "no web locations" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     @remote_data
@@ -337,7 +337,7 @@ class TestDownloadManager(TestCase):
                 redshift = 11.7, 
                 download_dirname=self.halocat_dir)
         substr = "no halo catalogs meeting" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     @remote_data
@@ -351,7 +351,7 @@ class TestDownloadManager(TestCase):
                 version_name = sim_defaults.default_version_name, 
                 redshift = 0, overwrite=False)
         substr = "you must set the ``overwrite`` keyword argument to True" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @remote_data
     def test_download_processed_halo_table4(self):
@@ -364,7 +364,7 @@ class TestDownloadManager(TestCase):
                 version_name = sim_defaults.default_version_name, 
                 redshift = 0, overwrite=False, download_dirname = 'abc')
         substr = "Your input ``download_dirname`` is a non-existent path." 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     @remote_data
@@ -379,7 +379,7 @@ class TestDownloadManager(TestCase):
                 redshift = 11.7, dz_tol = 200, 
                 overwrite=True, download_dirname = 'std_cache_loc')
         substr = "the ``ignore_nearby_redshifts`` to True, or decrease ``dz_tol``" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @remote_data
     def test_download_processed_halo_table6(self):
@@ -393,7 +393,7 @@ class TestDownloadManager(TestCase):
                 redshift = 0.3, dz_tol = 0.001, 
                 overwrite=False, download_dirname = self.halocat_dir)
         substr = "The closest redshift for these catalogs is" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     @pytest.mark.skipif('not APH_MACHINE')
@@ -428,7 +428,7 @@ class TestDownloadManager(TestCase):
                 redshift = 11.7, 
                 download_dirname=self.halocat_dir)
         substr = "no web locations" 
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @remote_data
     def test_download_ptcl_table2(self):
@@ -441,7 +441,7 @@ class TestDownloadManager(TestCase):
                 redshift = 11.7, 
                 download_dirname=self.halocat_dir)
         substr = "There are no particle catalogs meeting your specifications"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not APH_MACHINE')
     @remote_data
@@ -455,7 +455,7 @@ class TestDownloadManager(TestCase):
                 redshift = 0, 
                 download_dirname=self.halocat_dir)
         substr = "you must set the ``overwrite`` keyword argument to True."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @remote_data
     def test_download_ptcl_table4(self):
@@ -468,7 +468,7 @@ class TestDownloadManager(TestCase):
                 redshift = 0, 
                 download_dirname='abc')
         substr = "Your input ``download_dirname`` is a non-existent path."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @remote_data
     def test_download_ptcl_table5(self):
@@ -481,7 +481,7 @@ class TestDownloadManager(TestCase):
                 redshift = 0.2, dz_tol = 0.001,  
                 download_dirname=self.halocat_dir)
         substr = "The closest redshift for these catalogs is"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def tearDown(self):
         try:

--- a/halotools/sim_manager/tests/test_download_manager.py
+++ b/halotools/sim_manager/tests/test_download_manager.py
@@ -17,7 +17,7 @@ from ...custom_exceptions import UnsupportedSimError, HalotoolsError
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_fake_sim.py
+++ b/halotools/sim_manager/tests/test_fake_sim.py
@@ -33,7 +33,7 @@ class TestFakeSim(TestCase):
 	def test_attrs(self):
 		keylist = ['halo_hostid']
 		for key in keylist:
-			assert key in self.fake_sim.halo_table.keys()
+			assert key in list(self.fake_sim.halo_table.keys())
 
 	def tearDown(self):
 		del self.fake_sim
@@ -47,7 +47,7 @@ class TestFakeSimHalosNearBoundaries(TestCase):
 	def test_attrs(self):
 		keylist = ['halo_hostid']
 		for key in keylist:
-			assert key in self.fake_sim.halo_table.keys()
+			assert key in list(self.fake_sim.halo_table.keys())
 
 	def test_positions(self):
 		assert not np.any( (self.fake_sim.halo_table['halo_x'] > 1) & 

--- a/halotools/sim_manager/tests/test_halo_table_cache.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache.py
@@ -151,7 +151,7 @@ class TestHaloTableCache(TestCase):
         with pytest.raises(TypeError) as err:
             cache.add_entry_to_cache_log('abc', update_ascii = False)
         substr = "You can only add instances of HaloTableCacheLogEntry to the cache log"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
         assert len(cache.log) == 1
@@ -169,7 +169,7 @@ class TestHaloTableCache(TestCase):
         with pytest.raises(InvalidCacheLogEntry) as err:
             cache.add_entry_to_cache_log(self.bad_log_entry, update_ascii = False)
         substr = "The input filename does not exist."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_remove_entry_from_cache_log(self):
@@ -186,7 +186,7 @@ class TestHaloTableCache(TestCase):
         with pytest.raises(HalotoolsError) as err:
             cache.remove_entry_from_cache_log(*args, update_ascii = False)
         substr = "This entry does not appear in the log."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         cache.remove_entry_from_cache_log(*args, update_ascii = False,
             raise_non_existence_exception = False)

--- a/halotools/sim_manager/tests/test_halo_table_cache.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache.py
@@ -2,22 +2,21 @@
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
-from astropy.tests.helper import pytest 
-from astropy.table import Table 
-import warnings, os, shutil
+from astropy.tests.helper import pytest
+from astropy.table import Table
+import warnings
+import os
+import shutil
 
-import numpy as np 
-from copy import copy, deepcopy 
+from copy import deepcopy
 
 try:
-    import h5py 
+    import h5py
     HAS_H5PY = True
 except ImportError:
     HAS_H5PY = False
 
-from astropy.config.paths import _find_home 
-from astropy.table import Table
-from astropy.table import vstack as table_vstack
+from astropy.config.paths import _find_home
 
 from . import helper_functions
 
@@ -27,8 +26,8 @@ from ..halo_table_cache import HaloTableCache
 from ...custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 
 ### Determine whether the machine is mine
-# This will be used to select tests whose 
-# returned values depend on the configuration 
+# This will be used to select tests whose
+# returned values depend on the configuration
 # of my personal cache directory files
 aph_home = '/Users/aphearin'
 detected_home = _find_home()
@@ -37,14 +36,14 @@ if aph_home == detected_home:
 else:
     APH_MACHINE = False
 
-__all__ = ('TestHaloTableCache',  )
+__all__ = ('TestHaloTableCache', )
+
 
 class TestHaloTableCache(TestCase):
     """
     """
 
     def setUp(self):
-
 
         self.dummy_cache_baseloc = helper_functions.dummy_cache_baseloc
         try:
@@ -53,23 +52,22 @@ class TestHaloTableCache(TestCase):
             pass
         os.makedirs(self.dummy_cache_baseloc)
 
-
         if HAS_H5PY:
 
             # Create a good halo catalog and log entry
             self.good_table = Table(
-                {'halo_id': [1, 2, 3], 
-                'halo_x': [1, 2, 3], 
-                'halo_y': [1, 2, 3], 
-                'halo_z': [1, 2, 3], 
-                'halo_mass': [1, 2, 3], 
+                {'halo_id': [1, 2, 3],
+                'halo_x': [1, 2, 3],
+                'halo_y': [1, 2, 3],
+                'halo_z': [1, 2, 3],
+                'halo_mass': [1, 2, 3],
                 })
-            self.good_table_fname = os.path.join(self.dummy_cache_baseloc, 
+            self.good_table_fname = os.path.join(self.dummy_cache_baseloc,
                 'good_table.hdf5')
             self.good_table.write(self.good_table_fname, path='data')
 
-            self.good_log_entry = HaloTableCacheLogEntry('good_simname1', 
-                'good_halo_finder', 'good_version_name', 
+            self.good_log_entry = HaloTableCacheLogEntry('good_simname1',
+                'good_halo_finder', 'good_version_name',
                 get_redshift_string(0.0), self.good_table_fname)
 
             f = h5py.File(self.good_table_fname)
@@ -82,12 +80,12 @@ class TestHaloTableCache(TestCase):
             # Create a second good halo catalog and log entry
 
             self.good_table2 = deepcopy(self.good_table)
-            self.good_table2_fname = os.path.join(self.dummy_cache_baseloc, 
+            self.good_table2_fname = os.path.join(self.dummy_cache_baseloc,
                 'good_table2.hdf5')
             self.good_table2.write(self.good_table2_fname, path='data')
 
-            self.good_log_entry2 = HaloTableCacheLogEntry('good_simname2', 
-                'good_halo_finder2', 'good_version_name', 
+            self.good_log_entry2 = HaloTableCacheLogEntry('good_simname2',
+                'good_halo_finder2', 'good_version_name',
                 get_redshift_string(1.0), self.good_table2_fname)
 
             f = h5py.File(self.good_table2_fname)
@@ -100,12 +98,12 @@ class TestHaloTableCache(TestCase):
             # Create a bad halo catalog and log entry
 
             self.bad_table = Table(
-                {'halo_id': [1, 2, 3], 
-                'halo_y': [1, 2, 3], 
-                'halo_z': [1, 2, 3], 
-                'halo_mass': [1, 2, 3], 
+                {'halo_id': [1, 2, 3],
+                'halo_y': [1, 2, 3],
+                'halo_z': [1, 2, 3],
+                'halo_mass': [1, 2, 3],
                 })
-            bad_table_fname = os.path.join(self.dummy_cache_baseloc, 
+            bad_table_fname = os.path.join(self.dummy_cache_baseloc,
                 'bad_table.hdf5')
             self.bad_table.write(bad_table_fname, path='data')
 
@@ -190,7 +188,7 @@ class TestHaloTableCache(TestCase):
         substr = "This entry does not appear in the log."
         assert substr in err.value.message
 
-        cache.remove_entry_from_cache_log(*args, update_ascii = False, 
+        cache.remove_entry_from_cache_log(*args, update_ascii = False,
             raise_non_existence_exception = False)
         assert len(cache.log) == 1
 
@@ -207,7 +205,7 @@ class TestHaloTableCache(TestCase):
         os.rename(old_fname, new_fname)
 
         assert self.good_log_entry in cache.log
-        cache.update_cached_file_location(new_fname, old_fname, 
+        cache.update_cached_file_location(new_fname, old_fname,
             update_ascii = False)
         assert self.good_log_entry not in cache.log
 

--- a/halotools/sim_manager/tests/test_halo_table_cache.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache.py
@@ -30,7 +30,7 @@ from ...custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_halo_table_cache.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache.py
@@ -25,7 +25,7 @@ from ..halo_table_cache import HaloTableCache
 
 from ...custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 
-### Determine whether the machine is mine
+# Determine whether the machine is mine
 # This will be used to select tests whose
 # returned values depend on the configuration
 # of my personal cache directory files
@@ -57,22 +57,23 @@ class TestHaloTableCache(TestCase):
             # Create a good halo catalog and log entry
             self.good_table = Table(
                 {'halo_id': [1, 2, 3],
-                'halo_x': [1, 2, 3],
-                'halo_y': [1, 2, 3],
-                'halo_z': [1, 2, 3],
-                'halo_mass': [1, 2, 3],
-                })
+                 'halo_x': [1, 2, 3],
+                 'halo_y': [1, 2, 3],
+                 'halo_z': [1, 2, 3],
+                 'halo_mass': [1, 2, 3],
+                 })
             self.good_table_fname = os.path.join(self.dummy_cache_baseloc,
-                'good_table.hdf5')
+                                                 'good_table.hdf5')
             self.good_table.write(self.good_table_fname, path='data')
 
-            self.good_log_entry = HaloTableCacheLogEntry('good_simname1',
-                'good_halo_finder', 'good_version_name',
+            self.good_log_entry = HaloTableCacheLogEntry(
+                'good_simname1', 'good_halo_finder', 'good_version_name',
                 get_redshift_string(0.0), self.good_table_fname)
 
             f = h5py.File(self.good_table_fname)
-            for attr in self.good_log_entry.log_attributes:
-                f.attrs.create(str(attr), str(getattr(self.good_log_entry, attr)))
+            for attr_name in self.good_log_entry.log_attributes:
+                attr = getattr(self.good_log_entry, attr_name).encode('ascii')
+                f.attrs.create(attr_name, attr)
             f.attrs.create('Lbox', 100.)
             f.attrs.create('particle_mass', 1e8)
             f.close()
@@ -81,16 +82,17 @@ class TestHaloTableCache(TestCase):
 
             self.good_table2 = deepcopy(self.good_table)
             self.good_table2_fname = os.path.join(self.dummy_cache_baseloc,
-                'good_table2.hdf5')
+                                                  'good_table2.hdf5')
             self.good_table2.write(self.good_table2_fname, path='data')
 
-            self.good_log_entry2 = HaloTableCacheLogEntry('good_simname2',
-                'good_halo_finder2', 'good_version_name',
+            self.good_log_entry2 = HaloTableCacheLogEntry(
+                'good_simname2', 'good_halo_finder2', 'good_version_name',
                 get_redshift_string(1.0), self.good_table2_fname)
 
             f = h5py.File(self.good_table2_fname)
-            for attr in self.good_log_entry2.log_attributes:
-                f.attrs.create(str(attr), str(getattr(self.good_log_entry2, attr)))
+            for attr_name in self.good_log_entry2.log_attributes:
+                attr = getattr(self.good_log_entry2, attr_name).encode('ascii')
+                f.attrs.create(attr_name, attr)
             f.attrs.create('Lbox', 100.)
             f.attrs.create('particle_mass', 1e8)
             f.close()

--- a/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
@@ -26,7 +26,7 @@ from ..halo_table_cache_log_entry import HaloTableCacheLogEntry
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True
@@ -188,7 +188,7 @@ class TestHaloTableCacheLogEntry(TestCase):
         self.table1.write(self.fnames[num_scenario], path='data')
 
         f = h5py.File(self.fnames[num_scenario])
-        k = f.attrs.keys()
+        k = list(f.attrs.keys())
         f.close()
 
         log_entry = HaloTableCacheLogEntry(**self.get_scenario_kwargs(num_scenario))

--- a/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache_log_entry.py
@@ -130,7 +130,7 @@ class TestHaloTableCacheLogEntry(TestCase):
         with pytest.raises(TypeError) as err:
             _ = log_entry1 > 0
         substr = "You cannot compare the order"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_comparison_override3(self):

--- a/halotools/sim_manager/tests/test_ptcl_table_cache.py
+++ b/halotools/sim_manager/tests/test_ptcl_table_cache.py
@@ -32,7 +32,7 @@ from ...custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_ptcl_table_cache.py
+++ b/halotools/sim_manager/tests/test_ptcl_table_cache.py
@@ -159,7 +159,7 @@ class TestPtclTableCache(TestCase):
         with pytest.raises(TypeError) as err:
             cache.add_entry_to_cache_log('abc', update_ascii = False)
         substr = "You can only add instances of PtclTableCacheLogEntry to the cache log"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_entry_to_cache_log2(self):
@@ -192,7 +192,7 @@ class TestPtclTableCache(TestCase):
         with pytest.raises(InvalidCacheLogEntry) as err:
             cache.add_entry_to_cache_log(self.bad_log_entry, update_ascii = False)
         substr = "The input filename does not exist."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_remove_entry_from_cache_log1(self):
@@ -209,7 +209,7 @@ class TestPtclTableCache(TestCase):
         with pytest.raises(HalotoolsError) as err:
             cache.remove_entry_from_cache_log(*args, update_ascii = False)
         substr = "This entry does not appear in the log."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         cache.remove_entry_from_cache_log(*args, update_ascii = False, 
             raise_non_existence_exception = False)

--- a/halotools/sim_manager/tests/test_ptcl_table_cache.py
+++ b/halotools/sim_manager/tests/test_ptcl_table_cache.py
@@ -2,35 +2,36 @@
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
-from astropy.tests.helper import pytest 
-import warnings, os, shutil
+from astropy.tests.helper import pytest
+import warnings
+import os
+import shutil
+import numpy as np
 
-import numpy as np 
-from copy import copy, deepcopy 
+from copy import deepcopy
 
 try:
-    import h5py 
+    import h5py
     HAS_H5PY = True
 except ImportError:
     HAS_H5PY = False
 
-from astropy.config.paths import _find_home 
+from astropy.config.paths import _find_home
 from astropy.table import Table
-from astropy.table import vstack as table_vstack
+from astropy.extern import six
 
 from . import helper_functions
 
-from ..halo_table_cache_log_entry import HaloTableCacheLogEntry, get_redshift_string
-from ..halo_table_cache import HaloTableCache
+from ..halo_table_cache_log_entry import get_redshift_string
 
 from ..ptcl_table_cache_log_entry import PtclTableCacheLogEntry
 from ..ptcl_table_cache import PtclTableCache
 
 from ...custom_exceptions import InvalidCacheLogEntry, HalotoolsError
 
-### Determine whether the machine is mine
-# This will be used to select tests whose 
-# returned values depend on the configuration 
+# Determine whether the machine is mine
+# This will be used to select tests whose
+# returned values depend on the configuration
 # of my personal cache directory files
 aph_home = '/Users/aphearin'
 detected_home = _find_home()
@@ -39,7 +40,8 @@ if aph_home == detected_home:
 else:
     APH_MACHINE = False
 
-__all__ = ('TestPtclTableCache',  )
+__all__ = ('TestPtclTableCache', )
+
 
 class TestPtclTableCache(TestCase):
     """
@@ -54,46 +56,54 @@ class TestPtclTableCache(TestCase):
             pass
         os.makedirs(self.dummy_cache_baseloc)
 
-
         if HAS_H5PY:
             # Create a good halo catalog and log entry
             self.good_table = Table(
-                {'ptcl_id': [1, 2, 3], 
-                'x': [1, 2, 3], 
-                'y': [1, 2, 3], 
-                'z': [1, 2, 3], 
-                'vx': [1, 2, 3], 
-                'vy': [1, 2, 3], 
-                'vz': [1, 2, 3], 
-                })
-            self.good_table_fname = os.path.join(self.dummy_cache_baseloc, 
-                'good_table.hdf5')
+                {'ptcl_id': [1, 2, 3],
+                 'x': [1, 2, 3],
+                 'y': [1, 2, 3],
+                 'z': [1, 2, 3],
+                 'vx': [1, 2, 3],
+                 'vy': [1, 2, 3],
+                 'vz': [1, 2, 3],
+                 })
+            self.good_table_fname = os.path.join(self.dummy_cache_baseloc,
+                                                 'good_table.hdf5')
             self.good_table.write(self.good_table_fname, path='data')
 
-            self.good_log_entry = PtclTableCacheLogEntry('good_simname1', 
-                'good_version_name', get_redshift_string(0.0), self.good_table_fname)
+            self.good_log_entry = PtclTableCacheLogEntry(
+                'good_simname1', 'good_version_name', get_redshift_string(0.0),
+                self.good_table_fname)
 
             f = h5py.File(self.good_table_fname)
-            for attr in self.good_log_entry.log_attributes:
-                f.attrs.create(str(attr), str(getattr(self.good_log_entry, attr)))
+            for attr_name in self.good_log_entry.log_attributes:
+                attr = getattr(self.good_log_entry, attr_name)
+                if isinstance(attr, six.text_type):
+                    attr_lenght = len(attr)
+                    attr = np.array(attr).astype('|S{0}'.format(attr_lenght)),
+                f.attrs.create(attr_name, attr)
             f.attrs.create('Lbox', 100.)
             f.attrs.create('particle_mass', 1e8)
             f.close()
 
-
             # Create a second good halo catalog and log entry
 
             self.good_table2 = deepcopy(self.good_table)
-            self.good_table2_fname = os.path.join(self.dummy_cache_baseloc, 
-                'good_table2.hdf5')
+            self.good_table2_fname = os.path.join(self.dummy_cache_baseloc,
+                                                  'good_table2.hdf5')
             self.good_table2.write(self.good_table2_fname, path='data')
 
-            self.good_log_entry2 = PtclTableCacheLogEntry('good_simname2', 
-                'good_version_name', get_redshift_string(1.0), self.good_table2_fname)
+            self.good_log_entry2 = PtclTableCacheLogEntry(
+                'good_simname2', 'good_version_name',
+                get_redshift_string(1.0), self.good_table2_fname)
 
             f = h5py.File(self.good_table2_fname)
-            for attr in self.good_log_entry2.log_attributes:
-                f.attrs.create(str(attr), str(getattr(self.good_log_entry2, attr)))
+            for attr_name in self.good_log_entry2.log_attributes:
+                attr = getattr(self.good_log_entry2, attr_name)
+                if isinstance(attr, six.text_type):
+                    attr_lenght = len(attr)
+                    attr = np.array(attr).astype('|S{0}'.format(attr_lenght)),
+                f.attrs.create(attr_name, attr)
             f.attrs.create('Lbox', 100.)
             f.attrs.create('particle_mass', 1e8)
             f.close()
@@ -102,19 +112,19 @@ class TestPtclTableCache(TestCase):
 
             self.bad_table = Table(
                 {
-                'y': [1, 2, 3], 
-                'z': [1, 2, 3], 
+                    'y': [1, 2, 3],
+                    'z': [1, 2, 3],
                 })
 
-            bad_table_fname = os.path.join(self.dummy_cache_baseloc, 
-                'bad_table.hdf5')
+            bad_table_fname = os.path.join(self.dummy_cache_baseloc,
+                                           'bad_table.hdf5')
             self.bad_table.write(bad_table_fname, path='data')
 
             self.bad_log_entry = PtclTableCacheLogEntry('1', '2', '3', '4')
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_determine_log_entry_from_fname1(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
         entry = self.good_log_entry
         fname = entry.fname
         result = cache.determine_log_entry_from_fname(fname)
@@ -122,7 +132,7 @@ class TestPtclTableCache(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_determine_log_entry_from_fname2(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
         entry = self.bad_log_entry
         fname = entry.fname
         result = cache.determine_log_entry_from_fname(fname)
@@ -130,7 +140,7 @@ class TestPtclTableCache(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_determine_log_entry_from_fname3(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
         entry = self.bad_log_entry
         entry.fname = self.bad_log_entry.fname
         _t = Table({'x': [0]})
@@ -211,7 +221,7 @@ class TestPtclTableCache(TestCase):
         substr = "This entry does not appear in the log."
         assert substr in err.value.args[0]
 
-        cache.remove_entry_from_cache_log(*args, update_ascii = False, 
+        cache.remove_entry_from_cache_log(*args, update_ascii = False,
             raise_non_existence_exception = False)
         assert len(cache.log) == 1
 
@@ -228,7 +238,7 @@ class TestPtclTableCache(TestCase):
         os.rename(old_fname, new_fname)
 
         assert self.good_log_entry in cache.log
-        cache.update_cached_file_location(new_fname, old_fname, 
+        cache.update_cached_file_location(new_fname, old_fname,
             update_ascii = False)
         assert self.good_log_entry not in cache.log
 

--- a/halotools/sim_manager/tests/test_ptcl_table_cache.py
+++ b/halotools/sim_manager/tests/test_ptcl_table_cache.py
@@ -6,7 +6,6 @@ from astropy.tests.helper import pytest
 import warnings
 import os
 import shutil
-import numpy as np
 
 from copy import deepcopy
 
@@ -18,7 +17,6 @@ except ImportError:
 
 from astropy.config.paths import _find_home
 from astropy.table import Table
-from astropy.extern import six
 
 from . import helper_functions
 
@@ -77,10 +75,7 @@ class TestPtclTableCache(TestCase):
 
             f = h5py.File(self.good_table_fname)
             for attr_name in self.good_log_entry.log_attributes:
-                attr = getattr(self.good_log_entry, attr_name)
-                if isinstance(attr, six.text_type):
-                    attr_lenght = len(attr)
-                    attr = np.array(attr).astype('|S{0}'.format(attr_lenght)),
+                attr = getattr(self.good_log_entry, attr_name).encode('ascii')
                 f.attrs.create(attr_name, attr)
             f.attrs.create('Lbox', 100.)
             f.attrs.create('particle_mass', 1e8)
@@ -99,10 +94,7 @@ class TestPtclTableCache(TestCase):
 
             f = h5py.File(self.good_table2_fname)
             for attr_name in self.good_log_entry2.log_attributes:
-                attr = getattr(self.good_log_entry2, attr_name)
-                if isinstance(attr, six.text_type):
-                    attr_lenght = len(attr)
-                    attr = np.array(attr).astype('|S{0}'.format(attr_lenght)),
+                attr = getattr(self.good_log_entry2, attr_name).encode('ascii')
                 f.attrs.create(attr_name, attr)
             f.attrs.create('Lbox', 100.)
             f.attrs.create('particle_mass', 1e8)
@@ -150,7 +142,7 @@ class TestPtclTableCache(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_determine_log_entry_from_fname4(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
 
         entry = self.good_log_entry
         fname = entry.fname
@@ -163,86 +155,86 @@ class TestPtclTableCache(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_entry_to_cache_log1(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
         assert len(cache.log) == 0
 
         with pytest.raises(TypeError) as err:
-            cache.add_entry_to_cache_log('abc', update_ascii = False)
-        substr = "You can only add instances of PtclTableCacheLogEntry to the cache log"
+            cache.add_entry_to_cache_log('abc', update_ascii=False)
+        substr="You can only add instances of PtclTableCacheLogEntry to the cache log"
         assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_entry_to_cache_log2(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
-        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
+        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii=False)
         assert len(cache.log) == 1
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_entry_to_cache_log3(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
-        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
+        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii=False)
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
+            cache.add_entry_to_cache_log(self.good_log_entry, update_ascii=False)
             substr = "cache log already contains the entry"
             assert substr in str(w[-1].message)
         assert len(cache.log) == 1
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_entry_to_cache_log4(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
-        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
-        cache.add_entry_to_cache_log(self.good_log_entry2, update_ascii = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
+        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii=False)
+        cache.add_entry_to_cache_log(self.good_log_entry2, update_ascii=False)
         assert len(cache.log) == 2
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_entry_to_cache_log5(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
         with pytest.raises(InvalidCacheLogEntry) as err:
-            cache.add_entry_to_cache_log(self.bad_log_entry, update_ascii = False)
+            cache.add_entry_to_cache_log(self.bad_log_entry, update_ascii=False)
         substr = "The input filename does not exist."
         assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_remove_entry_from_cache_log1(self):
-        cache = PtclTableCache(read_log_from_standard_loc = False)
-        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
-        cache.add_entry_to_cache_log(self.good_log_entry2, update_ascii = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
+        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii=False)
+        cache.add_entry_to_cache_log(self.good_log_entry2, update_ascii=False)
         assert len(cache.log) == 2
 
         entry = self.good_log_entry
         args = [getattr(entry, attr) for attr in entry.log_attributes]
-        cache.remove_entry_from_cache_log(*args, update_ascii = False)
+        cache.remove_entry_from_cache_log(*args, update_ascii=False)
         assert len(cache.log) == 1
 
         with pytest.raises(HalotoolsError) as err:
-            cache.remove_entry_from_cache_log(*args, update_ascii = False)
+            cache.remove_entry_from_cache_log(*args, update_ascii=False)
         substr = "This entry does not appear in the log."
         assert substr in err.value.args[0]
 
-        cache.remove_entry_from_cache_log(*args, update_ascii = False,
-            raise_non_existence_exception = False)
+        cache.remove_entry_from_cache_log(*args, update_ascii=False,
+                                          raise_non_existence_exception=False)
         assert len(cache.log) == 1
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_update_cached_file_location(self):
         """
         """
-        cache = PtclTableCache(read_log_from_standard_loc = False)
-        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii = False)
+        cache = PtclTableCache(read_log_from_standard_loc=False)
+        cache.add_entry_to_cache_log(self.good_log_entry, update_ascii=False)
         old_fname = self.good_log_entry.fname
         old_basename = os.path.basename(old_fname)
         new_basename = "dummy" + old_basename
         new_fname = os.path.join(os.path.dirname(old_fname), new_basename)
         os.rename(old_fname, new_fname)
-
         assert self.good_log_entry in cache.log
         cache.update_cached_file_location(new_fname, old_fname,
-            update_ascii = False)
+                                          update_ascii=False)
         assert self.good_log_entry not in cache.log
 
         new_entry = cache.determine_log_entry_from_fname(new_fname)
+
         assert new_entry in cache.log
 
     def tearDown(self):
@@ -250,30 +242,3 @@ class TestPtclTableCache(TestCase):
             shutil.rmtree(self.dummy_cache_baseloc)
         except:
             pass
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/halotools/sim_manager/tests/test_ptcl_table_cache_log_entry.py
+++ b/halotools/sim_manager/tests/test_ptcl_table_cache_log_entry.py
@@ -26,7 +26,7 @@ from ..ptcl_table_cache_log_entry import PtclTableCacheLogEntry
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True
@@ -132,7 +132,7 @@ class TestPtclTableCacheLogEntry(TestCase):
         self.table1.write(self.fnames[num_scenario], path='data')
 
         f = h5py.File(self.fnames[num_scenario])
-        k = f.attrs.keys()
+        k = list(f.attrs.keys())
         f.close()
 
         log_entry = PtclTableCacheLogEntry(**self.get_scenario_kwargs(num_scenario))

--- a/halotools/sim_manager/tests/test_rockstar_hlist_reader.py
+++ b/halotools/sim_manager/tests/test_rockstar_hlist_reader.py
@@ -25,7 +25,7 @@ except ImportError:
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_rockstar_hlist_reader.py
+++ b/halotools/sim_manager/tests/test_rockstar_hlist_reader.py
@@ -113,7 +113,7 @@ class TestRockstarHlistReader(TestCase):
                 redshift = 4, version_name = 'dummy', Lbox = 100, particle_mass = 1e8 
                 )
         substr = "at least have the following columns"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_bad_columns_to_keep_dict2(self):
@@ -127,7 +127,7 @@ class TestRockstarHlistReader(TestCase):
                 redshift = 4, version_name = 'dummy', Lbox = 100, particle_mass = 1e8 
                 )
         substr = "at least have the following columns"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_bad_columns_to_keep_dict3(self):
@@ -141,7 +141,7 @@ class TestRockstarHlistReader(TestCase):
                 redshift = 4, version_name = 'dummy', Lbox = 100, particle_mass = 1e8 
                 )
         substr = "at least have the following columns"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_bad_columns_to_keep_dict4(self):
@@ -155,7 +155,7 @@ class TestRockstarHlistReader(TestCase):
                 redshift = 4, version_name = 'dummy', Lbox = 100, particle_mass = 1e8 
                 )
         substr = "appears more than once in your ``columns_to_keep_dict``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     @pytest.mark.slow
@@ -212,7 +212,7 @@ class TestRockstarHlistReader(TestCase):
                 simname = entry.simname, halo_finder = entry.halo_finder, redshift = entry.redshift, 
                 version_name = entry.version_name, Lbox = 250., particle_mass = 1.35e8)
         substr = "There is already an existing entry in the Halotools cache log"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.slow
     @pytest.mark.skipif('not HAS_H5PY')
@@ -236,7 +236,7 @@ class TestRockstarHlistReader(TestCase):
                 version_name = 'dummy', Lbox = 250., particle_mass = 1.35e8, 
                 )
         substr = "must begin with the substring ``halo_``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.slow
     @pytest.mark.skipif('not HAS_H5PY')

--- a/halotools/sim_manager/tests/test_supported_sims.py
+++ b/halotools/sim_manager/tests/test_supported_sims.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 import numpy as np
 from astropy.config.paths import _find_home 
 
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True
@@ -31,7 +31,7 @@ class TestSupportedSims(TestCase):
         """
         """
 
-        for simname in self.adict.keys():
+        for simname in list(self.adict.keys()):
             alist = self.adict[simname]
             for a in alist:
                 z = 1/a - 1
@@ -51,7 +51,7 @@ class TestSupportedSims(TestCase):
         ``halo_rvir`` column never exeeds the number 50. This is a crude way of 
         ensuring that units are in Mpc/h, not kpc/h. 
         """
-        for simname in self.adict.keys():
+        for simname in list(self.adict.keys()):
             alist = self.adict[simname]
             a = alist[0]
             z = 1/a - 1

--- a/halotools/sim_manager/tests/test_tabular_ascii_reader.py
+++ b/halotools/sim_manager/tests/test_tabular_ascii_reader.py
@@ -15,7 +15,7 @@ from ..tabular_ascii_reader import TabularAsciiReader
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_tabular_ascii_reader.py
+++ b/halotools/sim_manager/tests/test_tabular_ascii_reader.py
@@ -57,7 +57,7 @@ class TestTabularAsciiReader(TestCase):
                 os.path.basename(self.dummy_fname), 
                 columns_to_keep_dict = {'mass': (2, 'f4')})
         substr = 'is not a file'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_get_header_char(self):
         reader = TabularAsciiReader(
@@ -69,7 +69,7 @@ class TestTabularAsciiReader(TestCase):
                 columns_to_keep_dict = {'mass': (2, 'f4')}, 
                 header_char = '###')
         substr = 'must be a single string character'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_process_columns_to_keep(self):
 
@@ -78,21 +78,21 @@ class TestTabularAsciiReader(TestCase):
                 self.dummy_fname, columns_to_keep_dict = {'mass': (2, 'f4', 'c')}, 
                 header_char = '*')
         substr = 'must be a two-element tuple.'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         with pytest.raises(TypeError) as err:
             reader = TabularAsciiReader(
                 self.dummy_fname, columns_to_keep_dict = {'mass': (3.5, 'f4')}, 
                 header_char = '*')
         substr = 'The first element of the two-element tuple'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         with pytest.raises(TypeError) as err:
             reader = TabularAsciiReader(
                 self.dummy_fname, columns_to_keep_dict = {'mass': (2, 'Jose Canseco')}, 
                 header_char = '*')
         substr = 'The second element of the two-element tuple'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_verify_input_row_cuts(self):
 
@@ -123,21 +123,21 @@ class TestTabularAsciiReader(TestCase):
                 self.dummy_fname, columns_to_keep_dict = {'mass': (2, 'f4')}, 
                 row_cut_min_dict = {'mass': 9}, row_cut_max_dict = {'mass': 8})
         substr = 'This will result in zero selected rows '
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         with pytest.raises(KeyError) as err:
             reader = TabularAsciiReader(
                 self.dummy_fname, columns_to_keep_dict = {'mass': (2, 'f4')}, 
                 row_cut_min_dict = {'mass': 9}, row_cut_max_dict = {'vmax': 8})
         substr = 'The ``vmax`` key does not appear in the input'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         with pytest.raises(KeyError) as err:
             reader = TabularAsciiReader(
                 self.dummy_fname, columns_to_keep_dict = {'vmax': (1, 'f4')}, 
                 row_cut_min_dict = {'mass': 9}, row_cut_max_dict = {'vmax': 8})
         substr = 'The ``mass`` key does not appear in the input'
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_verify_eq_neq_consistency(self):
 
@@ -146,7 +146,7 @@ class TestTabularAsciiReader(TestCase):
                 self.dummy_fname, columns_to_keep_dict = {'mvir': (2, 'f4')}, 
                 row_cut_eq_dict = {'mvir': 8}, row_cut_neq_dict = {'mvir': 8})
         substr = 'This will result in zero selected rows '
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_read_dummy_halo_catalog1(self):
         fname = 'abc'
@@ -155,7 +155,7 @@ class TestTabularAsciiReader(TestCase):
         with pytest.raises(IOError) as err:
             reader = TabularAsciiReader(fname, columns_to_keep_dict)
         substr = "is not a file"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_read_dummy_halo_catalog2(self):
         fname = self.dummy_fname
@@ -165,7 +165,7 @@ class TestTabularAsciiReader(TestCase):
         with pytest.raises(ValueError) as err:
             reader = TabularAsciiReader(fname, columns_to_keep_dict)
         substr = "appears more than once in your ``columns_to_keep_dict``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.slow
     def test_read_dummy_halo_catalog3(self):
@@ -178,7 +178,7 @@ class TestTabularAsciiReader(TestCase):
             reader = TabularAsciiReader(self.dummy_fname, columns_to_keep_dict, 
                 row_cut_min_dict = row_cut_min_dict, row_cut_max_dict=row_cut_max_dict)
         substr = "This will result in zero selected rows and is not permissible."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.slow
     def test_read_dummy_halo_catalog4(self):
@@ -192,7 +192,7 @@ class TestTabularAsciiReader(TestCase):
             reader = TabularAsciiReader(self.dummy_fname, columns_to_keep_dict, 
                 row_cut_eq_dict = row_cut_eq_dict, row_cut_neq_dict=row_cut_neq_dict)
         substr = "This will result in zero selected rows and is not permissible."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.slow
     def test_read_dummy_halo_catalog5(self):
@@ -237,7 +237,7 @@ class TestTabularAsciiReader(TestCase):
         with pytest.raises(ValueError) as err:
             arr = reader.read_ascii(chunk_memory_size = 0)
         substr = "Must choose non-zero size for input ``chunk_memory_size``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def tearDown(self):
         try:

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -99,7 +99,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 Lbox = 200, particle_mass = 100, redshift = '', 
                 **self.good_halocat_args)
         substr = "The ``redshift`` metadata must be a float."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     def test_successful_load(self):
@@ -232,7 +232,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 Lbox = 200, particle_mass = 100, redshift = self.redshift,
                 user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
         substr = "Inconsistent values of Lbox"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_ptcl_table_bad_args2(self):
 
@@ -250,7 +250,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 Lbox = 200, particle_mass = 100, redshift = self.redshift,
                 user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
         substr = "Inconsistent values of particle_mass"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_ptcl_table_bad_args3(self):
 
@@ -268,7 +268,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 Lbox = 200, particle_mass = 200, redshift = self.redshift,
                 user_supplied_ptclcat = ptclcat, **self.good_halocat_args)
         substr = "Inconsistent values of redshift"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_ptcl_table_bad_args4(self):
 
@@ -277,7 +277,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 Lbox = 200, particle_mass = 200, redshift = self.redshift,
                 user_supplied_ptclcat = 98, **self.good_halocat_args)
         substr = "an instance of UserSuppliedPtclCatalog"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache1(self):
@@ -296,13 +296,13 @@ class TestUserSuppliedHaloCatalog(TestCase):
             halocat.add_halocat_to_cache(
                 fname, dummy_string, dummy_string, dummy_string, dummy_string)
         substr = "Either choose a different fname or set ``overwrite`` to True"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         with pytest.raises(HalotoolsError) as err:
             halocat.add_halocat_to_cache(
                 fname, dummy_string, dummy_string, dummy_string, dummy_string, 
                 overwrite = True)
-        assert substr not in err.value.message
+        assert substr not in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache2(self):
@@ -317,7 +317,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
             halocat.add_halocat_to_cache(
                 basename, dummy_string, dummy_string, dummy_string, dummy_string)
         substr = "The directory you are trying to store the file does not exist."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache3(self):
@@ -337,7 +337,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 fname, dummy_string, dummy_string, dummy_string, dummy_string, 
                 overwrite = True)
         substr = "The fname must end with an ``.hdf5`` extension."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache4(self):
@@ -364,7 +364,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 fname, not_representable_as_string, dummy_string, dummy_string, dummy_string, 
                 overwrite = True)
         substr = "must all be strings."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache5(self):
@@ -391,7 +391,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
                 fname, dummy_string, dummy_string, dummy_string, dummy_string, 
                 overwrite = True, some_more_metadata = not_representable_as_string)
         substr = "keyword is not representable as a string."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     @pytest.mark.skipif('not HAS_H5PY')

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -30,7 +30,7 @@ from ...custom_exceptions import HalotoolsError, InvalidCacheLogEntry
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -2,19 +2,21 @@
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
-import warnings, os, shutil
+import warnings
+import os
+import shutil
 
-from astropy.config.paths import _find_home 
-from astropy.tests.helper import remote_data, pytest
+from astropy.config.paths import _find_home
+from astropy.tests.helper import pytest
 
 try:
-    import h5py 
+    import h5py
     HAS_H5PY = True
 except ImportError:
     HAS_H5PY = False
 
-import numpy as np 
-from copy import copy, deepcopy 
+import numpy as np
+from copy import deepcopy
 
 from . import helper_functions
 
@@ -24,11 +26,11 @@ from .. import UserSuppliedHaloCatalog
 from ..user_supplied_ptcl_catalog import UserSuppliedPtclCatalog
 from ..halo_table_cache import HaloTableCache
 
-from ...custom_exceptions import HalotoolsError, InvalidCacheLogEntry
+from ...custom_exceptions import HalotoolsError
 
-### Determine whether the machine is mine
-# This will be used to select tests whose 
-# returned values depend on the configuration 
+# Determine whether the machine is mine
+# This will be used to select tests whose
+# returned values depend on the configuration
 # of my personal cache directory files
 aph_home = '/Users/aphearin'
 detected_home = _find_home()
@@ -40,11 +42,11 @@ else:
 __all__ = ('TestUserSuppliedHaloCatalog', )
 
 class TestUserSuppliedHaloCatalog(TestCase):
-    """ Class providing tests of the `~halotools.sim_manager.UserSuppliedHaloCatalog`. 
+    """ Class providing tests of the `~halotools.sim_manager.UserSuppliedHaloCatalog`.
     """
 
     def setUp(self):
-        """ Pre-load various arrays into memory for use by all tests. 
+        """ Pre-load various arrays into memory for use by all tests.
         """
         self.Nhalos = 1e2
         self.Lbox = 100
@@ -55,15 +57,15 @@ class TestUserSuppliedHaloCatalog(TestCase):
         self.halo_mass = np.logspace(10, 15, self.Nhalos)
         self.halo_id = np.arange(0, self.Nhalos, dtype = np.int)
         self.good_halocat_args = (
-            {'halo_x': self.halo_x, 'halo_y': self.halo_y, 
+            {'halo_x': self.halo_x, 'halo_y': self.halo_y,
             'halo_z': self.halo_z, 'halo_id': self.halo_id, 'halo_mass': self.halo_mass}
             )
         self.toy_list = [elt for elt in self.halo_x]
 
         self.num_ptcl = 1e4
         self.good_ptcl_table = Table(
-            {'x': np.zeros(self.num_ptcl), 
-            'y': np.zeros(self.num_ptcl), 
+            {'x': np.zeros(self.num_ptcl),
+            'y': np.zeros(self.num_ptcl),
             'z': np.zeros(self.num_ptcl)}
             )
 
@@ -77,26 +79,26 @@ class TestUserSuppliedHaloCatalog(TestCase):
     def test_particle_mass_requirement(self):
 
         with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 **self.good_halocat_args)
 
     def test_lbox_requirement(self):
 
         with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedHaloCatalog(particle_mass = 200, 
+            halocat = UserSuppliedHaloCatalog(particle_mass = 200,
                 **self.good_halocat_args)
 
     def test_halos_contained_inside_lbox(self):
 
         with pytest.raises(HalotoolsError):
-            halocat = UserSuppliedHaloCatalog(Lbox = 20, particle_mass = 100, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 20, particle_mass = 100,
                 **self.good_halocat_args)
 
     def test_redshift_is_float(self):
 
         with pytest.raises(HalotoolsError) as err:
             halocat = UserSuppliedHaloCatalog(
-                Lbox = 200, particle_mass = 100, redshift = '', 
+                Lbox = 200, particle_mass = 100, redshift = '',
                 **self.good_halocat_args)
         substr = "The ``redshift`` metadata must be a float."
         assert substr in err.value.args[0]
@@ -104,8 +106,8 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
     def test_successful_load(self):
 
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
         assert hasattr(halocat, 'Lbox')
         assert halocat.Lbox == 200
@@ -114,9 +116,9 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
     def test_additional_metadata(self):
 
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
             particle_mass = 100, redshift = self.redshift,
-            arnold_schwarzenegger = 'Stick around!', 
+            arnold_schwarzenegger = 'Stick around!',
             **self.good_halocat_args)
         assert hasattr(halocat, 'arnold_schwarzenegger')
         assert halocat.arnold_schwarzenegger == 'Stick around!'
@@ -127,7 +129,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
         bad_halocat_args = deepcopy(self.good_halocat_args)
         with pytest.raises(HalotoolsError):
             bad_halocat_args['halo_x'][0] = -1
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 particle_mass = 100, redshift = self.redshift,
                 **bad_halocat_args)
 
@@ -136,25 +138,25 @@ class TestUserSuppliedHaloCatalog(TestCase):
         bad_halocat_args = deepcopy(self.good_halocat_args)
         with pytest.raises(HalotoolsError):
             bad_halocat_args['halo_x'][0] = 10000
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 particle_mass = 100, redshift = self.redshift,
                 **bad_halocat_args)
 
     def test_has_halo_x_column(self):
-        # must have halo_x column 
+        # must have halo_x column
         bad_halocat_args = deepcopy(self.good_halocat_args)
         with pytest.raises(HalotoolsError):
             del bad_halocat_args['halo_x']
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 particle_mass = 100, redshift = self.redshift,
                 **bad_halocat_args)
 
     def test_has_halo_id_column(self):
-        # Must have halo_id column 
+        # Must have halo_id column
         bad_halocat_args = deepcopy(self.good_halocat_args)
         with pytest.raises(HalotoolsError):
             del bad_halocat_args['halo_id']
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 particle_mass = 100, redshift = self.redshift,
                 **bad_halocat_args)
 
@@ -163,19 +165,19 @@ class TestUserSuppliedHaloCatalog(TestCase):
         bad_halocat_args = deepcopy(self.good_halocat_args)
         with pytest.raises(HalotoolsError):
             del bad_halocat_args['halo_mass']
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 particle_mass = 100, redshift = self.redshift,
                 **bad_halocat_args)
 
     def test_halo_prefix_warning(self):
-        # Must raise warning if a length-Nhalos array is passed with 
+        # Must raise warning if a length-Nhalos array is passed with
         # a keyword argument that does not begin with 'halo_'
         bad_halocat_args = deepcopy(self.good_halocat_args)
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             bad_halocat_args['s'] = np.ones(self.Nhalos)
-            halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+            halocat = UserSuppliedHaloCatalog(Lbox = 200,
                 particle_mass = 100, redshift = self.redshift,
                 **bad_halocat_args)
             assert 'interpreted as metadata' in str(w[-1].message)
@@ -183,11 +185,11 @@ class TestUserSuppliedHaloCatalog(TestCase):
     def test_ptcl_table(self):
         """ Method performs various existence and consistency tests on the input ptcl_table.
 
-        * Enforce that instances do *not* have ``ptcl_table`` attributes if none is passed. 
+        * Enforce that instances do *not* have ``ptcl_table`` attributes if none is passed.
 
-        * Enforce that instances *do* have ``ptcl_table`` attributes if a legitimate one is passed. 
+        * Enforce that instances *do* have ``ptcl_table`` attributes if a legitimate one is passed.
 
-        * Enforce that ptcl_table have ``x``, ``y`` and ``z`` columns. 
+        * Enforce that ptcl_table have ``x``, ``y`` and ``z`` columns.
 
         * Enforce that ptcl_table input is an Astropy `~astropy.table.Table` object, not a Numpy recarray
         """
@@ -195,19 +197,19 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
     def test_ptcl_table_dne(self):
         # Must not have a ptcl_table attribute when none is passed
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
             particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
         assert not hasattr(halocat, 'ptcl_table')
 
     def test_ptcl_table_exists_when_given_goodargs(self):
-   
+
         # Must have ptcl_table attribute when argument is legitimate
         ptclcat = UserSuppliedPtclCatalog(
-            x = np.zeros(self.num_ptcl), 
-            y = np.zeros(self.num_ptcl), 
-            z = np.zeros(self.num_ptcl), 
-            Lbox = 200, particle_mass = 100, 
+            x = np.zeros(self.num_ptcl),
+            y = np.zeros(self.num_ptcl),
+            z = np.zeros(self.num_ptcl),
+            Lbox = 200, particle_mass = 100,
             redshift = self.redshift
             )
 
@@ -220,10 +222,10 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
         # Must have ptcl_table attribute when argument is legitimate
         ptclcat = UserSuppliedPtclCatalog(
-            x = np.zeros(self.num_ptcl), 
-            y = np.zeros(self.num_ptcl), 
-            z = np.zeros(self.num_ptcl), 
-            Lbox = 100, particle_mass = 100, 
+            x = np.zeros(self.num_ptcl),
+            y = np.zeros(self.num_ptcl),
+            z = np.zeros(self.num_ptcl),
+            Lbox = 100, particle_mass = 100,
             redshift = self.redshift
             )
 
@@ -238,10 +240,10 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
         # Must have ptcl_table attribute when argument is legitimate
         ptclcat = UserSuppliedPtclCatalog(
-            x = np.zeros(self.num_ptcl), 
-            y = np.zeros(self.num_ptcl), 
-            z = np.zeros(self.num_ptcl), 
-            Lbox = 200, particle_mass = 200, 
+            x = np.zeros(self.num_ptcl),
+            y = np.zeros(self.num_ptcl),
+            z = np.zeros(self.num_ptcl),
+            Lbox = 200, particle_mass = 200,
             redshift = self.redshift
             )
 
@@ -256,10 +258,10 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
         # Must have ptcl_table attribute when argument is legitimate
         ptclcat = UserSuppliedPtclCatalog(
-            x = np.zeros(self.num_ptcl), 
-            y = np.zeros(self.num_ptcl), 
-            z = np.zeros(self.num_ptcl), 
-            Lbox = 200, particle_mass = 200, 
+            x = np.zeros(self.num_ptcl),
+            y = np.zeros(self.num_ptcl),
+            z = np.zeros(self.num_ptcl),
+            Lbox = 200, particle_mass = 200,
             redshift = self.redshift + 0.1
             )
 
@@ -281,8 +283,8 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache1(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
 
         basename = 'abc'
@@ -300,14 +302,14 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
         with pytest.raises(HalotoolsError) as err:
             halocat.add_halocat_to_cache(
-                fname, dummy_string, dummy_string, dummy_string, dummy_string, 
+                fname, dummy_string, dummy_string, dummy_string, dummy_string,
                 overwrite = True)
         assert substr not in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache2(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
 
         basename = 'abc'
@@ -321,8 +323,8 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache3(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
 
         basename = 'abc'
@@ -334,15 +336,15 @@ class TestUserSuppliedHaloCatalog(TestCase):
         dummy_string = '  '
         with pytest.raises(HalotoolsError) as err:
             halocat.add_halocat_to_cache(
-                fname, dummy_string, dummy_string, dummy_string, dummy_string, 
+                fname, dummy_string, dummy_string, dummy_string, dummy_string,
                 overwrite = True)
         substr = "The fname must end with an ``.hdf5`` extension."
         assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache4(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
 
         basename = 'abc.hdf5'
@@ -354,22 +356,22 @@ class TestUserSuppliedHaloCatalog(TestCase):
         dummy_string = '  '
         class Dummy(object):
             pass
-            
+
             def __str__(self):
                 raise TypeError
         not_representable_as_string = Dummy()
 
         with pytest.raises(HalotoolsError) as err:
             halocat.add_halocat_to_cache(
-                fname, not_representable_as_string, dummy_string, dummy_string, dummy_string, 
+                fname, not_representable_as_string, dummy_string, dummy_string, dummy_string,
                 overwrite = True)
         substr = "must all be strings."
         assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache5(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
 
         basename = 'abc.hdf5'
@@ -381,14 +383,14 @@ class TestUserSuppliedHaloCatalog(TestCase):
         dummy_string = '  '
         class Dummy(object):
             pass
-            
+
             def __str__(self):
                 raise TypeError
         not_representable_as_string = Dummy()
 
         with pytest.raises(HalotoolsError) as err:
             halocat.add_halocat_to_cache(
-                fname, dummy_string, dummy_string, dummy_string, dummy_string, 
+                fname, dummy_string, dummy_string, dummy_string, dummy_string,
                 overwrite = True, some_more_metadata = not_representable_as_string)
         substr = "keyword is not representable as a string."
         assert substr in err.value.args[0]
@@ -396,8 +398,8 @@ class TestUserSuppliedHaloCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_halocat_to_cache6(self):
-        halocat = UserSuppliedHaloCatalog(Lbox = 200, 
-            particle_mass = 100, redshift = self.redshift, 
+        halocat = UserSuppliedHaloCatalog(Lbox = 200,
+            particle_mass = 100, redshift = self.redshift,
             **self.good_halocat_args)
 
         basename = 'abc.hdf5'
@@ -409,19 +411,19 @@ class TestUserSuppliedHaloCatalog(TestCase):
         processing_notes = 'dummy processing notes'
 
         halocat.add_halocat_to_cache(
-            fname, simname, halo_finder, version_name, processing_notes, 
+            fname, simname, halo_finder, version_name, processing_notes,
             overwrite = True, some_additional_metadata = processing_notes)
 
         cache = HaloTableCache()
         assert halocat.log_entry in cache.log
 
         cache.remove_entry_from_cache_log(
-            halocat.log_entry.simname, 
+            halocat.log_entry.simname,
             halocat.log_entry.halo_finder,
             halocat.log_entry.version_name,
             halocat.log_entry.redshift,
-            halocat.log_entry.fname, 
-            raise_non_existence_exception = True, 
+            halocat.log_entry.fname,
+            raise_non_existence_exception = True,
             update_ascii = True,
             delete_corresponding_halo_catalog = True)
 

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -29,7 +29,7 @@ from ...custom_exceptions import HalotoolsError, InvalidCacheLogEntry
 # This will be used to select tests whose 
 # returned values depend on the configuration 
 # of my personal cache directory files
-aph_home = u'/Users/aphearin'
+aph_home = '/Users/aphearin'
 detected_home = _find_home()
 if aph_home == detected_home:
     APH_MACHINE = True
@@ -253,9 +253,9 @@ class TestUserSuppliedPtclCatalog(TestCase):
         version_name = 'dummy_version_name'
         processing_notes = 'dummy processing notes'
 
-        assert 'x' in ptclcat.ptcl_table.keys()
-        assert 'y' in ptclcat.ptcl_table.keys()
-        assert 'z' in ptclcat.ptcl_table.keys()
+        assert 'x' in list(ptclcat.ptcl_table.keys())
+        assert 'y' in list(ptclcat.ptcl_table.keys())
+        assert 'z' in list(ptclcat.ptcl_table.keys())
 
         ptclcat.add_ptclcat_to_cache(
             fname, simname, version_name, processing_notes, overwrite = True)

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -92,7 +92,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
                 Lbox = 200, particle_mass = 100, redshift = '', 
                 **self.good_ptclcat_args)
         substr = "The ``redshift`` metadata must be a float."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
     def test_successful_load(self):
@@ -162,13 +162,13 @@ class TestUserSuppliedPtclCatalog(TestCase):
             ptclcat.add_ptclcat_to_cache(
                 fname, dummy_string, dummy_string, dummy_string)
         substr = "Either choose a different fname or set ``overwrite`` to True"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         with pytest.raises(HalotoolsError) as err:
             ptclcat.add_ptclcat_to_cache(
                 fname, dummy_string, dummy_string, dummy_string, 
                 overwrite = True)
-        assert substr not in err.value.message
+        assert substr not in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache2(self):
@@ -185,7 +185,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
             ptclcat.add_ptclcat_to_cache(
                 basename, dummy_string, dummy_string, dummy_string, dummy_string)
         substr = "The directory you are trying to store the file does not exist."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache3(self):
@@ -207,7 +207,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
                 fname, dummy_string, dummy_string, dummy_string, 
                 overwrite = True)
         substr = "The fname must end with an ``.hdf5`` extension."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache4(self):
@@ -236,7 +236,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
                 fname, not_representable_as_string, dummy_string, dummy_string, 
                 overwrite = True)
         substr = "must all be strings."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
 
 

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -145,8 +145,8 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache1(self):
-    	""" Verify the overwrite requirement is enforced
-    	"""
+        """ Verify the overwrite requirement is enforced
+        """
         ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
             particle_mass = 100, redshift = self.redshift, 
             **self.good_ptclcat_args)
@@ -172,8 +172,8 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache2(self):
-    	""" Verify that the appropriate message is issued when trying to save the file to a non-existent directory.
-    	""" 
+        """ Verify that the appropriate message is issued when trying to save the file to a non-existent directory.
+        """ 
         ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
             particle_mass = 100, redshift = self.redshift, 
             **self.good_ptclcat_args)
@@ -189,8 +189,8 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache3(self):
-    	""" Verify that the .hdf5 extension requirement is enforced.
-    	"""
+        """ Verify that the .hdf5 extension requirement is enforced.
+        """
         ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
             particle_mass = 100, redshift = self.redshift, 
             **self.good_ptclcat_args)
@@ -211,8 +211,8 @@ class TestUserSuppliedPtclCatalog(TestCase):
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_add_ptclcat_to_cache4(self):
-    	""" Enforce string representation of positional arguments
-    	"""
+        """ Enforce string representation of positional arguments
+        """
         ptclcat = UserSuppliedPtclCatalog(Lbox = 200, 
             particle_mass = 100, redshift = self.redshift, 
             **self.good_ptclcat_args)
@@ -226,7 +226,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
         dummy_string = '  '
         class Dummy(object):
             pass
-            
+
             def __str__(self):
                 raise TypeError
         not_representable_as_string = Dummy()

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -2,7 +2,7 @@
 """
 
 import numpy as np
-import os, sys, urllib2, fnmatch
+import os, sys, urllib.request, urllib.error, urllib.parse, fnmatch
 from warnings import warn 
 import datetime 
 
@@ -135,7 +135,7 @@ class UserSuppliedHaloCatalog(object):
         self.halo_table = Table(halo_table_dict)
 
         self._test_metadata_dict(**metadata_dict)
-        for key, value in metadata_dict.iteritems():
+        for key, value in metadata_dict.items():
             setattr(self, key, value)
 
         self._passively_bind_ptcl_table(**kwargs)
@@ -163,7 +163,7 @@ class UserSuppliedHaloCatalog(object):
             assert type(halo_id) is np.ndarray 
             Nhalos = custom_len(halo_id)
             assert Nhalos > 1
-        except KeyError, AssertionError:
+        except KeyError as AssertionError:
             msg = ("\nThe UserSuppliedHaloCatalog requires a ``halo_id`` keyword argument "
                 "storing an ndarray of length Nhalos > 1.\n")
             raise HalotoolsError(msg)
@@ -239,7 +239,7 @@ class UserSuppliedHaloCatalog(object):
             msg = ("\nThe ``redshift`` metadata must be a float.\n")
             raise HalotoolsError(msg)
 
-        for key, value in metadata_dict.iteritems():
+        for key, value in metadata_dict.items():
             if (type(value) == np.ndarray):
                 if custom_len(value) == len(self.halo_table['halo_id']):
                     msg = ("\nThe input ``" + key + "`` argument stores a length-Nhalos ndarray.\n"
@@ -381,7 +381,7 @@ class UserSuppliedHaloCatalog(object):
                 "and ``processing_notes``\nmust all be strings.")
             raise HalotoolsError(msg)
 
-        for key, value in additional_metadata.iteritems():
+        for key, value in additional_metadata.items():
             try:
                 _ = str(value)
             except:
@@ -416,7 +416,7 @@ class UserSuppliedHaloCatalog(object):
 
         f.attrs.create('processing_notes', str(processing_notes))
 
-        for key, value in additional_metadata.iteritems():
+        for key, value in additional_metadata.items():
             f.attrs.create(key, str(value))
 
         f.close()

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -387,54 +387,41 @@ class UserSuppliedHaloCatalog(object):
 
 
         ############################################################
-        ## Now write the file to disk and add the appropriate metadata
+        # Now write the file to disk and add the appropriate metadata
 
-        self.halo_table.write(fname, path='data', overwrite = overwrite)
+        self.halo_table.write(fname, path='data', overwrite=overwrite)
 
         f = h5py.File(fname)
 
-        redshift_string = str(get_redshift_string(self.redshift))
+        redshift_string = get_redshift_string(self.redshift)
 
-        f.attrs.create('simname', str(simname))
-        f.attrs.create('halo_finder', str(halo_finder))
-        f.attrs.create('version_name', str(version_name))
-        f.attrs.create('redshift', redshift_string)
-        f.attrs.create('fname', str(fname))
+        f.attrs.create('simname', simname.encode('ascii'))
+        f.attrs.create('halo_finder', halo_finder.encode('ascii'))
+        f.attrs.create('version_name', version_name.encode('ascii'))
+        f.attrs.create('redshift', redshift_string.encode('ascii'))
+        f.attrs.create('fname', fname.encode('ascii'))
 
         f.attrs.create('Lbox', self.Lbox)
         f.attrs.create('particle_mass', self.particle_mass)
 
-        time_right_now = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        time_right_now = datetime.datetime.now().strftime(
+            '%Y-%m-%d %H:%M:%S').encode('ascii')
+
         f.attrs.create('time_catalog_was_originally_cached', time_right_now)
 
-        f.attrs.create('processing_notes', str(processing_notes))
+        f.attrs.create('processing_notes', processing_notes.encode('ascii'))
 
         for key, value in additional_metadata.items():
-            f.attrs.create(key, str(value))
+            f.attrs.create(key, value.encode('ascii'))
 
         f.close()
         ############################################################
         # Now that the file is on disk, add it to the cache
         cache = HaloTableCache()
 
-        log_entry = HaloTableCacheLogEntry(simname = simname,
-            halo_finder = halo_finder, version_name = version_name,
-            redshift = self.redshift, fname = fname)
+        log_entry = HaloTableCacheLogEntry(
+            simname=simname, halo_finder=halo_finder,
+            version_name=version_name, redshift=self.redshift, fname=fname)
 
-        cache.add_entry_to_cache_log(log_entry, update_ascii = True)
+        cache.add_entry_to_cache_log(log_entry, update_ascii=True)
         self.log_entry = log_entry
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -2,7 +2,7 @@
 """
 
 import numpy as np
-import os, sys, urllib2, fnmatch
+import os, sys, urllib.request, urllib.error, urllib.parse, fnmatch
 from warnings import warn 
 import datetime 
 
@@ -145,7 +145,7 @@ class UserSuppliedPtclCatalog(object):
         self.ptcl_table = Table(ptcl_table_dict)
 
         self._test_metadata_dict(**metadata_dict)
-        for key, value in metadata_dict.iteritems():
+        for key, value in metadata_dict.items():
             setattr(self, key, value)
 
 
@@ -164,7 +164,7 @@ class UserSuppliedPtclCatalog(object):
             assert Nptcls >= 1e4
             assert Nptcls == len(y)
             assert Nptcls == len(z)
-        except KeyError, AssertionError:
+        except KeyError as AssertionError:
             msg = ("\nThe UserSuppliedPtclCatalog requires ``x``, ``y`` and ``z`` keyword arguments,\n "
                 "each of which must store an ndarray of the same length Nptcls >= 1e4.\n")
             raise HalotoolsError(msg)

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -183,7 +183,7 @@ class UserSuppliedPtclCatalog(object):
             {key: kwargs[key] for key in kwargs if key not in ptcl_table_dict}
             )
 
-    	return ptcl_table_dict, metadata_dict
+        return ptcl_table_dict, metadata_dict
 
     def _test_metadata_dict(self, **metadata_dict):
         try:

--- a/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
+++ b/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
@@ -120,15 +120,15 @@ class TestHodModelFactoryTutorial(TestCase):
         assert hasattr(model_instance, 'mean_quiescent_fraction_centrals')
         assert hasattr(model_instance, 'mean_quiescent_fraction_satellites')
 
-        assert 'centrals_quiescent_ordinates_param1' in model_instance.param_dict.keys()
-        assert 'centrals_quiescent_ordinates_param2' in model_instance.param_dict.keys()
-        assert 'satellites_quiescent_ordinates_param1' in model_instance.param_dict.keys()
-        assert 'satellites_quiescent_ordinates_param4' in model_instance.param_dict.keys()
+        assert 'centrals_quiescent_ordinates_param1' in list(model_instance.param_dict.keys())
+        assert 'centrals_quiescent_ordinates_param2' in list(model_instance.param_dict.keys())
+        assert 'satellites_quiescent_ordinates_param1' in list(model_instance.param_dict.keys())
+        assert 'satellites_quiescent_ordinates_param4' in list(model_instance.param_dict.keys())
 
         halocat = FakeSim()
         model_instance.populate_mock(halocat)
 
-        assert 'quiescent' in model_instance.mock.galaxy_table.keys()
+        assert 'quiescent' in list(model_instance.mock.galaxy_table.keys())
         assert set(model_instance.mock.galaxy_table['quiescent']) == {True, False}
 
         cenmask = model_instance.mock.galaxy_table['gal_type'] == 'centrals'
@@ -196,7 +196,7 @@ class TestHodModelFactoryTutorial(TestCase):
 
         halocat = FakeSim()
         new_model.populate_mock(halocat)
-        assert 'galsize' in new_model.mock.galaxy_table.keys()
+        assert 'galsize' in list(new_model.mock.galaxy_table.keys())
         assert len(set(new_model.mock.galaxy_table['galsize'])) > 0
 
     @pytest.mark.slow
@@ -222,7 +222,7 @@ class TestHodModelFactoryTutorial(TestCase):
                     'disrupted_fraction_'+self.gal_type: 0.25})
 
             def assign_disrupted(self, **kwargs):
-                if 'table' in kwargs.keys():
+                if 'table' in list(kwargs.keys()):
                     table = kwargs['table']
                     halo_mass = table[self.prim_haloprop_key]
                 else:
@@ -232,7 +232,7 @@ class TestHodModelFactoryTutorial(TestCase):
                 randomizer = np.random.uniform(0, 1, len(halo_mass))
                 is_disrupted = randomizer < disrupted_fraction
 
-                if 'table' in kwargs.keys():
+                if 'table' in list(kwargs.keys()):
                     table['disrupted'][:] = is_disrupted
                 else:
                     return is_disrupted
@@ -258,10 +258,10 @@ class TestHodModelFactoryTutorial(TestCase):
 
         halocat = FakeSim()
         new_model.populate_mock(halocat)
-        assert 'axis_ratio' in new_model.mock.galaxy_table.keys()
+        assert 'axis_ratio' in list(new_model.mock.galaxy_table.keys())
         assert len(set(new_model.mock.galaxy_table['axis_ratio'])) > 1
 
-        assert 'disrupted' in new_model.mock.galaxy_table.keys()
+        assert 'disrupted' in list(new_model.mock.galaxy_table.keys())
         assert set(new_model.mock.galaxy_table['disrupted']) == {True, False}
 
         mask = new_model.mock.galaxy_table['disrupted'] == False

--- a/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
+++ b/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
@@ -354,7 +354,7 @@ class TestHodModelFactoryTutorial(TestCase):
         halocat = FakeSim()
         with pytest.raises(KeyError) as err:
             model.populate_mock(halocat)
-        assert "halo_spin" in err.value.message
+        assert "halo_spin" in err.value.args[0]
 
     @pytest.mark.slow
     def test_hod_modeling_tutorial6(self):

--- a/halotools/utils/array_utils.py
+++ b/halotools/utils/array_utils.py
@@ -5,7 +5,7 @@ Modules performing small, commonly used tasks throughout the package.
 
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+
 
 __all__ = (['custom_len', 'find_idx_nearest_val', 
     'randomly_downsample_data', 'array_is_monotonic', 'convert_to_ndarray'])
@@ -69,7 +69,7 @@ def convert_to_ndarray(x, dt = None):
                 return x.astype(dt)
     elif type(x) is Table:
         return x
-    elif (type(x) is str) or (type(x) is unicode):
+    elif (type(x) is str) or (type(x) is str):
         x = np.array([x])
         if dt is None:
             return x.astype(type(x.flatten()[0]))

--- a/halotools/utils/group_member_generator.py
+++ b/halotools/utils/group_member_generator.py
@@ -146,7 +146,7 @@ def group_member_generator(data, grouping_key, requested_columns,
         msg = ("\nThe input ``requested_columns`` must be an iterable sequence\n")
         raise TypeError(msg)
     except AssertionError:
-        if type(requested_columns) in (str, unicode):
+        if type(requested_columns) in (str, str):
             msg = ("\n Your input ``requested_columns`` should be a \n"
                 "list of strings, not a single string\n")
         else:

--- a/halotools/utils/io_utils.py
+++ b/halotools/utils/io_utils.py
@@ -4,36 +4,38 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from time import time
-import sys, urllib.request, urllib.parse, urllib.error
+import sys
+from astropy.extern.six.moves import urllib
 
 __all__ = ['file_len', 'download_file_from_url']
+
 
 def file_len(fname):
     with open(fname) as f:
         for i, l in enumerate(f):
             pass
-    return i + 1    
-    
+    return i + 1
+
 
 def download_file_from_url(url, fname):
-    """ Function to download a file from the web to a specific location, 
-    and print a progress bar along the way. 
+    """ Function to download a file from the web to a specific location,
+    and print a progress bar along the way.
 
-    Parameters 
+    Parameters
     ----------
-    url : string 
-        web location of desired file, e.g., 
-        ``http://www.some.website.com/somefile.txt``. 
+    url : string
+        web location of desired file, e.g.,
+        ``http://www.some.website.com/somefile.txt``.
 
-    fname : string 
-        Location and filename to store the downloaded file, e.g., 
+    fname : string
+        Location and filename to store the downloaded file, e.g.,
         ``/Users/username/dirname/possibly_new_filename.txt``
     """
     start = time()
     print("\n... Downloading data from the following location: \n%s\n" % url)
-    print(" ... Saving the data with the following filename: \n%s\n" % fname) 
+    print(" ... Saving the data with the following filename: \n%s\n" % fname)
 
-    def reporthook(blocks_thus_far, bytes_per_block, file_size_in_bytes): 
+    def reporthook(blocks_thus_far, bytes_per_block, file_size_in_bytes):
         try:
             blocks_in_file = int(round(file_size_in_bytes/bytes_per_block))
             printout_condition = int(round(blocks_in_file/20))

--- a/halotools/utils/io_utils.py
+++ b/halotools/utils/io_utils.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from time import time
-import sys, urllib
+import sys, urllib.request, urllib.parse, urllib.error
 
 __all__ = ['file_len', 'download_file_from_url']
 
@@ -46,7 +46,7 @@ def download_file_from_url(url, fname):
             pass
         sys.stdout.flush()
 
-    urllib.urlretrieve(url, fname, reporthook)
+    urllib.request.urlretrieve(url, fname, reporthook)
 
 
 

--- a/halotools/utils/spherical_geometry.py
+++ b/halotools/utils/spherical_geometry.py
@@ -101,6 +101,6 @@ def sample_spherical_surface(N_points):
     ran_ra = ran1
     ran_dec = ran2
 
-    coords = zip(ran_ra,ran_dec)
+    coords = list(zip(ran_ra,ran_dec))
 
     return coords

--- a/halotools/utils/table_utils.py
+++ b/halotools/utils/table_utils.py
@@ -8,59 +8,58 @@ Modules performing small, commonly used tasks throughout the package.
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-
-__all__ = ['SampleSelector']
-
 from math import ceil
 import numpy as np
-import collections
-from warnings import warn 
+from warnings import warn
 from astropy.table import Table
 
 from ..custom_exceptions import HalotoolsError
 
+__all__ = ['SampleSelector']
+
+
 def compute_conditional_percentiles(**kwargs):
     """
-    In bins of the ``prim_haloprop``, compute the rank-order percentile 
-    of the input ``table`` based on the value of ``sec_haloprop``. 
+    In bins of the ``prim_haloprop``, compute the rank-order percentile
+    of the input ``table`` based on the value of ``sec_haloprop``.
 
     Parameters
     ----------
-    table : astropy table, optional 
+    table : astropy table, optional
         a keyword argument that stores halo catalog being used to make mock galaxy population
-        If a `table` is passed, the `prim_haloprop_key` and `sec_haloprop_key` keys 
-        must also be passed. If not passing a `table`, you must directly pass the 
-        `prim_haloprop` and `sec_haloprop` keyword arguments. 
+        If a `table` is passed, the `prim_haloprop_key` and `sec_haloprop_key` keys
+        must also be passed. If not passing a `table`, you must directly pass the
+        `prim_haloprop` and `sec_haloprop` keyword arguments.
 
-    prim_haloprop_key : string, optional 
-        Name of the column of the input ``table`` that will be used to access the 
-        primary halo property. `compute_conditional_percentiles` bins the ``table`` by 
-        ``prim_haloprop_key`` when computing the result. 
+    prim_haloprop_key : string, optional
+        Name of the column of the input ``table`` that will be used to access the
+        primary halo property. `compute_conditional_percentiles` bins the ``table`` by
+        ``prim_haloprop_key`` when computing the result.
 
-    sec_haloprop_key : string, optional 
-        Name of the column of the input ``table`` that will be used to access the 
-        secondary halo property. `compute_conditional_percentiles` bins the ``table`` by 
-        ``prim_haloprop_key``, and in each bin uses the value stored in ``sec_haloprop_key`` 
-        to compute the ``prim_haloprop``-conditioned rank-order percentile. 
+    sec_haloprop_key : string, optional
+        Name of the column of the input ``table`` that will be used to access the
+        secondary halo property. `compute_conditional_percentiles` bins the ``table`` by
+        ``prim_haloprop_key``, and in each bin uses the value stored in ``sec_haloprop_key``
+        to compute the ``prim_haloprop``-conditioned rank-order percentile.
 
-    prim_haloprop : array_like, optional 
-        Array storing the primary halo property used to bin the input points. 
-        If a `prim_haloprop` is passed, you must also pass a `sec_haloprop`. 
+    prim_haloprop : array_like, optional
+        Array storing the primary halo property used to bin the input points.
+        If a `prim_haloprop` is passed, you must also pass a `sec_haloprop`.
 
-    sec_haloprop : array_like, optional 
-        Array storing the secondary halo property used to define the conditional percentiles 
-        in each bin of `prim_haloprop`. 
+    sec_haloprop : array_like, optional
+        Array storing the secondary halo property used to define the conditional percentiles
+        in each bin of `prim_haloprop`.
 
-    prim_haloprop_bin_boundaries : array, optional 
-        Array defining the boundaries by which we will bin the input ``table``. 
-        Default is None, in which case the binning will be automatically determined using 
-        the ``dlog10_prim_haloprop`` keyword. 
+    prim_haloprop_bin_boundaries : array, optional
+        Array defining the boundaries by which we will bin the input ``table``.
+        Default is None, in which case the binning will be automatically determined using
+        the ``dlog10_prim_haloprop`` keyword.
 
-    dlog10_prim_haloprop : float, optional 
-        Logarithmic spacing of bins of the mass-like variable within which 
-        we will assign secondary property percentiles. Default is 0.2. 
+    dlog10_prim_haloprop : float, optional
+        Logarithmic spacing of bins of the mass-like variable within which
+        we will assign secondary property percentiles. Default is 0.2.
 
-    Examples 
+    Examples
     --------
     >>> from halotools.sim_manager import FakeSim
     >>> fakesim = FakeSim()
@@ -69,9 +68,9 @@ def compute_conditional_percentiles(**kwargs):
 
     Notes
     -----
-    The sign of the result is such that in bins of the primary property, 
-    *smaller* values of the secondary property 
-    receive *smaller* values of the returned percentile. 
+    The sign of the result is such that in bins of the primary property,
+    *smaller* values of the secondary property
+    receive *smaller* values of the returned percentile.
 
     """
 
@@ -101,24 +100,24 @@ def compute_conditional_percentiles(**kwargs):
         """
         Parameters
         ----------
-        prim_haloprop : array 
-            Array storing the value of the primary halo property column of the ``table`` 
-            passed to ``compute_conditional_percentiles``. 
+        prim_haloprop : array
+            Array storing the value of the primary halo property column of the ``table``
+            passed to ``compute_conditional_percentiles``.
 
-        prim_haloprop_bin_boundaries : array, optional 
-            Array defining the boundaries by which we will bin the input ``table``. 
-            Default is None, in which case the binning will be automatically determined using 
-            the ``dlog10_prim_haloprop`` keyword. 
+        prim_haloprop_bin_boundaries : array, optional
+            Array defining the boundaries by which we will bin the input ``table``.
+            Default is None, in which case the binning will be automatically determined using
+            the ``dlog10_prim_haloprop`` keyword.
 
-        dlog10_prim_haloprop : float, optional 
-            Logarithmic spacing of bins of the mass-like variable within which 
-            we will assign secondary property percentiles. Default is 0.2. 
+        dlog10_prim_haloprop : float, optional
+            Logarithmic spacing of bins of the mass-like variable within which
+            we will assign secondary property percentiles. Default is 0.2.
 
-        Returns 
+        Returns
         --------
-        output : array 
-            Numpy array of integers storing the bin index of the prim_haloprop bin 
-            to which each halo in the input table was assigned. 
+        output : array
+            Numpy array of integers storing the bin index of the prim_haloprop bin
+            to which each halo in the input table was assigned.
 
         """
         try:
@@ -135,13 +134,13 @@ def compute_conditional_percentiles(**kwargs):
             lg10_max_prim_haloprop = np.log10(np.max(prim_haloprop))+0.001
             num_prim_haloprop_bins = (lg10_max_prim_haloprop-lg10_min_prim_haloprop)/dlog10_prim_haloprop
             prim_haloprop_bin_boundaries = np.logspace(
-                lg10_min_prim_haloprop, lg10_max_prim_haloprop, 
+                lg10_min_prim_haloprop, lg10_max_prim_haloprop,
                 num=ceil(num_prim_haloprop_bins))
 
         # digitize the masses so that we can access them bin-wise
         output = np.digitize(prim_haloprop, prim_haloprop_bin_boundaries)
 
-        # Use the largest bin for any points larger than the largest bin boundary, 
+        # Use the largest bin for any points larger than the largest bin boundary,
         ### and raise a warning if such points are found
         Nbins = len(prim_haloprop_bin_boundaries)
         if Nbins in output:
@@ -180,7 +179,7 @@ def compute_conditional_percentiles(**kwargs):
 
         percentiles = np.zeros(num_in_bin)
         percentiles[ind_sorted] = (np.arange(num_in_bin) + 1.0) / float(num_in_bin)
-        
+
         # place the percentiles into the catalog
         output[indices_of_prim_haloprop_bin] = percentiles
 
@@ -190,14 +189,14 @@ def compute_conditional_percentiles(**kwargs):
 
 
 class SampleSelector(object):
-    """ Container class for commonly used sample selections. 
+    """ Container class for commonly used sample selections.
     """
 
     @staticmethod
     def host_halo_selection(return_subhalos=False, **kwargs):
-        """ Method divides sample in to host halos and subhalos, and returns 
-        either the hosts or the hosts and the subs depending 
-        on the value of the input ``return_subhalos``. 
+        """ Method divides sample in to host halos and subhalos, and returns
+        either the hosts or the hosts and the subs depending
+        on the value of the input ``return_subhalos``.
         """
         table = kwargs['table']
         mask = table['halo_upid'] == -1
@@ -207,46 +206,46 @@ class SampleSelector(object):
             return table[mask], table[~mask]
 
     @staticmethod
-    def property_range(lower_bound = -float("inf"), upper_bound = float("inf"), 
+    def property_range(lower_bound = -float("inf"), upper_bound = float("inf"),
         return_complement = False, host_halos_only=False, subhalos_only=False, **kwargs):
-        """ Method makes a cut on an input table column based on an input upper and lower bound, and 
-        returns the cut table. 
+        """ Method makes a cut on an input table column based on an input upper and lower bound, and
+        returns the cut table.
 
-        Parameters 
+        Parameters
         ----------
-        table : Astropy Table object, keyword argument 
+        table : Astropy Table object, keyword argument
 
-        key : string, keyword argument 
+        key : string, keyword argument
             Column name that will be used to apply the cut
 
-        lower_bound : float, optional keyword argument 
-            Minimum value for the input column of the returned table. Default is :math:`-\\infty`. 
+        lower_bound : float, optional keyword argument
+            Minimum value for the input column of the returned table. Default is :math:`-\\infty`.
 
-        upper_bound : float, optional keyword argument 
-            Maximum value for the input column of the returned table. Default is :math:`+\\infty`. 
+        upper_bound : float, optional keyword argument
+            Maximum value for the input column of the returned table. Default is :math:`+\\infty`.
 
-        return_complement : bool, optional keyword argument 
-            If True, `property_range` gives the table elements that do not pass the cut 
-            as the second return argument. Default is False. 
+        return_complement : bool, optional keyword argument
+            If True, `property_range` gives the table elements that do not pass the cut
+            as the second return argument. Default is False.
 
-        host_halos_only : bool, optional keyword argument 
-            If true, `property_range` will use the `host_halo_selection` method to 
-            make an additional cut on the sample so that only host halos are returned. 
+        host_halos_only : bool, optional keyword argument
+            If true, `property_range` will use the `host_halo_selection` method to
+            make an additional cut on the sample so that only host halos are returned.
             Default is False
 
-        subhalos_only : bool, optional keyword argument 
-            If true, `property_range` will use the `host_halo_selection` method to 
-            make an additional cut on the sample so that only subhalos are returned. 
+        subhalos_only : bool, optional keyword argument
+            If true, `property_range` will use the `host_halo_selection` method to
+            make an additional cut on the sample so that only subhalos are returned.
             Default is False
 
 
-        Returns 
+        Returns
         -------
         cut_table : Astropy Table object
 
-        Examples 
+        Examples
         ---------
-        To demonstrate the `property_range` method, we will start out by loading 
+        To demonstrate the `property_range` method, we will start out by loading
         a table of halos into memory using the `FakeSim` class:
 
         >>> from halotools.sim_manager import FakeSim
@@ -286,27 +285,27 @@ class SampleSelector(object):
 
     @staticmethod
     def split_sample(**kwargs):
-        """ Method divides a sample into subsamples based on the percentile ranking of a given property. 
+        """ Method divides a sample into subsamples based on the percentile ranking of a given property.
 
-        Parameters 
+        Parameters
         ----------
-        table : Astropy Table object, keyword argument 
+        table : Astropy Table object, keyword argument
 
-        key : string, keyword argument 
+        key : string, keyword argument
             Column name that will be used to define the percentiles
 
-        percentiles : array_like 
-            Sequence of percentiles used to define the returned subsamples. If ``percentiles`` 
-            has more than one element, the elements must be monotonically increasing. 
-            If ``percentiles`` is length-N, there will be N+1 returned subsamples. 
+        percentiles : array_like
+            Sequence of percentiles used to define the returned subsamples. If ``percentiles``
+            has more than one element, the elements must be monotonically increasing.
+            If ``percentiles`` is length-N, there will be N+1 returned subsamples.
 
-        Returns 
+        Returns
         -------
-        subsamples : list 
+        subsamples : list
 
-        Examples 
+        Examples
         --------
-        To demonstrate the `split_sample` method, we will start out by loading 
+        To demonstrate the `split_sample` method, we will start out by loading
         a table of halos into memory using the `FakeSim` class:
 
         >>> from halotools.sim_manager import FakeSim
@@ -357,7 +356,7 @@ class SampleSelector(object):
             print("Raise exception: too many percentile bins")
             idx_too_few = np.nanargmin(d)
             raise ValueError("The input percentiles spacing is too fine.\n"
-                "For example, there are no table elements in the percentile range (%.2f, %.2f)" % 
+                "For example, there are no table elements in the percentile range (%.2f, %.2f)" %
                   (percentiles[idx_too_few], percentiles[idx_too_few+1]))
 
 
@@ -367,7 +366,7 @@ class SampleSelector(object):
 
         return result
 
-            
+
 
 
 

--- a/halotools/utils/table_utils.py
+++ b/halotools/utils/table_utils.py
@@ -332,7 +332,7 @@ class SampleSelector(object):
             raise TypeError("Input table must be an Astropy Table instance")
 
         key = kwargs['key']
-        if key not in table.keys():
+        if key not in list(table.keys()):
             raise KeyError("Input key must be a column name of the input table")
         table.sort(key)
 
@@ -362,7 +362,7 @@ class SampleSelector(object):
 
 
         result = np.zeros(len(indices)-1, dtype=object)
-        for i, first_idx, last_idx in zip(range(len(result)), indices[:-1], indices[1:]):
+        for i, first_idx, last_idx in zip(list(range(len(result))), indices[:-1], indices[1:]):
             result[i] = table[first_idx:last_idx]
 
         return result

--- a/halotools/utils/tests/test_array_utils.py
+++ b/halotools/utils/tests/test_array_utils.py
@@ -161,7 +161,7 @@ def test_convert_to_ndarray11():
 def test_convert_to_ndarray12():
     """
     """
-    v = np.array(u'abc')
+    v = np.array('abc')
     varr = array_utils.convert_to_ndarray(v) 
     assert type(varr) == np.ndarray
     assert len(varr) == 1
@@ -170,7 +170,7 @@ def test_convert_to_ndarray12():
 def test_convert_to_ndarray13():
     """
     """
-    v = u'abc'
+    v = 'abc'
     varr = array_utils.convert_to_ndarray(v) 
     assert type(varr) == np.ndarray
     assert len(varr) == 1

--- a/halotools/utils/tests/test_group_member_generator.py
+++ b/halotools/utils/tests/test_group_member_generator.py
@@ -2,25 +2,22 @@
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
-from copy import deepcopy 
 
 from collections import Counter
 
-import numpy as np 
+import numpy as np
 
 from astropy.tests.helper import pytest
-from astropy.table import Table 
 
 from ..group_member_generator import group_member_generator
 
 from ...sim_manager import FakeSim
 
-from ...custom_exceptions import HalotoolsError
-
 __all__ = ['TestGroupMemberGenerator']
 
+
 class TestGroupMemberGenerator(TestCase):
-    """ Class providing tests of the `~halotools.utils.aggregation`. 
+    """ Class providing tests of the `~halotools.utils.aggregation`.
     """
     def setUp(self):
         fake_sim = FakeSim()
@@ -28,14 +25,14 @@ class TestGroupMemberGenerator(TestCase):
         self.halo_table.sort('halo_hostid')
 
     def test_argument_checks1(self):
-        """ Verify that an informative exception is raised when 
-        passing in data that is not a table or structured array. 
+        """ Verify that an informative exception is raised when
+        passing in data that is not a table or structured array.
         """
         grouping_key = 'halo_hostid'
         requested_columns = ['halo_mvir']
 
         with pytest.raises(TypeError) as err:
-            g = group_member_generator(4, 
+            g = group_member_generator(4,
                 grouping_key, requested_columns, data_is_already_sorted=False)
             for _ in g:
                 pass
@@ -43,14 +40,14 @@ class TestGroupMemberGenerator(TestCase):
         assert substr in err.value.message
 
     def test_argument_checks2(self):
-        """ Verify that an informative exception is raised when 
-        passing in a non-iterable for ``requested_columns``. 
+        """ Verify that an informative exception is raised when
+        passing in a non-iterable for ``requested_columns``.
         """
         grouping_key = 'halo_hostid'
         requested_columns = 5
 
         with pytest.raises(TypeError) as err:
-            g = group_member_generator(self.halo_table, 
+            g = group_member_generator(self.halo_table,
                 grouping_key, requested_columns, data_is_already_sorted=False)
             for _ in g:
                 pass
@@ -58,14 +55,14 @@ class TestGroupMemberGenerator(TestCase):
         assert substr in err.value.message
 
     def test_argument_checks3(self):
-        """ Verify that an informative exception is raised when 
-        passing in unacceptable ``requested_columns``. 
+        """ Verify that an informative exception is raised when
+        passing in unacceptable ``requested_columns``.
         """
         grouping_key = 'halo_hostid'
         requested_columns = ['Jose Canseco']
 
         with pytest.raises(KeyError) as err:
-            g = group_member_generator(self.halo_table, 
+            g = group_member_generator(self.halo_table,
                 grouping_key, requested_columns, data_is_already_sorted=False)
             for _ in g:
                 pass
@@ -73,14 +70,14 @@ class TestGroupMemberGenerator(TestCase):
         assert substr in err.value.message
 
     def test_argument_checks4(self):
-        """ Verify that an informative exception is raised when 
-        passing in unacceptable ``grouping_key``. 
+        """ Verify that an informative exception is raised when
+        passing in unacceptable ``grouping_key``.
         """
         grouping_key = 'Jose Canseco'
         requested_columns = ['halo_hostid']
 
         with pytest.raises(KeyError) as err:
-            g = group_member_generator(self.halo_table, 
+            g = group_member_generator(self.halo_table,
                 grouping_key, requested_columns, data_is_already_sorted=False)
             for _ in g:
                 pass
@@ -88,14 +85,14 @@ class TestGroupMemberGenerator(TestCase):
         assert substr in err.value.message
 
     def test_argument_checks5(self):
-        """ Verify that an informative exception is raised when 
-        passing in a single string for ``requested_columns``, rather than a list. 
+        """ Verify that an informative exception is raised when
+        passing in a single string for ``requested_columns``, rather than a list.
         """
         grouping_key = 'halo_hostid'
         requested_columns = 'Jose Canseco'
 
         with pytest.raises(KeyError) as err:
-            g = group_member_generator(self.halo_table, 
+            g = group_member_generator(self.halo_table,
                 grouping_key, requested_columns, data_is_already_sorted=False)
             for _ in g:
                 pass
@@ -103,14 +100,14 @@ class TestGroupMemberGenerator(TestCase):
         assert substr in err.value.message
 
     def test_argument_checks6(self):
-        """ Verify that an informative exception is raised when 
-        the input data is not appropriately sorted. 
+        """ Verify that an informative exception is raised when
+        the input data is not appropriately sorted.
         """
         grouping_key = 'halo_mvir'
         requested_columns = ['halo_mvir']
 
         with pytest.raises(ValueError) as err:
-            g = group_member_generator(self.halo_table, 
+            g = group_member_generator(self.halo_table,
                 grouping_key, requested_columns, data_is_already_sorted=False)
             for _ in g:
                 pass
@@ -118,12 +115,12 @@ class TestGroupMemberGenerator(TestCase):
         assert substr in err.value.message
 
     def test_function_correctness1(self):
-        """ Verify that the aggregation function can correctly compute 
-        and broadcast the result of a trivial group-wise function. 
+        """ Verify that the aggregation function can correctly compute
+        and broadcast the result of a trivial group-wise function.
         """
         grouping_key = 'halo_hostid'
         requested_columns = ['halo_hostid']
-        gen = group_member_generator(self.halo_table, 
+        gen = group_member_generator(self.halo_table,
             grouping_key, requested_columns, data_is_already_sorted=False)
 
         result = np.zeros(len(self.halo_table))
@@ -133,14 +130,14 @@ class TestGroupMemberGenerator(TestCase):
         assert np.all(result == self.halo_table['halo_hostid'])
 
     def test_function_correctness2(self):
-        """ Verify that the aggregation function can correctly identify 
+        """ Verify that the aggregation function can correctly identify
         the first group member
         """
         self.halo_table.sort(keys=['halo_hostid', 'halo_upid'])
 
         grouping_key = 'halo_hostid'
         requested_columns = ['halo_upid']
-        gen = group_member_generator(self.halo_table, 
+        gen = group_member_generator(self.halo_table,
             grouping_key, requested_columns, data_is_already_sorted=False)
 
         result = np.zeros(len(self.halo_table))
@@ -148,17 +145,17 @@ class TestGroupMemberGenerator(TestCase):
             first, last, group_array_list = group_data
             result[first:last] = group_array_list[0][0]
 
-        assert np.all(result == -1)        
-            
+        assert np.all(result == -1)
+
     def test_function_correctness3(self):
-        """ Verify that the aggregation function can correctly compute 
-        and broadcast the values of the group-wise host halo mass. 
+        """ Verify that the aggregation function can correctly compute
+        and broadcast the values of the group-wise host halo mass.
         """
         self.halo_table.sort(keys=['halo_hostid', 'halo_upid'])
-        
+
         grouping_key = 'halo_hostid'
         requested_columns = ['halo_mvir']
-        gen = group_member_generator(self.halo_table, 
+        gen = group_member_generator(self.halo_table,
             grouping_key, requested_columns, data_is_already_sorted=False)
 
         result = np.zeros(len(self.halo_table))
@@ -167,18 +164,18 @@ class TestGroupMemberGenerator(TestCase):
             result[first:last] = group_array_list[0][0]
 
         host_mask = self.halo_table['halo_upid'] == -1
-        assert np.all(self.halo_table['halo_mvir'][host_mask] == result[host_mask])            
-        assert np.any(self.halo_table['halo_mvir'][~host_mask] != result[~host_mask])            
+        assert np.all(self.halo_table['halo_mvir'][host_mask] == result[host_mask])
+        assert np.any(self.halo_table['halo_mvir'][~host_mask] != result[~host_mask])
 
     def test_function_correctness4(self):
-        """ Verify that the aggregation function can correctly compute 
-        and broadcast the values of the group-wise mean mass-weighted spin. 
+        """ Verify that the aggregation function can correctly compute
+        and broadcast the values of the group-wise mean mass-weighted spin.
         """
         self.halo_table.sort(keys=['halo_hostid', 'halo_upid'])
-        
+
         grouping_key = 'halo_hostid'
         requested_columns = ['halo_mvir', 'halo_spin']
-        gen = group_member_generator(self.halo_table, 
+        gen = group_member_generator(self.halo_table,
             grouping_key, requested_columns, data_is_already_sorted=False)
 
         result = np.zeros(len(self.halo_table))

--- a/halotools/utils/tests/test_group_member_generator.py
+++ b/halotools/utils/tests/test_group_member_generator.py
@@ -37,7 +37,7 @@ class TestGroupMemberGenerator(TestCase):
             for _ in g:
                 pass
         substr = "The input ``data`` must be an Astropy Table or Numpy Structured Array"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_argument_checks2(self):
         """ Verify that an informative exception is raised when
@@ -52,7 +52,7 @@ class TestGroupMemberGenerator(TestCase):
             for _ in g:
                 pass
         substr = "The input ``requested_columns`` must be an iterable sequence"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_argument_checks3(self):
         """ Verify that an informative exception is raised when
@@ -67,7 +67,7 @@ class TestGroupMemberGenerator(TestCase):
             for _ in g:
                 pass
         substr = "Each element of the input ``requested_columns`` must be"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_argument_checks4(self):
         """ Verify that an informative exception is raised when
@@ -82,7 +82,7 @@ class TestGroupMemberGenerator(TestCase):
             for _ in g:
                 pass
         substr = "Input ``grouping_key`` must be a column name of the input ``data``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_argument_checks5(self):
         """ Verify that an informative exception is raised when
@@ -97,7 +97,7 @@ class TestGroupMemberGenerator(TestCase):
             for _ in g:
                 pass
         substr = "list of strings, not a single string"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_argument_checks6(self):
         """ Verify that an informative exception is raised when
@@ -112,7 +112,7 @@ class TestGroupMemberGenerator(TestCase):
             for _ in g:
                 pass
         substr = "Your input ``data`` must be sorted so that"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_function_correctness1(self):
         """ Verify that the aggregation function can correctly compute

--- a/halotools/utils/tests/test_table_utils.py
+++ b/halotools/utils/tests/test_table_utils.py
@@ -12,69 +12,69 @@ from ...sim_manager import FakeSim
 __all__ = ('TestSampleSelector', 'TestComputeConditionalPercentiles')
 
 class TestSampleSelector(TestCase):
-	"""
-	"""
+    """
+    """
 
-	def test_split_sample(self):
-		Npts = 10
-		x = np.linspace(0, 9, Npts)
+    def test_split_sample(self):
+        Npts = 10
+        x = np.linspace(0, 9, Npts)
 
-		d = {'x':x}
-		t = Table(d)
-		ax = np.array(x, dtype=[('x', 'f4')])
+        d = {'x':x}
+        t = Table(d)
+        ax = np.array(x, dtype=[('x', 'f4')])
 
-		percentiles = 0.5
-		result = SampleSelector.split_sample(table=t, key='x', percentiles = percentiles)
+        percentiles = 0.5
+        result = SampleSelector.split_sample(table=t, key='x', percentiles = percentiles)
 
-		assert len(result) == 2
-		assert len(result[0]) == 5
-		assert len(result[1]) == 5
+        assert len(result) == 2
+        assert len(result[0]) == 5
+        assert len(result[1]) == 5
 
-		result0_sum = result[0]['x'].sum()
-		correct_sum = np.sum([0, 1, 2, 3, 4])
-		assert result0_sum == correct_sum
+        result0_sum = result[0]['x'].sum()
+        correct_sum = np.sum([0, 1, 2, 3, 4])
+        assert result0_sum == correct_sum
 
-		result1_sum = result[1]['x'].sum()
-		correct_sum = np.sum([5, 6, 7, 8, 9])
-		assert result1_sum == correct_sum
+        result1_sum = result[1]['x'].sum()
+        correct_sum = np.sum([5, 6, 7, 8, 9])
+        assert result1_sum == correct_sum
 
-		f = partial(SampleSelector.split_sample, table=t[0:4], key='x', 
-			percentiles=[0.1, 0.2, 0.3, 0.4, 0.5])
-		self.assertRaises(ValueError, f)
+        f = partial(SampleSelector.split_sample, table=t[0:4], key='x', 
+                percentiles=[0.1, 0.2, 0.3, 0.4, 0.5])
+        self.assertRaises(ValueError, f)
 
-		f = partial(SampleSelector.split_sample, table=t, key='x', 
-			percentiles=[0.1, 0.1, 0.95])
-		self.assertRaises(ValueError, f)
+        f = partial(SampleSelector.split_sample, table=t, key='x', 
+                percentiles=[0.1, 0.1, 0.95])
+        self.assertRaises(ValueError, f)
 
-		f = partial(SampleSelector.split_sample, table=t, key='y', 
-			percentiles= 0.5)
-		self.assertRaises(KeyError, f)
+        f = partial(SampleSelector.split_sample, table=t, key='y', 
+                percentiles= 0.5)
+        self.assertRaises(KeyError, f)
 
-		f = partial(SampleSelector.split_sample, table=ax, key='x', 
-			percentiles= 0.5)
-		self.assertRaises(TypeError, f)
+        f = partial(SampleSelector.split_sample, table=ax, key='x', 
+                percentiles= 0.5)
+        self.assertRaises(TypeError, f)
 
 
 class TestComputeConditionalPercentiles(TestCase):
 
     def setup_class(self):
-    	Npts = 1e4
-    	mass1 = np.zeros(Npts/2) + 1e12
+        Npts = 1e4
+        mass1 = np.zeros(Npts/2) + 1e12
         mass2 = np.zeros(Npts/2) + 1e14
         mass = np.append(mass1, mass2)
         zform1 = np.linspace(0, 10, Npts/2)
         zform2 = np.linspace(20, 30, Npts/2)
         zform = np.append(zform1, zform2)
 
-    	d = {'halo_mvir': mass, 'halo_zform': zform}
+        d = {'halo_mvir': mass, 'halo_zform': zform}
         t = Table(d)
         randomizer = np.random.random(len(t))
         random_idx = np.argsort(randomizer)
         t = t[random_idx]
-    	self.custom_halo_table = t
+        self.custom_halo_table = t
 
-    	fakesim = FakeSim()
-    	self.fake_halo_table = fakesim.halo_table
+        fakesim = FakeSim()
+        self.fake_halo_table = fakesim.halo_table
 
     def test_custom_halo_table(self):
 
@@ -83,20 +83,20 @@ class TestComputeConditionalPercentiles(TestCase):
 
     def test_fake_halo_table(self):
 
-    	percentiles = compute_conditional_percentiles(
-    		table = self.fake_halo_table, 
-    		prim_haloprop_key = 'halo_mvir', 
-    		sec_haloprop_key = 'halo_vmax')
-    	split = percentiles < 0.5
-    	low_vmax, high_vmax = self.fake_halo_table[split], self.fake_halo_table[np.invert(split)]
-    	#assert len(low_vmax) == len(high_vmax)
+        percentiles = compute_conditional_percentiles(
+                table = self.fake_halo_table, 
+                prim_haloprop_key = 'halo_mvir', 
+                sec_haloprop_key = 'halo_vmax')
+        split = percentiles < 0.5
+        low_vmax, high_vmax = self.fake_halo_table[split], self.fake_halo_table[np.invert(split)]
+        #assert len(low_vmax) == len(high_vmax)
 
     def test_custom_halo_table(self):
-    	prim_haloprop_bin_boundaries = [1e10, 1e13, 1e15]
+        prim_haloprop_bin_boundaries = [1e10, 1e13, 1e15]
 
-    	manual_mass_split = self.custom_halo_table['halo_mvir'] < 1e13
-    	manual_low_mass = self.custom_halo_table[manual_mass_split]
-    	manual_high_mass = self.custom_halo_table[np.invert(manual_mass_split)]
+        manual_mass_split = self.custom_halo_table['halo_mvir'] < 1e13
+        manual_low_mass = self.custom_halo_table[manual_mass_split]
+        manual_high_mass = self.custom_halo_table[np.invert(manual_mass_split)]
         assert np.all(manual_low_mass['halo_mvir'] == 1e12)
         assert np.all(manual_high_mass['halo_mvir'] == 1e14)
         assert manual_low_mass['halo_zform'].max() == 10 
@@ -104,35 +104,35 @@ class TestComputeConditionalPercentiles(TestCase):
         assert manual_high_mass['halo_zform'].max() == 30 
         assert manual_high_mass['halo_zform'].min() == 20 
 
-    	percentiles = compute_conditional_percentiles(
-    		table = self.custom_halo_table, 
-    		prim_haloprop_key = 'halo_mvir', 
-    		sec_haloprop_key = 'halo_zform', 
-    		prim_haloprop_bin_boundaries = prim_haloprop_bin_boundaries)
+        percentiles = compute_conditional_percentiles(
+                table = self.custom_halo_table, 
+                prim_haloprop_key = 'halo_mvir', 
+                sec_haloprop_key = 'halo_zform', 
+                prim_haloprop_bin_boundaries = prim_haloprop_bin_boundaries)
 
         assert np.all(percentiles <= 1)
         assert np.all(percentiles >= 0)
         assert np.any(percentiles > 0.9)
         assert np.any(percentiles < 0.1)
 
-    	low_mass_percentiles = percentiles[manual_mass_split]
+        low_mass_percentiles = percentiles[manual_mass_split]
         assert np.all(low_mass_percentiles <= 1)
         assert np.all(low_mass_percentiles >= 0)
         assert np.any(low_mass_percentiles > 0.9)
         assert np.any(low_mass_percentiles < 0.1)
 
-    	high_mass_percentiles = percentiles[np.invert(manual_mass_split)]
+        high_mass_percentiles = percentiles[np.invert(manual_mass_split)]
         assert np.all(high_mass_percentiles <= 1)
         assert np.all(high_mass_percentiles >= 0)
         assert np.any(high_mass_percentiles > 0.9)
         assert np.any(high_mass_percentiles < 0.1)
-    	assert set(low_mass_percentiles) == set(high_mass_percentiles)
+        assert set(low_mass_percentiles) == set(high_mass_percentiles)
 
-    	low_mass_split = low_mass_percentiles < 0.5
-    	low_mass_low_zform = manual_low_mass[low_mass_split]
-    	low_mass_high_zform = manual_low_mass[np.invert(low_mass_split)]
+        low_mass_split = low_mass_percentiles < 0.5
+        low_mass_low_zform = manual_low_mass[low_mass_split]
+        low_mass_high_zform = manual_low_mass[np.invert(low_mass_split)]
         assert 0 <= low_mass_low_zform['halo_zform'].max() <= 5
-    	assert 5 <= low_mass_high_zform['halo_zform'].max() <= 10
+        assert 5 <= low_mass_high_zform['halo_zform'].max() <= 10
 
         high_mass_split = high_mass_percentiles < 0.5
         high_mass_low_zform = manual_high_mass[high_mass_split]
@@ -140,9 +140,9 @@ class TestComputeConditionalPercentiles(TestCase):
         assert 20 <= high_mass_low_zform['halo_zform'].max() <= 25
         assert 25 <= high_mass_high_zform['halo_zform'].max() <= 30
 
-    	split = percentiles <= 0.5
-    	low_zform, high_zform = self.custom_halo_table[split], self.custom_halo_table[np.invert(split)]
-    	assert len(low_zform) == len(high_zform)
+        split = percentiles <= 0.5
+        low_zform, high_zform = self.custom_halo_table[split], self.custom_halo_table[np.invert(split)]
+        assert len(low_zform) == len(high_zform)
 
 
 

--- a/halotools/utils/tests/test_value_added_halo_table_functions.py
+++ b/halotools/utils/tests/test_value_added_halo_table_functions.py
@@ -61,7 +61,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         with pytest.raises(HalotoolsError) as err:
             broadcast_host_halo_property(4, 'xxx')
         substr = "The input ``table`` must be an Astropy `~astropy.table.Table` object"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         del t
 
@@ -72,7 +72,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         with pytest.raises(HalotoolsError) as err:
             broadcast_host_halo_property(t, 'xxx')
         substr = "The input table does not the input ``halo_property_key``"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         del t
 
@@ -85,7 +85,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         with pytest.raises(HalotoolsError) as err:
             broadcast_host_halo_property(t, 'halo_mvir')
         substr = "Your input table already has an existing new_colname column name."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         broadcast_host_halo_property(t, 'halo_mvir', delete_possibly_existing_column = True)
 
@@ -97,7 +97,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         with pytest.raises(HalotoolsError) as err:
             add_halo_hostid(5, delete_possibly_existing_column = False)
         substr = "The input ``table`` must be an Astropy `~astropy.table.Table` object"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_add_halo_hostid2(self):
         """
@@ -107,7 +107,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         with pytest.raises(HalotoolsError) as err:
             add_halo_hostid(t, delete_possibly_existing_column = False)
         substr = "The input table must have ``halo_upid`` and ``halo_id`` keys"
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
     def test_add_halo_hostid3(self):
         """
@@ -116,7 +116,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         with pytest.raises(HalotoolsError) as err:
             add_halo_hostid(t, delete_possibly_existing_column = False)
         substr = "Your input table already has an existing ``halo_hostid`` column name."
-        assert substr in err.value.message
+        assert substr in err.value.args[0]
 
         existing_halo_hostid = deepcopy(t['halo_hostid'].data)
         del t['halo_hostid']

--- a/halotools/utils/tests/test_value_added_halo_table_functions.py
+++ b/halotools/utils/tests/test_value_added_halo_table_functions.py
@@ -9,7 +9,7 @@ from collections import Counter
 import numpy as np
 
 from astropy.tests.helper import pytest
-from astropy.extern.six import xrange as range
+from astropy.extern.six.moves import xrange as range
 
 from ..value_added_halo_table_functions import *
 

--- a/halotools/utils/tests/test_value_added_halo_table_functions.py
+++ b/halotools/utils/tests/test_value_added_halo_table_functions.py
@@ -2,15 +2,14 @@
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
-from copy import deepcopy 
+from copy import deepcopy
 
 from collections import Counter
-from copy import deepcopy 
 
-import numpy as np 
+import numpy as np
 
 from astropy.tests.helper import pytest
-from astropy.table import Table 
+from astropy.extern.six import xrange as range
 
 from ..value_added_halo_table_functions import *
 
@@ -20,12 +19,13 @@ from ...custom_exceptions import HalotoolsError
 
 __all__ = ['TestValueAddedHaloTableFunctions']
 
+
 class TestValueAddedHaloTableFunctions(TestCase):
-    """ Class providing tests of the `~halotools.utils.value_added_halo_table_functions`. 
+    """ Class providing tests of the `~halotools.utils.value_added_halo_table_functions`.
     """
     def setUp(self):
         fake_sim = FakeSim()
-        self.table= fake_sim.halo_table
+        self.table = fake_sim.halo_table
 
     def test_broadcast_host_halo_mass1(self):
         """
@@ -33,7 +33,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         t = deepcopy(self.table)
         broadcast_host_halo_property(t, 'halo_mvir')
 
-        assert 'halo_mvir_host_halo' in t.keys()
+        assert 'halo_mvir_host_halo' in list(t.keys())
 
         hostmask = t['halo_hostid'] == t['halo_id']
         assert np.all(t['halo_mvir_host_halo'][hostmask] == t['halo_mvir'][hostmask])
@@ -42,12 +42,12 @@ class TestValueAddedHaloTableFunctions(TestCase):
         data = Counter(t['halo_hostid'])
         frequency_analysis = data.most_common()
 
-        for igroup in xrange(0, 10):
+        for igroup in range(0, 10):
             idx = np.where(t['halo_hostid'] == frequency_analysis[igroup][0])[0]
             idx_host = np.where(t['halo_id'] == frequency_analysis[igroup][0])[0]
             assert np.all(t['halo_mvir_host_halo'][idx] == t['halo_mvir'][idx_host])
 
-        for igroup in xrange(-10, -1):
+        for igroup in range(-10, -1):
             idx = np.where(t['halo_hostid'] == frequency_analysis[igroup][0])[0]
             idx_host = np.where(t['halo_id'] == frequency_analysis[igroup][0])[0]
             assert np.all(t['halo_mvir_host_halo'][idx] == t['halo_mvir'][idx_host])
@@ -88,7 +88,7 @@ class TestValueAddedHaloTableFunctions(TestCase):
         assert substr in err.value.message
 
         broadcast_host_halo_property(t, 'halo_mvir', delete_possibly_existing_column = True)
-        
+
         del t
 
     def test_add_halo_hostid1(self):

--- a/halotools/utils/value_added_halo_table_functions.py
+++ b/halotools/utils/value_added_halo_table_functions.py
@@ -66,19 +66,19 @@ def broadcast_host_halo_property(table, halo_property_key,
         raise HalotoolsError(msg)
 
     try:
-        assert halo_property_key in table.keys()
-        assert 'halo_id' in table.keys()
+        assert halo_property_key in list(table.keys())
+        assert 'halo_id' in list(table.keys())
     except AssertionError:
         msg = ("\nThe input table does not the input ``halo_property_key`` = "+str(halo_property_key)+" column")
         raise HalotoolsError(msg)
 
     new_colname = halo_property_key + '_host_halo'
-    if (new_colname in table.keys()) & (delete_possibly_existing_column is False):
+    if (new_colname in list(table.keys())) & (delete_possibly_existing_column is False):
         msg = ("\nYour input table already has an existing new_colname column name.\n"
             "If you want to overwrite this column, "
             "you must set ``delete_possibly_existing_column`` to True.\n")
         raise HalotoolsError(msg)
-    elif (new_colname in table.keys()) & (delete_possibly_existing_column is True):
+    elif (new_colname in list(table.keys())) & (delete_possibly_existing_column is True):
         del table[new_colname]
 
 
@@ -124,18 +124,18 @@ def add_halo_hostid(table, delete_possibly_existing_column = False):
         raise HalotoolsError(msg)
 
     try:
-        assert 'halo_upid' in table.keys()
-        assert 'halo_id' in table.keys()
+        assert 'halo_upid' in list(table.keys())
+        assert 'halo_id' in list(table.keys())
     except AssertionError:
         msg = ("\nThe input table must have ``halo_upid`` and ``halo_id`` keys")
         raise HalotoolsError(msg)
 
-    if ('halo_hostid' in table.keys()) & (delete_possibly_existing_column is False):
+    if ('halo_hostid' in list(table.keys())) & (delete_possibly_existing_column is False):
         msg = ("\nYour input table already has an existing ``halo_hostid`` column name.\n"
             "If you want to overwrite this column, "
             "you must set ``delete_possibly_existing_column`` to True.\n")
         raise HalotoolsError(msg)
-    elif ('halo_hostid' in table.keys()) & (delete_possibly_existing_column is True):
+    elif ('halo_hostid' in list(table.keys())) & (delete_possibly_existing_column is True):
         del table['halo_hostid']
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,6 @@ import glob
 import os
 import sys
 
-if sys.version_info[0] >2:
-    raise SystemError("You are using python 3.x, but currently Halotools is only 2.x compatible.")
-
-
 import ah_bootstrap
 from setuptools import setup
 


### PR DESCRIPTION
@bsipocz - I finally resolved the bug that was causing your PR to fail on my local tests. So this PR introduces full-fledge python 3.x compatibility, at long last. 

However, I am a bit mystified by the resolution, and I don't want to merge the PR until I understand it. As shown in this commit, https://github.com/aphearin/halotools/commit/469a7f96c2202ffedc75198dd82d49977a47b128, all I had to do is wrap `yield_entry` with the `bool` function. Without doing this, `yield_entry` stores an integer, and so the way the concluding control flow *was* written, the generator always yielded an empty list, causing test failures that are local to my machine where my local cache.log is *not* empty. What I'm confused about is what change led to this. Why did this only crop up now? Let me know if you have any insight. I'll be glad to put this PR into the repo when I get to the bottom of it. 