### PR TITLE
Crossmatch

### DIFF
--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/basic_examples/crossmatching_galaxy_catalogs.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/basic_examples/crossmatching_galaxy_catalogs.rst
@@ -1,0 +1,44 @@
+:orphan:
+
+.. _crossmatching_galaxy_catalogs:
+
+****************************************************
+Cross-matching galaxy and halo catalogs
+****************************************************
+
+This tutorial demonstrates how to use the 
+`~halotools.utils.crossmatch` function to create "value-added" versions of your 
+galaxy catalog that are supplemented by additional properties 
+only stored in the halo catalog. 
+
+For a closely related tutorial, see :ref:`crossmatching_halo_catalogs`. 
+
+Example 1: Creating a value-added galaxy catalog from information in a halo catalog
+=====================================================================================
+
+Let's start out by generating a mock galaxy catalog from a (fake) halo catalog:
+
+>>> from halotools.sim_manager import FakeSim
+>>> halocat = FakeSim()
+>>> from halotools.empirical_models import PrebuiltHodModelFactory
+>>> model = PrebuiltHodModelFactory('leauthaud11')
+>>> model.populate_mock(halocat)
+
+The tabular data of mock galaxies is stored in ``model.mock.galaxy_table``, 
+an Astropy `~astropy.table.Table`, and the halo catalog initially passed 
+to the `~halotools.empirical_models.HodMockFactory` is stored in  
+``halocat.halo_table``. All mock galaxy catalogs come with 
+a ``halo_id`` that lets you cross-match the galaxies against the halos they live in 
+using the `~halotools.utils.crossmatch` function. This function returns the indices 
+providing the correspondence between the rows in the ``galaxy_table`` that have 
+matches in the ``halo_table``. 
+
+>>> import numpy as np
+>>> from halotools.utils import crossmatch 
+>>> idx_galaxies, idx_halos = crossmatch(model.mock.galaxy_table['halo_id'], halocat.halo_table['halo_id'])
+>>> model.mock.galaxy_table['halo_vmax'] = np.zeros(len(model.mock.galaxy_table), dtype = halocat.halo_table['halo_vmax'].dtype)
+>>> model.mock.galaxy_table['halo_vmax'][idx_galaxies] = halocat.halo_table['halo_vmax'][idx_halos]
+
+
+
+

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/basic_examples/crossmatching_galaxy_catalogs.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/basic_examples/crossmatching_galaxy_catalogs.rst
@@ -13,9 +13,6 @@ only stored in the halo catalog.
 
 For a closely related tutorial, see :ref:`crossmatching_halo_catalogs`. 
 
-Example 1: Creating a value-added galaxy catalog from information in a halo catalog
-=====================================================================================
-
 Let's start out by generating a mock galaxy catalog from a (fake) halo catalog:
 
 >>> from halotools.sim_manager import FakeSim
@@ -25,13 +22,18 @@ Let's start out by generating a mock galaxy catalog from a (fake) halo catalog:
 >>> model.populate_mock(halocat)
 
 The tabular data of mock galaxies is stored in ``model.mock.galaxy_table``, 
-an Astropy `~astropy.table.Table`, and the halo catalog initially passed 
-to the `~halotools.empirical_models.HodMockFactory` is stored in  
-``halocat.halo_table``. All mock galaxy catalogs come with 
+an Astropy `~astropy.table.Table`. All mock galaxy catalogs come with 
 a ``halo_id`` that lets you cross-match the galaxies against the halos they live in 
 using the `~halotools.utils.crossmatch` function. This function returns the indices 
 providing the correspondence between the rows in the ``galaxy_table`` that have 
-matches in the ``halo_table``. 
+matches in the ``halo_table``. You can use this function to transfer any 
+property stored in the halo catalog onto the galaxies in your mock. 
+If you are working with a model you have built yourself, and you know in advance that 
+you would like some particular halo property to always be a part of your ``galaxy_table``, 
+then you can exploit :ref:`list_of_haloprops_needed_mechanism` when building your model. 
+But you can always use the `~halotools.utils.crossmatch` function to perform this task 
+in a post-processing phase, as shown here for the case of adding the ``halo_vmax`` 
+column to the ``galaxy_table``. 
 
 >>> import numpy as np
 >>> from halotools.utils import crossmatch 

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/index.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/index.rst
@@ -20,6 +20,14 @@ straightforward calculation on a mock galaxy catalog. By reading through
 these examples, you will gain a working knowledge of all the major functions 
 in the `~halotools.mock_observables` package. 
 
