### PR TITLE
fixed bug in ascii reader

### DIFF
--- a/halotools/sim_manager/tabular_ascii_reader.py
+++ b/halotools/sim_manager/tabular_ascii_reader.py
@@ -556,8 +556,8 @@ class TabularAsciiReader(object):
                    "``chunk_memory_size``")
             raise ValueError(msg)
 
-        num_rows_in_chunk = num_data_rows // Nchunks
-        num_full_chunks = num_data_rows // num_rows_in_chunk
+        num_rows_in_chunk = int(num_data_rows // Nchunks)
+        num_full_chunks = int(num_data_rows // num_rows_in_chunk)
         num_rows_in_chunk_remainder = num_data_rows - num_rows_in_chunk*Nchunks
 
         header_length = self.header_len()


### PR DESCRIPTION
In the conversion to make this python 3 compliant by @bsipocz in 82cd264f916a80a3a592b39363f7bb4dae2ff5a3 a bug was introduced.

3.0 // 2.0 = 1.0 (type float)

The range() function does not like receiving floats.  I don't know if this bug shows up elsewhere, but @aphearin you should be aware.