### PR TITLE
Masscut fix

### DIFF
--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -122,12 +122,25 @@ class HodMockFactory(MockFactory):
         # make a (possibly trivial) completeness cut 
         cutoff_mvir = self.Num_ptcl_requirement*self.particle_mass
         mass_cut = halo_table[self.halo_mass_column_key] > cutoff_mvir
+        max_column_value = np.max(halo_table[self.halo_mass_column_key])
         halo_table = halo_table[mass_cut]
         if len(halo_table) == 0:
-            msg = ("Your mass cut resulted in zero halos in the halo catalog.\n"
-                "This is not permissible, and indicates a problem in either \n"
-                "the processing of the halo catalog or in the value of ``Num_ptcl_requirement``.\n")
-            raise HalotoolsError(msg)
+            msg = ("During the pre-processing phase of HOD mock-making \n"
+                "controlled by the `preprocess_halo_catalog` method of the HodMockFactory,\n"
+                "a cut on halo completeness is made. The column used in this cut\n"
+                "is determined by the value of the halo_mass_column_key string \n"
+                "passed to the HodMockFactory constructor, which in this case was ``%s``.\n"
+                "The largest value of this column in the uncut catalog is %.2e.\n"
+                "Your mass cut of M > %.2e resulted in zero halos in the halo catalog;\n"
+                "for reference, your halo catalog has a particle mass of m_p = %.2e.\n"
+                "Such a cut is not permissible. \nThis could indicate a problem in "
+                "the processing of the halo catalog,\n"
+                "for example, an incorrect column number and/or dtype.\n"
+                "Alternatively, the value of Num_ptcl_requirement = %.2e \n"
+                "that was passed to the HodMockFactory constructor could be the problem.\n")
+            raise HalotoolsError(msg % (
+                self.halo_mass_column_key, max_column_value, cutoff_mvir, 
+                self.particle_mass, self.Num_ptcl_requirement))
 
         ############################################################
 

--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -123,6 +123,11 @@ class HodMockFactory(MockFactory):
         cutoff_mvir = self.Num_ptcl_requirement*self.particle_mass
         mass_cut = halo_table[self.halo_mass_column_key] > cutoff_mvir
         halo_table = halo_table[mass_cut]
+        if len(halo_table) == 0:
+            msg = ("Your mass cut resulted in zero halos in the halo catalog.\n"
+                "This is not permissible, and indicates a problem in either \n"
+                "the processing of the halo catalog or in the value of ``Num_ptcl_requirement``.\n")
+            raise HalotoolsError(msg)
 
         ############################################################
 


### PR DESCRIPTION
This PR addresses #473. For reference, below appears the example error message raised by the newly-added testing function `test_zero_halo_edge_case` dedicated to guaranteeing that a maximal cut will never be made in the future. This testing function attempts to populate the FakeSim with a cut that exceeds the maximum value of virial mass. 

@mclaughlin6464 - this is the best I can do to write an informative error message without understanding better what happened; if you encountered this problem, others are likely to as well, so your feedback would be appreciated. 

> HalotoolsError: During the pre-processing phase of HOD mock-making 
> controlled by the `preprocess_halo_catalog` method of the HodMockFactory,
> a cut on halo completeness is made. The column used in this cut
> is determined by the value of the halo_mass_column_key string 
> passed to the HodMockFactory constructor, which in this case was ``halo_mvir``.
> The largest value of this column in the uncut catalog is 1.00e+16.
> Your mass cut of M > 1.00e+18 resulted in zero halos in the halo catalog;
> for reference, your halo catalog has a particle mass of m_p = 1.00e+08.
> Such a cut is not permissible. 
> This could indicate a problem in the processing of the halo catalog,
> for example, an incorrect column number and/or dtype.
> Alternatively, the value of Num_ptcl_requirement = 1.00e+10 
> that was passed to the HodMockFactory constructor could be the problem.
> 