+cross-matching galaxy and halo catalogs 
+-------------------------------------------------
+
+.. toctree:: 
+   :maxdepth: 1
+
+   basic_examples/crossmatching_galaxy_catalogs
+
 galaxy properties as a function of halo mass
 -------------------------------------------------
 

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/crossmatching_halo_catalogs.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/crossmatching_halo_catalogs.rst
@@ -12,6 +12,8 @@ two different examples of how you can use the
 `~halotools.utils.crossmatch` function to exploit this column to create 
 "value-added" versions of your halo catalogs. 
 
+For a closely related tutorial, see :ref:`crossmatching_galaxy_catalogs`. 
+
 Example 1: Combining information from different halo catalogs 
 =================================================================
 When analyzing halo catalogs, it's a common situation for you to have 
@@ -34,7 +36,9 @@ or generally any structured data table with an object ID.
 
 Now let's add some new column information to ``halo_table2`` 
 and use the `~halotools.utils.crossmatch` function to transfer 
-this information to ``halo_table1``. 
+this information to ``halo_table1``. This function returns the indices 
+providing the correspondence between the rows in the ``halo_table1`` that have 
+matches in the ``halo_table2``. 
 
 >>> import numpy as np
 >>> halo_table2['some_new_column'] = np.random.random(len(halo_table2))

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/crossmatching_halo_catalogs.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/crossmatching_halo_catalogs.rst
@@ -2,15 +2,19 @@
 
 .. _crossmatching_halo_catalogs:
 
-****************************************************
-Cross-matching subhalo catalogs
-****************************************************
+***********************************************************
+Creating value-added halo catalogs through cross-matching
+***********************************************************
 
 All halo catalogs come with an integer ID column providing a unique 
 identifier of the (sub)halo in the catalog. This tutorial demonstrates 
 two different examples of how you can use the 
 `~halotools.utils.crossmatch` function to exploit this column to create 
 "value-added" versions of your halo catalogs. 
+In Example 1, we'll show how to combine information from two partially 
+overlapping halo catalogs. In Example 2, we'll show how to create new 
+columns for a subhalo catalog storing the properties of the host halo, 
+e.g., host mass :math:`M_{\rm vir}^{\rm host}`. 
 
 For a closely related tutorial, see :ref:`crossmatching_galaxy_catalogs`. 
 
@@ -20,7 +24,7 @@ When analyzing halo catalogs, it's a common situation for you to have
 two different versions of a halo catalog, 
 one with halo properties that you wish to transfer to the other. 
 In general, the two versions may only partially overlap, 
-different cuts have have been applied to the catalogs. 
+as different cuts may have have been applied to the catalogs. 
 We'll demonstrate this scenario using the `~halotools.sim_manager.FakeSim` 
 halo catalog that is randomly generated on-the-fly, but the 
 same calculation applies equally well to real halo catalogs, 
@@ -37,8 +41,8 @@ or generally any structured data table with an object ID.
 Now let's add some new column information to ``halo_table2`` 
 and use the `~halotools.utils.crossmatch` function to transfer 
 this information to ``halo_table1``. This function returns the indices 
-providing the correspondence between the rows in the ``halo_table1`` that have 
-matches in the ``halo_table2``. 
+providing the correspondence between the rows in ``halo_table1`` that have 
+matches in ``halo_table2``. 
 
 >>> import numpy as np
 >>> halo_table2['some_new_column'] = np.random.random(len(halo_table2))
@@ -47,8 +51,8 @@ The halo catalog column ``halo_id`` is a Long giving a unique identifier
 to every halo and subhalo in the halo catalog, so we can use that column 
 to match one object to the other. 
 
->>> halo_table1['transferred_column'] = np.zeros(len(halo_table1), dtype = halo_table2['some_new_column'].dtype)
 >>> from halotools.utils import crossmatch
