### PR TITLE
Fixed bug in processing of arguments.

### DIFF
--- a/halotools/mock_observables/group_identification/fof_groups.py
+++ b/halotools/mock_observables/group_identification/fof_groups.py
@@ -116,8 +116,8 @@ class FoFGroups(object):
             Lbox = np.array([period, period, period])
 
         if np.shape(Lbox) != (3,):
-            raise ValueError("Lbox must be an array of length 3, or number indicating the\
-                              length of one side of a cube")
+            raise ValueError("Lbox must be an array of length 3, or number indicating the "
+                "length of one side of a cube")
         if (period is not None) and (not np.all(Lbox==period)):
             raise ValueError("If both Lbox and Period are defined, they must be equal.")
         

--- a/halotools/mock_observables/pair_counters/npairs_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_3d.py
@@ -134,8 +134,7 @@ def npairs_3d(sample1, sample2, rbins, period = None,
 
     # Create a function object that has a single argument, for parallelization purposes
     engine = partial(npairs_3d_engine, 
-        double_mesh, sample1[:,0], sample1[:,1], sample1[:,2], 
-        sample2[:,0], sample2[:,1], sample2[:,2], rbins)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rbins)
 
     # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(

--- a/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
@@ -173,8 +173,7 @@ def npairs_jackknife_3d(sample1, sample2, rbins, period=None, weights1=None, wei
 
     # Create a function object that has a single argument, for parallelization purposes
     engine = partial(npairs_jackknife_3d_engine, 
-        double_mesh, sample1[:,0], sample1[:,1], sample1[:,2], 
-        sample2[:,0], sample2[:,1], sample2[:,2], 
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
         weights1, weights2, jtags1, jtags2, N_samples, rbins)
 
     # Calculate the cell1 indices that will be looped over by the engine

--- a/halotools/mock_observables/pair_counters/npairs_per_object_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_per_object_3d.py
@@ -125,8 +125,7 @@ def npairs_per_object_3d(sample1, sample2, rbins, period = None,
 
     # Create a function object that has a single argument, for parallelization purposes
     engine = partial(npairs_per_object_3d_engine, 
-        double_mesh, sample1[:,0], sample1[:,1], sample1[:,2], 
-        sample2[:,0], sample2[:,1], sample2[:,2], rbins)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rbins)
 
     # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(

--- a/halotools/mock_observables/pair_counters/npairs_projected.py
+++ b/halotools/mock_observables/pair_counters/npairs_projected.py
@@ -142,8 +142,7 @@ def npairs_projected(sample1, sample2, rp_bins, pi_max, period = None,
 
     # # Create a function object that has a single argument, for parallelization purposes
     engine = partial(npairs_projected_engine, 
-        double_mesh, sample1[:,0], sample1[:,1], sample1[:,2], 
-        sample2[:,0], sample2[:,1], sample2[:,2], rp_bins, pi_max)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rp_bins, pi_max)
 
     # # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(

--- a/halotools/mock_observables/pair_counters/npairs_s_mu.py
+++ b/halotools/mock_observables/pair_counters/npairs_s_mu.py
@@ -177,8 +177,7 @@ def npairs_s_mu(sample1, sample2, s_bins, mu_bins, period = None,
 
     # # Create a function object that has a single argument, for parallelization purposes
     engine = partial(npairs_s_mu_engine, 
-        double_mesh, sample1[:,0], sample1[:,1], sample1[:,2], 
-        sample2[:,0], sample2[:,1], sample2[:,2], s_bins, mu_bins)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, s_bins, mu_bins)
 
     # # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(

--- a/halotools/mock_observables/pair_counters/npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/npairs_xy_z.py
@@ -147,8 +147,7 @@ def npairs_xy_z(sample1, sample2, rp_bins, pi_bins, period = None,
 
     # # Create a function object that has a single argument, for parallelization purposes
     engine = partial(npairs_xy_z_engine, 
-        double_mesh, sample1[:,0], sample1[:,1], sample1[:,2], 
-        sample2[:,0], sample2[:,1], sample2[:,2], rp_bins, pi_bins)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rp_bins, pi_bins)
 
     # # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(

--- a/halotools/mock_observables/pair_counters/pairwise_distance_3d.py
+++ b/halotools/mock_observables/pair_counters/pairwise_distance_3d.py
@@ -131,8 +131,7 @@ def pairwise_distance_3d(data1, data2, rmax, period = None,
     
     # Create a function object that has a single argument, for parallelization purposes
     engine = partial(pairwise_distance_3d_engine, 
-        double_mesh, data1[:,0], data1[:,1], data1[:,2], 
-        data2[:,0], data2[:,1], data2[:,2], rmax)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rmax)
     
     # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(

--- a/halotools/mock_observables/pair_counters/pairwise_distance_xy_z.py
+++ b/halotools/mock_observables/pair_counters/pairwise_distance_xy_z.py
@@ -133,8 +133,7 @@ def pairwise_distance_xy_z(data1, data2, rp_max, pi_max, period = None,
     
     # Create a function object that has a single argument, for parallelization purposes
     engine = partial(pairwise_distance_xy_z_engine, 
-        double_mesh, data1[:,0], data1[:,1], data1[:,2], 
-        data2[:,0], data2[:,1], data2[:,2], rp_max, pi_max)
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rp_max, pi_max)
     
     # Calculate the cell1 indices that will be looped over by the engine
     num_threads, cell1_tuples = _cell1_parallelization_indices(


### PR DESCRIPTION
During the processing of the arguments passed to many of the functions in `mock_observables`, the initial positions are shifted in the case where there are no PBCs. Many of the functions failed to use the shifted positions and only used the original positions. The test suite did not cover this because there were no tests for which PBCs were turned off and positions did not span [0, Lbox]. This is now fixed. 