### PR TITLE
Added new compiler flag to cython

### DIFF
--- a/halotools/mock_observables/pair_counters/cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/cpairs/setup_package.py
@@ -1,12 +1,9 @@
-
-
 from distutils.extension import Extension
 import os
-import sys
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
-SOURCES = ["cpairs.pyx", "distances.pyx", "pairwise_distances.pyx",\
-           "per_object_cpairs.pyx"]
+SOURCES = ("cpairs.pyx", "distances.pyx", "pairwise_distances.pyx",
+    "per_object_cpairs.pyx")
 THIS_PKG_NAME = '.'.join(__name__.split('.')[:-1])
 
 def get_extensions():
@@ -16,15 +13,15 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = ['-Ofast', '-march=native']
 
     extensions = []
     for name, source in zip(names, sources):
         extensions.append(Extension(name=name,
-                          sources=[source],
-                          include_dirs=include_dirs,
-                          libraries=libraries,
-                          language = language,
-                          extra_compile_args=extra_compile_args))
+            sources=[source],
+            include_dirs=include_dirs,
+            libraries=libraries,
+            language = language,
+            extra_compile_args=extra_compile_args))
 
     return extensions

--- a/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
@@ -1,10 +1,11 @@
 from distutils.extension import Extension
 import os
-import sys
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
-SOURCES = ["marked_cpairs.pyx", "weighting_functions.pyx", "custom_weighting_func.pyx",
-           "pairwise_velocity_funcs.pyx","distances.pyx", "conditional_pairwise_distances.pyx"]
+SOURCES = ("marked_cpairs.pyx", "weighting_functions.pyx", 
+    "custom_weighting_func.pyx",
+    "pairwise_velocity_funcs.pyx","distances.pyx", 
+    "conditional_pairwise_distances.pyx")
 THIS_PKG_NAME = '.'.join(__name__.split('.')[:-1])
 
 def get_extensions():
@@ -14,15 +15,15 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = ['-Ofast', '-march=native']
 
     extensions = []
     for name, source in zip(names, sources):
         extensions.append(Extension(name=name,
-                          sources=[source],
-                          include_dirs=include_dirs,
-                          libraries=libraries,
-                          language = language,
-                          extra_compile_args=extra_compile_args))
+            sources=[source],
+            include_dirs=include_dirs,
+            libraries=libraries,
+            language = language,
+            extra_compile_args=extra_compile_args))
 
     return extensions


### PR DESCRIPTION
As suggested by @manodeep, `mock_observables` is now being compiled while throwing the `-march=native` flag, resulting in a 10% speedup of `npairs`. 