+>>> halo_table1['transferred_column'] = np.zeros(len(halo_table1), dtype = halo_table2['some_new_column'].dtype)
 >>> idx_table1, idx_table2 = crossmatch(halo_table1['halo_id'], halo_table2['halo_id'])
 >>> halo_table1['transferred_column'][idx_table1] = halo_table2['some_new_column'][idx_table2]
 
@@ -66,17 +70,16 @@ column in your data table storing the associated host halo property,
 and in order to create such a column, you need to cross-match the 
 ``halo_id`` column against the ``halo_hostid`` column. 
 As described in :ref:`rockstar_subhalo_nomenclature`, for the case of subhalos, 
-either of these two columns points to the ``halo_id`` of the host halo. 
+the ``halo_hostid`` column points to the ``halo_id`` of the host halo. 
 So we use the `~halotools.utils.crossmatch` function to add new columns to 
 the halo catalog such that some property of the host halo is transferred onto 
-all of its subhalos. (Note that many subhalos share a common 
-host, and in some cases there may be no matching host halo, 
-so this calculation is not a simple table `~astropy.table.join`). 
+all of its subhalos. 
 
 >>> halocat = FakeSim()
->>> idx_table1, idx_table2 = crossmatch(halocat.halo_table['halo_hostid'], halocat.halo_table['halo_id']) 
->>> halocat.halo_table['host_halo_mvir'] = halocat.halo_table['halo_mvir'] # initialize the array
->>> halocat.halo_table['host_halo_mvir'][idx_table1] = halocat.halo_table[idx_table2]['halo_mvir'] 
+>>> t = halocat.halo_table 
+>>> idx_table1, idx_table2 = crossmatch(t['halo_hostid'], t['halo_id']) 
+>>> t['host_halo_mvir'] = t['halo_mvir'] # initialize the new column
+>>> t['host_halo_mvir'][idx_table1] = t[idx_table2]['halo_mvir'] 
 
 
 

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/crossmatching_halo_catalogs.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/crossmatching_halo_catalogs.rst
@@ -1,0 +1,82 @@
+:orphan:
+
+.. _crossmatching_halo_catalogs:
+
+****************************************************
+Cross-matching subhalo catalogs
+****************************************************
+
+All halo catalogs come with an integer ID column providing a unique 
+identifier of the (sub)halo in the catalog. This tutorial demonstrates 
+two different examples of how you can use the 
+`~halotools.utils.crossmatch` function to exploit this column to create 
+"value-added" versions of your halo catalogs. 
+
+Example 1: Combining information from different halo catalogs 
+=================================================================
+When analyzing halo catalogs, it's a common situation for you to have 
+two different versions of a halo catalog, 
+one with halo properties that you wish to transfer to the other. 
+In general, the two versions may only partially overlap, 
+different cuts have have been applied to the catalogs. 
+We'll demonstrate this scenario using the `~halotools.sim_manager.FakeSim` 
+halo catalog that is randomly generated on-the-fly, but the 
+same calculation applies equally well to real halo catalogs, 
+or generally any structured data table with an object ID. 
+
+>>> from halotools.sim_manager import FakeSim
+>>> halocat1 = FakeSim()
+>>> halo_table1 = halocat1.halo_table
+
+>>> halocat2 = FakeSim()
+>>> mask = halocat2.halo_table['halo_mvir'] > 1e11
+>>> halo_table2 = halocat2.halo_table[mask]
+
+Now let's add some new column information to ``halo_table2`` 
+and use the `~halotools.utils.crossmatch` function to transfer 
+this information to ``halo_table1``. 
+
+>>> import numpy as np
+>>> halo_table2['some_new_column'] = np.random.random(len(halo_table2))
+
+The halo catalog column ``halo_id`` is a Long giving a unique identifier 
+to every halo and subhalo in the halo catalog, so we can use that column 
+to match one object to the other. 
+
+>>> halo_table1['transferred_column'] = np.zeros(len(halo_table1), dtype = halo_table2['some_new_column'].dtype)
+>>> from halotools.utils import crossmatch
+>>> idx_table1, idx_table2 = crossmatch(halo_table1['halo_id'], halo_table2['halo_id'])
+>>> halo_table1['transferred_column'][idx_table1] = halo_table2['some_new_column'][idx_table2]
+
+Now for those objects in ``halo_table1`` that are also in ``halo_table2``, 
+the values from the ``some_new_column`` column will be stored in the 
+``transferred_column``; rows without a matching entry will still be set to their 
+initial value of zero. 
+
+Example 2: Transferring host halo properties to their subhalos  
+=================================================================
+When analyzing catalogs that include subhalos, one very common kind of calculation 
+that is done over and over is to group subhalos according to some property of the 
+host halo, such as host halo mass. Such calculations become easy when there is a 
+column in your data table storing the associated host halo property, 
+and in order to create such a column, you need to cross-match the 
+``halo_id`` column against the ``halo_hostid`` column. 
+As described in :ref:`rockstar_subhalo_nomenclature`, for the case of subhalos, 
+either of these two columns points to the ``halo_id`` of the host halo. 
+So we use the `~halotools.utils.crossmatch` function to add new columns to 
+the halo catalog such that some property of the host halo is transferred onto 
+all of its subhalos. (Note that many subhalos share a common 
+host, and in some cases there may be no matching host halo, 
+so this calculation is not a simple table `~astropy.table.join`). 
+
+>>> halocat = FakeSim()
+>>> idx_table1, idx_table2 = crossmatch(halocat.halo_table['halo_hostid'], halocat.halo_table['halo_id']) 
+>>> halocat.halo_table['host_halo_mvir'] = halocat.halo_table['halo_mvir'] # initialize the array
+>>> halocat.halo_table['host_halo_mvir'][idx_table1] = halocat.halo_table[idx_table2]['halo_mvir'] 
+
+
+
+
+
+
+

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/index.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/index.rst
@@ -19,14 +19,6 @@ straightforward calculation on a halo catalog. By reading through
 these examples, you will gain a working knowledge of all the major functions 
 in the `~halotools.mock_observables` package. 
 
