### PR TITLE
Delta sigma control flow refactoring

### DIFF
--- a/halotools/mock_observables/mock_observables_helpers.py
+++ b/halotools/mock_observables/mock_observables_helpers.py
@@ -6,6 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from warnings import warn 
 import numpy as np
 import multiprocessing
+
+from ..utils.array_utils import array_is_monotonic
+
+
 num_available_cores = multiprocessing.cpu_count()
 
 __all__ = ('enforce_sample_respects_pbcs', 'get_num_threads', 'get_period')
@@ -103,5 +107,50 @@ def get_period(period):
             raise ValueError(msg)
 
     return period, PBCs
+
+def enforce_sample_has_correct_shape(sample):
+    """ Function inspects the input ``sample`` and enforces that it is of shape (Npts, 3). 
+    """
+    sample = np.atleast_1d(sample)
+    try:
+        input_shape = np.shape(sample)
+        assert len(input_shape) == 2
+        assert input_shape[1] == 3
+    except:
+        msg = ("Input sample of points must be a Numpy ndarray of shape (Npts, 3).\n"
+            "To convert a sequence of 1d arrays x, y, z into correct shape expected \n"
+            "throughout the `mock_observables` package:\n\n"
+            ">>> sample = np.vstack([x, y, z]).T ")
+        raise TypeError(msg)
+    return sample
+
+
+def get_separation_bins_array(separation_bins):
+    """ Function verifies that the input ``separation_bins`` is a monotonically increasing 
+    1d Numpy array with at least two entries, all of which are required to be strictly positive. 
+
+    This helper function can be used equally well with 3d separation bins ``rbins``, 
+    2d projected separation bins ``rp_bins``, or 1d line-of-sight bins ``pi_bins``. 
+    """
+    separation_bins = np.atleast_1d(separation_bins)
+    
+    try:
+        assert separation_bins.ndim == 1
+        assert len(separation_bins) > 1
+        if len(separation_bins) > 2:
+            assert array_is_monotonic(separation_bins, strict = True) == 1
+        assert np.all(separation_bins > 0)
+    except AssertionError:
+        msg = ("\n Input separation bins must be a monotonically increasing \n"
+               "1-D array with at least two entries, all of which must be strictly positive.\n")
+        raise TypeError(msg)
+
+    return separation_bins
+
+
+
+
+
+
 
 

--- a/halotools/mock_observables/tests/test_clustering_helpers.py
+++ b/halotools/mock_observables/tests/test_clustering_helpers.py
@@ -1,0 +1,21 @@
+""" Module provides unit-testing for `~halotools.mock_observables.clustering_helpers`. 
+"""
+from __future__ import absolute_import, division, print_function
+from astropy.tests.helper import pytest
+
+from ..clustering_helpers import verify_tpcf_estimator
+
+__all__ = ('test_verify_tpcf_estimator', )
+
+def test_verify_tpcf_estimator():
+    """
+    """
+    _ = verify_tpcf_estimator('Natural')
+
+    with pytest.raises(ValueError) as err:
+        _ = verify_tpcf_estimator('Cuba Gooding, Jr.')
+    substr = "is not in the list of available estimators:"
+    assert substr in err.value.args[0]
+
+
+

--- a/halotools/mock_observables/tests/test_mock_observables_helpers.py
+++ b/halotools/mock_observables/tests/test_mock_observables_helpers.py
@@ -8,6 +8,7 @@ import pytest
 import multiprocessing 
 
 from ..mock_observables_helpers import enforce_sample_respects_pbcs, get_num_threads, get_period
+from ..mock_observables_helpers import enforce_sample_has_correct_shape, get_separation_bins_array
 
 __all__ = ('test_enforce_sample_respects_pbcs', 'test_get_num_threads', 
     'test_get_period')
@@ -87,6 +88,39 @@ def test_get_period():
         period, PBCs = get_period([1,1, np.inf])
     substr = "All values must bounded positive numbers."
     assert substr in err.value.args[0]
+
+def test_enforce_sample_has_correct_shape():
+
+    npts = 100
+    good_sample = np.zeros((npts, 3))
+    _ = enforce_sample_has_correct_shape(good_sample)
+
+    bad_sample = np.zeros((npts, 2))
+    with pytest.raises(TypeError) as err:
+        _ = enforce_sample_has_correct_shape(bad_sample)
+    substr = "Input sample of points must be a Numpy ndarray of shape (Npts, 3)."
+    assert substr in err.value.args[0]
+
+def test_get_separation_bins_array():
+
+    good_rbins = [1,2]
+    _ = get_separation_bins_array(good_rbins)
+
+    good_rbins = np.linspace(1, 2, 10)
+    _ = get_separation_bins_array(good_rbins)
+
+    bad_rbins = [0, 1]
+    with pytest.raises(TypeError) as err:
+        _ = get_separation_bins_array(bad_rbins)
+    substr = "Input separation bins must be a monotonically increasing "
+    assert substr in err.value.args[0]
+
+    bad_rbins = [1, 2, 2, 4]
+    with pytest.raises(TypeError) as err:
+        _ = get_separation_bins_array(bad_rbins)
+    substr = "Input separation bins must be a monotonically increasing "
+    assert substr in err.value.args[0]
+
 
 
 

--- a/halotools/mock_observables/tpcf_estimators.py
+++ b/halotools/mock_observables/tpcf_estimators.py
@@ -96,7 +96,7 @@ def _TP_estimator_requirements(estimator):
     else: 
         available_estimators = _list_estimators()
         if estimator not in available_estimators:
-            msg = ("Input `estimator` must be one of the following:{0}".value(available_estimators))
+            msg = ("Input `estimator` must be one of the following:{0}".format(available_estimators))
             raise HalotoolsError(msg)
     
     return do_DD, do_DR, do_RR


### PR DESCRIPTION
This PR adds a few new helper functions to the `mock_observables` package to process function arguments and do bounds-checking with more transparency. Currently only implementing these improvements in the `delta_sigma` function, but the remaining `tpcf_xxx` functions will soon follow suit. This PR also fixes a couple of bugs in the docstring to `delta_sigma`. 