-cross-matching halo catalogs with each other
--------------------------------------------------
-
-.. toctree:: 
-	:maxdepth: 1
-
-	crossmatching_halo_catalogs
-
 halo properties as a function of halo mass
 -------------------------------------------------
 
@@ -34,6 +26,14 @@ halo properties as a function of halo mass
    :maxdepth: 1
 
    basic_examples/halo_catalog_analysis_tutorial1
+
+cross-matching halo catalogs 
+-------------------------------------------------
+
+.. toctree:: 
+	:maxdepth: 1
+
+	crossmatching_halo_catalogs
 
 halo properties as a function of distance from a nearby halo 
 --------------------------------------------------------------

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/index.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/halocat_analysis/index.rst
@@ -19,6 +19,14 @@ straightforward calculation on a halo catalog. By reading through
 these examples, you will gain a working knowledge of all the major functions 
 in the `~halotools.mock_observables` package. 
 
+cross-matching halo catalogs with each other
+-------------------------------------------------
+
+.. toctree:: 
+	:maxdepth: 1
+
+	crossmatching_halo_catalogs
+
 halo properties as a function of halo mass
 -------------------------------------------------
 

--- a/docs/source_notes/empirical_models/factories/model_factory_composite_sequence_mechanisms.rst
+++ b/docs/source_notes/empirical_models/factories/model_factory_composite_sequence_mechanisms.rst
@@ -8,9 +8,6 @@
 Composite Model Bookkeeping Mechanisms
 ****************************************************
 
-This tutorial remains to be written. See `Github Issue 211 <https://github.com/astropy/halotools/issues/211/>`_
-
-
 .. _param_dict_mechanism:
 
 The ``param_dict`` mechanism

--- a/halotools/utils/__init__.py
+++ b/halotools/utils/__init__.py
@@ -1,10 +1,6 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-# This sub-module is destined for common non-package specific utility
-# functions that will ultimately be merged into `astropy.utils`
-
-from __future__ import (division, print_function, 
-    absolute_import, unicode_literals)
+""" This module contains helper functions used throughout the Halotools package.
+"""
+from __future__ import division, print_function, absolute_import, unicode_literals
 
 from .spherical_geometry import *
 from .array_utils import *
@@ -12,3 +8,4 @@ from .io_utils import *
 from .table_utils import *
 from .value_added_halo_table_functions import *
 from .group_member_generator import group_member_generator
+from .crossmatch import crossmatch

--- a/halotools/utils/crossmatch.py
+++ b/halotools/utils/crossmatch.py
@@ -6,9 +6,10 @@ import numpy as np
 
 def crossmatch(x, y, skip_bounds_checking = False):
     """
-    Function used to identify elements of an integer array x 
-    that may appear in an integer array y, and return the 
-    indices providing the correspondence. 
+    Function providing the index-correspondence between the 
+    elements of an array x with values that have a match in an array y. 
+    The elements in x may be repeated, but the elements in y must be unique. 
+    The arrays x and y may be only partially overlapping. 
 
     The applications of this function envolve cross-matching 
     two catalogs/data tables which share an objectID. 
@@ -23,8 +24,8 @@ def crossmatch(x, y, skip_bounds_checking = False):
     you can use the `~halotools.utils.crossmatch` function to create new columns 
     storing properties of the associated host. 
 
-    See :ref:`crossmatching_halo_catalogs` for a tutorial on common usage 
-    of this function with a halo catalog. 
+    See :ref:`crossmatching_halo_catalogs` and :ref:`crossmatching_galaxy_catalogs`
+    for tutorials on common usages of this function with halo and galaxy catalogs. 
 
     Parameters 
     ----------
@@ -35,7 +36,10 @@ def crossmatch(x, y, skip_bounds_checking = False):
         Array of unique integers. 
 
     skip_bounds_checking : bool, optional 
-        If set to False, the input y will be 
+        If set to False, the input arrays will be tested for consistency 
+        with the assumptions of the algorithm. If set to True, 
+        testing is bypassed and the function evaluates faster. 
+        Default is False. 
 
     Returns 
     -------
@@ -49,19 +53,18 @@ def crossmatch(x, y, skip_bounds_checking = False):
 
     Examples 
     --------
-    Create a sample of 1e6 random integers between 0 and 1000:
+    Let's create some fake integer data 
+    to demonstrate basic usage of the function:
 
     >>> xmax = 1000
     >>> numx = 1e6
     >>> x = np.random.random_integers(0, xmax, numx)
-    >>> x.sort()
+    >>> y = np.arange(-xmax/2, xmax/2)[::10]
 
-    Randomly select 50 unique integers between 0 and 1000:
+    Note that x may have repeated entries, and that x and y may be 
+    only partially overlapping. 
 
-    >>> y = np.random.choice(xmax+1, 50)
-    >>> y.sort()
-
-    Now find the integers in x for which there are matches in y
+    Now find the integers in x for which there are matches in y:
 
     >>> x_idx, y_idx = crossmatch(x, y)
 
@@ -73,7 +76,9 @@ def crossmatch(x, y, skip_bounds_checking = False):
     See also 
     ---------
     :ref:`crossmatching_halo_catalogs`
-    
+
+    :ref:`crossmatching_galaxy_catalogs`
+
     """
     # Ensure inputs are Numpy arrays
     x = np.atleast_1d(x)

--- a/halotools/utils/crossmatch.py
+++ b/halotools/utils/crossmatch.py
@@ -1,0 +1,126 @@
+""" Module containing the `~halotools.utils.crossmatch` function used to 
+calculate indices providing the correspondence between two data tables 
+sharing a common objectID.
+""" 
+import numpy as np 
+
+def crossmatch(x, y, skip_bounds_checking = False):
+    """
+    Function used to identify elements of an integer array x 
+    that may appear in an integer array y, and return the 
+    indices providing the correspondence. 
+
+    The applications of this function envolve cross-matching 
+    two catalogs/data tables which share an objectID. 
+    For example, if you have a primary data table and a secondary data table containing 
+    supplementary information about (some of) the objects, the 
+    `~halotools.utils.crossmatch` function can be used to "value-add" the 
+    primary table with data from the second. 
+
+    For another example, suppose you have a single data table 
+    with an object ID column and also a column for a "host" ID column 
+    (e.g., ``halo_hostid`` in Halotools-provided catalogs), 
+    you can use the `~halotools.utils.crossmatch` function to create new columns 
+    storing properties of the associated host. 
+
+    See :ref:`crossmatching_halo_catalogs` for a tutorial on common usage 
+    of this function with a halo catalog. 
+
+    Parameters 
+    ----------
+    x : integer array
+        Array of integers with possibly repeated entries. 
+
+    y : integer array
+        Array of unique integers. 
+
+    skip_bounds_checking : bool, optional 
+        If set to False, the input y will be 
+
+    Returns 
+    -------
+    idx_x : integer array
+        Boolean array used to apply a mask to x 
+        such that x[idx_x] == y[idx_y] 
+
+    y_idx : integer array  
+        Array of integers used to apply a fancy-indexing mask to y 
+        such that x[idx_x] == y[idx_y] 
+
+    Examples 
+    --------
+    Create a sample of 1e6 random integers between 0 and 1000:
+
+    >>> xmax = 1000
+    >>> numx = 1e6
+    >>> x = np.random.random_integers(0, xmax, numx)
+    >>> x.sort()
+
+    Randomly select 50 unique integers between 0 and 1000:
+
+    >>> y = np.random.choice(xmax+1, 50)
+    >>> y.sort()
+
+    Now find the integers in x for which there are matches in y
+
+    >>> x_idx, y_idx = crossmatch(x, y)
+
+    The indexing arrays ``x_idx`` and ``y_idx`` are such that 
+    the following assertion always holds true:
+
+    >>> assert np.all(x[x_idx] == y[y_idx])
+
+    See also 
+    ---------
+    :ref:`crossmatching_halo_catalogs`
+    
+    """
+    # Ensure inputs are Numpy arrays
+    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
+
+    # Require that the inputs meet the assumptions of the algorithm
+    if skip_bounds_checking is True:
+        pass
+    else:
+        try:
+            assert len(set(y)) == len(y)
+            assert np.all(np.array(y, dtype = np.int64) == y)
+            assert np.shape(y) == (len(y), )
+        except:
+            msg = ("Input array y must be a 1d sequence of unique integers")
+            raise ValueError(msg)
+        try:
+            assert np.all(np.array(x, dtype = np.int64) == x)
+            assert np.shape(x) == (len(x), )
+        except:
+            msg = ("Input array x must be a 1d sequence of integers")
+            raise ValueError(msg)
+
+    # Internally, we will work with sorted arrays, and then undo the sorting at the end
+    idx_x_sorted = np.argsort(x)
+    idx_y_sorted = np.argsort(y)
+    x_sorted = np.copy(x[idx_x_sorted])
+    y_sorted = np.copy(y[idx_y_sorted])
+
+    # x may have repeated entries, so find the unique values as well as their multiplicity
+    unique_xvals, counts = np.unique(x_sorted, return_counts = True)
+
+    # Determine which of the unique x values has a match in y
+    unique_xval_has_match = np.in1d(unique_xvals, y_sorted, assume_unique = True)
+
+    # Create a boolean array with True for each value in x with a match, otherwise False
+    idx_x = np.repeat(unique_xval_has_match, counts)
+
+    # For each unique value of x with a match in y, identify the index of the match
+    matching_indices_in_y = np.searchsorted(y_sorted, unique_xvals[unique_xval_has_match])
+
+    # Repeat each matching index according to the multiplicity in x
+    idx_y = np.repeat(matching_indices_in_y, counts[unique_xval_has_match])
+
+    # Undo the original sorting and return the result
+    return idx_x_sorted[idx_x], idx_y_sorted[idx_y]
+
+
+
+

--- a/halotools/utils/crossmatch.py
+++ b/halotools/utils/crossmatch.py
@@ -7,7 +7,7 @@ import numpy as np
 def crossmatch(x, y, skip_bounds_checking = False):
     """
     Function providing the index-correspondence between the 
-    elements of an array x with values that have a match in an array y. 
+    elements of an integer array x with values that have a match in an integer array y. 
     The elements in x may be repeated, but the elements in y must be unique. 
     The arrays x and y may be only partially overlapping. 
 
@@ -36,19 +36,22 @@ def crossmatch(x, y, skip_bounds_checking = False):
         Array of unique integers. 
 
     skip_bounds_checking : bool, optional 
-        If set to False, the input arrays will be tested for consistency 
-        with the assumptions of the algorithm. If set to True, 
-        testing is bypassed and the function evaluates faster. 
+        The first step in the `crossmatch` function is to test that the input 
+        arrays satisfy the assumptions of the algorithm 
+        (namely that ``x`` and ``y`` store integers, 
+        and that all values in ``y`` are unique). 
+        If ``skip_bounds_checking`` is set to True, 
+        this testing is bypassed and the function evaluates faster. 
         Default is False. 
 
     Returns 
     -------
     idx_x : integer array
-        Boolean array used to apply a mask to x 
+        Integer array used to apply a mask to x 
         such that x[idx_x] == y[idx_y] 
 
     y_idx : integer array  
-        Array of integers used to apply a fancy-indexing mask to y 
+        Integer array used to apply a mask to y 
         such that x[idx_x] == y[idx_y] 
 
     Examples 
@@ -61,7 +64,7 @@ def crossmatch(x, y, skip_bounds_checking = False):
     >>> x = np.random.random_integers(0, xmax, numx)
     >>> y = np.arange(-xmax/2, xmax/2)[::10]
 
-    Note that x may have repeated entries, and that x and y may be 
+    Note that x has repeated entries, and that x and y are  
     only partially overlapping. 
 
     Now find the integers in x for which there are matches in y:

--- a/halotools/utils/tests/test_crossmatch.py
+++ b/halotools/utils/tests/test_crossmatch.py
@@ -1,0 +1,132 @@
+""" Module providing unit-testing of `~halotools.utils.crossmatch` function.
+"""
+import numpy as np 
+from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
+
+from ..crossmatch import crossmatch 
+
+__all__ = ('test_crossmatch1', )
+
+fixed_seed = 43
+
+def test_crossmatch1():
+    """ x has unique entries. All y values are in x. All x values are in y. 
+    """
+    x = np.array([1, 3, 5])
+    y = np.array([5, 1])
+    x_idx, y_idx = crossmatch(x, y)
+
+    assert np.all(x[x_idx] == y[y_idx])
+
+def test_crossmatch2():
+    """ x has repeated entries. All y values are in x. All x values are in y. 
+    """
+    x = np.array([1, 3, 5, 3, 1, 1, 3, 5])
+    y = np.array([5, 1])
+    x_idx, y_idx = crossmatch(x, y)
+
+    assert np.all(x[x_idx] == y[y_idx])
+
+def test_crossmatch3():
+    """ x has repeated entries. All y values are in x. Some x values are not in y. 
+    """
+    x = np.array([0, 1, 3, 5, 3, -1, 1, 3, 5, -1])
+    y = np.array([5, 1])
+    x_idx, y_idx = crossmatch(x, y)
+
+    assert np.all(x[x_idx] == y[y_idx])
+
+def test_crossmatch4():
+    """ x has repeated entries. Some y values are not in x. Some x values are not in y. 
+    """
+    x = np.array([1, 3, 5, 3, 1, -1, 3, 5, -10, -10])
+    y = np.array([5, 1, 100, 20])
+    x_idx, y_idx = crossmatch(x, y)
+
+    assert np.all(x[x_idx] == y[y_idx])
+
+def test_crossmatch5():
+    """ x has repeated entries. Some y values are not in x. Some x values are not in y. 
+    """
+    xmax = 100
+    numx = 10000
+    with NumpyRNGContext(fixed_seed):
+        x = np.random.random_integers(0, xmax, numx)
+
+    y = np.arange(-xmax, xmax)[::10]
+    np.random.shuffle(y)
+
+    x_idx, y_idx = crossmatch(x, y)
+
+    assert np.all(x[x_idx] == y[y_idx])
+
+def test_crossmatch6():
+    """ x and y have zero overlap.
+    """
+    x = np.array([-1, -5, -10])
+    y = np.array([1, 2, 3, 4])
+    x_idx, y_idx = crossmatch(x, y)
+    assert len(x_idx) == 0
+    assert len(y_idx) == 0
+    assert np.all(x[x_idx] == y[y_idx])
+
+def test_error_handling1():
+    """ Verify that we raise the proper exception when y has repeated entries.
+    """
+    x = np.ones(5)
+    y = np.ones(5)
+
+    with pytest.raises(ValueError) as err:
+        result = crossmatch(x, y)
+    substr = "Input array y must be a 1d sequence of unique integers"
+    assert substr in err.value.args[0]
+
+def test_error_handling2():
+    """ Verify that we raise the proper exception when y has non-integer values.
+    """
+    x = np.ones(5)
+    y = np.arange(0, 5, 0.5)
+
+    with pytest.raises(ValueError) as err:
+        result = crossmatch(x, y)
+    substr = "Input array y must be a 1d sequence of unique integers"
+    assert substr in err.value.args[0]
+
+def test_error_handling3():
+    """ Verify that we raise the proper exception when y is multi-dimensional.
+    """
+    x = np.ones(5)
+    y = np.arange(0, 6).reshape(2, 3)
+
+    with pytest.raises(ValueError) as err:
+        result = crossmatch(x, y)
+    substr = "Input array y must be a 1d sequence of unique integers"
+    assert substr in err.value.args[0]
+
+def test_error_handling4():
+    """ Verify that we raise the proper exception when x has non-integer values.
+    """
+    x = np.arange(0, 5, 0.5)
+    y = np.arange(0, 6)
+
+    with pytest.raises(ValueError) as err:
+        result = crossmatch(x, y)
+    substr = "Input array x must be a 1d sequence of integers"
+    assert substr in err.value.args[0]
+
+def test_error_handling5():
+    """ Verify that we raise the proper exception when x is multi-dimensional.
+    """
+    x = np.arange(0, 6).reshape(2, 3)
+    y = np.arange(0, 6)
+
+    with pytest.raises(ValueError) as err:
+        result = crossmatch(x, y)
+    substr = "Input array x must be a 1d sequence of integers"
+    assert substr in err.value.args[0]
+
+
+
+
+

--- a/halotools/utils/tests/test_value_added_halo_table_functions.py
+++ b/halotools/utils/tests/test_value_added_halo_table_functions.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+""" Module providing unit-testing for `~halotools.utils.value_added_halo_table_functions`. 
+"""
+
 from __future__ import (absolute_import, division, print_function)
 
 from unittest import TestCase
@@ -12,6 +14,7 @@ from astropy.tests.helper import pytest
 from astropy.extern.six.moves import xrange as range
 
 from ..value_added_halo_table_functions import broadcast_host_halo_property, add_halo_hostid
+from ..crossmatch import crossmatch 
 
 from ...sim_manager import FakeSim
 
@@ -38,6 +41,13 @@ class TestValueAddedHaloTableFunctions(TestCase):
         hostmask = t['halo_hostid'] == t['halo_id']
         assert np.all(t['halo_mvir_host_halo'][hostmask] == t['halo_mvir'][hostmask])
         assert np.any(t['halo_mvir_host_halo'][~hostmask] != t['halo_mvir'][~hostmask])
+
+        # Verify that both the group_member_generator method and the 
+        # crossmatch method give identical results for calculation of host halo mass
+        idx_table1, idx_table2 = crossmatch(t['halo_hostid'], t['halo_id'])
+        t['tmp'] = np.zeros(len(t), dtype = t['halo_mvir'].dtype)
+        t['tmp'][idx_table1] = t['halo_mvir'][idx_table2]
+        assert np.all(t['tmp'] == t['halo_mvir_host_halo'])
 
         data = Counter(t['halo_hostid'])
         frequency_analysis = data.most_common()


### PR DESCRIPTION
This PR introduces a new user-facing function to the `utils` sub-package, `crossmatch`. This function returns the indices giving the correspondence between elements of an integer array `x` with values that have a match in an integer array `y`. When `x` and `y` have unique entries, this calculation is equivalent to the `join` function in `astropy.table`, but `crossmatch` also covers the case where the array `x` has repeated entries, and the arrays `x` and `y` may only be partially overlapping. This function is useful for transferring properties from one table to another, or also in doing specific kinds of group aggregation calculations in which some pre-computed property of the groups is broadcast to the members (the calculation of host halo mass is a common example). The `crossmatch` function is very fast even for very large arrays, because all the expensive operations are done exclusively using heavily optimized Numpy functions `np.argsort`, `np.unique`, `np.in1d`, `np.searchsorted`, and `np.repeat`. 

Question for @taldcroft - how do *you* do such calculations? Is this functionality redundant with some function in `astropy`? If not, would this be a candidate for the core?

CC @duncandc - nothing for you to do here, just wanted you to be aware that this feature is now in the repo. 

Also tagging @a-kravtsov as we have previously discussed the `np.repeat` function in the context of making mocks; the `crossmatch` source code demonstrates another example of how useful `np.repeat` can be. 






