### PR TITLE
Halo table read optimization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ distribute-*.tar.gz
 # Other
 .*.swp
 *~
-
+temporary_testing_script.py 
 *.ipynb
 .ipynb_checkpoints/*
 */.ipynb_checkpoints/*

--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -168,22 +168,42 @@ class HaloTableCacheLogEntry(object):
             return False
         else:
 
-            verification_sequence = ('_verify_h5py_extension',
-                '_verify_hdf5_has_complete_metadata',
-                '_verify_metadata_consistency',
-                '_verify_table_read',
-                '_verify_has_required_data_columns',
-                '_verify_all_keys_begin_with_halo',
-                '_verify_all_positions_inside_box',
-                '_verify_halo_ids_are_unique',
-                '_verify_halo_rvir_mpc_units')
+            tmp_msg, num_failures = self._verify_h5py_extension(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_hdf5_has_complete_metadata(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_metadata_consistency(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_table_read(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_has_required_data_columns(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_all_keys_begin_with_halo(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_all_positions_inside_box(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_halo_ids_are_unique(num_failures)
+            msg += tmp_msg
+            tmp_msg, num_failures = self._verify_halo_rvir_mpc_units(num_failures)
+            msg += tmp_msg
 
-            for verification_function in verification_sequence:
-                func = getattr(self, verification_function)
-                tmp_msg, num_failures = func(num_failures)
-                msg += tmp_msg
+            # verification_sequence = ('_verify_h5py_extension',
+            #     '_verify_hdf5_has_complete_metadata',
+            #     '_verify_metadata_consistency',
+            #     '_verify_table_read',
+            #     '_verify_has_required_data_columns',
+            #     '_verify_all_keys_begin_with_halo',
+            #     '_verify_all_positions_inside_box',
+            #     '_verify_halo_ids_are_unique',
+            #     '_verify_halo_rvir_mpc_units')
 
-            if num_failures > 0: self._cache_safety_message = message_preamble + msg
+            # for verification_function in verification_sequence:
+            #     func = getattr(self, verification_function)
+            #     tmp_msg, num_failures = func(num_failures)
+            #     msg += tmp_msg
+
+            if num_failures > 0: 
+                self._cache_safety_message = message_preamble + msg
 
             self._num_failures = num_failures
             return num_failures == 0

--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -174,17 +174,17 @@ class HaloTableCacheLogEntry(object):
             msg += tmp_msg
             tmp_msg, num_failures = self._verify_metadata_consistency(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures, halo_table = self._verify_table_read(num_failures)
+            tmp_msg, num_failures = self._verify_table_read(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_has_required_data_columns(halo_table, num_failures)
+            tmp_msg, num_failures = self._verify_has_required_data_columns(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_all_keys_begin_with_halo(halo_table, num_failures)
+            tmp_msg, num_failures = self._verify_all_keys_begin_with_halo(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_all_positions_inside_box(halo_table, num_failures)
+            tmp_msg, num_failures = self._verify_all_positions_inside_box(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_halo_ids_are_unique(halo_table, num_failures)
+            tmp_msg, num_failures = self._verify_halo_ids_are_unique(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_halo_rvir_mpc_units(halo_table, num_failures)
+            tmp_msg, num_failures = self._verify_halo_rvir_mpc_units(num_failures)
             msg += tmp_msg
 
             # verification_sequence = ('_verify_h5py_extension',
@@ -214,14 +214,14 @@ class HaloTableCacheLogEntry(object):
         msg = ''
 
         try:
-            halo_table = Table.read(self.fname, path='data')
+            data = Table.read(self.fname, path='data')
         except:
             num_failures += 1
             msg = (str(num_failures)+". The hdf5 file must be readable with "
                 "Astropy \nusing the following syntax:\n\n"
                 ">>> halo_data = Table.read(fname, path='data')\n\n")
             pass
-        return msg, num_failures, halo_table
+        return msg, num_failures
 
 
     def _verify_metadata_consistency(self, num_failures):
@@ -276,13 +276,14 @@ class HaloTableCacheLogEntry(object):
         return msg, num_failures
 
 
-    def _verify_all_keys_begin_with_halo(self, halo_table, num_failures):
+    def _verify_all_keys_begin_with_halo(self, num_failures):
         """
         """
         msg = ''
 
         try:
-            for key in list(halo_table.keys()):
+            data = Table.read(self.fname, path='data')
+            for key in list(data.keys()):
                 try:
                     assert key[0:5] == 'halo_'
                 except AssertionError:
@@ -295,13 +296,14 @@ class HaloTableCacheLogEntry(object):
 
         return msg, num_failures
 
-    def _verify_has_required_data_columns(self, halo_table, num_failures):
+    def _verify_has_required_data_columns(self, num_failures):
         """
         """
         msg = ''
 
         try:
-            keys = list(halo_table.keys())
+            data = Table.read(self.fname, path='data')
+            keys = list(data.keys())
             try:
                 assert 'halo_x' in keys
                 assert 'halo_y' in keys
@@ -320,19 +322,20 @@ class HaloTableCacheLogEntry(object):
 
         return msg, num_failures
 
-    def _verify_all_positions_inside_box(self, halo_table, num_failures):
+    def _verify_all_positions_inside_box(self, num_failures):
         """
         """
         msg = ''
 
         try:
+            data = Table.read(self.fname, path='data')
             f = self.h5py.File(self.fname)
             Lbox = f.attrs['Lbox']
             f.close()
             try:
-                halo_x = halo_table['halo_x'].data
-                halo_y = halo_table['halo_y'].data
-                halo_z = halo_table['halo_z'].data
+                halo_x = data['halo_x']
+                halo_y = data['halo_y']
+                halo_z = data['halo_z']
 
                 assert np.all(halo_x >= 0)
                 assert np.all(halo_x <= Lbox)
@@ -352,20 +355,24 @@ class HaloTableCacheLogEntry(object):
 
         return msg, num_failures
 
-    def _verify_halo_ids_are_unique(self, halo_table, num_failures):
+    def _verify_halo_ids_are_unique(self, num_failures):
         """
         """
         msg = ''
 
         try:
-            halo_id = halo_table['halo_id'].data
-            assert halo_id.dtype.str[1] in ('i','u')
-            assert len(halo_id) == len(set(halo_id))
-        except AssertionError:
-            num_failures += 1
-            msg = (str(num_failures)+". The ``halo_id`` column "
-                "must contain a unique set of integers.\n\n"
-                )
+            data = Table.read(self.fname, path='data')
+            try:
+                halo_id = data['halo_id'].data
+                assert halo_id.dtype.str[1] in ('i','u')
+                assert len(halo_id) == len(set(halo_id))
+            except AssertionError:
+                num_failures += 1
+                msg = (str(num_failures)+". The ``halo_id`` column "
+                    "must contain a unique set of integers.\n\n"
+                    )
+        except:
+            pass
 
         return msg, num_failures
 
@@ -394,21 +401,25 @@ class HaloTableCacheLogEntry(object):
             msg = str(num_failures) + ". The input file must have '.hdf5' extension.\n\n"
         return msg, num_failures
 
-    def _verify_halo_rvir_mpc_units(self, halo_table, num_failures):
+    def _verify_halo_rvir_mpc_units(self, num_failures):
         """ Require that all values stored in the halo_rvir column
         are less than 50, a crude way to ensure that units are not kpc.
         """
         msg = ''
 
         try:
-            halo_rvir = halo_table['halo_rvir'].data
-            assert np.all(halo_rvir < 50)
-        except AssertionError:
-            num_failures += 1
-            msg = (str(num_failures)+". All values of the "
-                "``halo_rvir`` column\n"
-                "must be less than 50, crudely ensuring you used Mpc/h units.\n\n"
-                )
+            data = Table.read(self.fname, path='data')
+            try:
+                halo_rvir = data['halo_rvir']
+                assert np.all(halo_rvir < 50)
+            except AssertionError:
+                num_failures += 1
+                msg = (str(num_failures)+". All values of the "
+                    "``halo_rvir`` column\n"
+                    "must be less than 50, crudely ensuring you used Mpc/h units.\n\n"
+                    )
+        except:
+            pass
 
         return msg, num_failures
 

--- a/halotools/sim_manager/halo_table_cache_log_entry.py
+++ b/halotools/sim_manager/halo_table_cache_log_entry.py
@@ -174,33 +174,18 @@ class HaloTableCacheLogEntry(object):
             msg += tmp_msg
             tmp_msg, num_failures = self._verify_metadata_consistency(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_table_read(num_failures)
+            tmp_msg, num_failures, halo_table = self._verify_table_read(num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_has_required_data_columns(num_failures)
+            tmp_msg, num_failures = self._verify_has_required_data_columns(halo_table,num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_all_keys_begin_with_halo(num_failures)
+            tmp_msg, num_failures = self._verify_all_keys_begin_with_halo(halo_table, num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_all_positions_inside_box(num_failures)
+            tmp_msg, num_failures = self._verify_all_positions_inside_box(halo_table, num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_halo_ids_are_unique(num_failures)
+            tmp_msg, num_failures = self._verify_halo_ids_are_unique(halo_table, num_failures)
             msg += tmp_msg
-            tmp_msg, num_failures = self._verify_halo_rvir_mpc_units(num_failures)
+            tmp_msg, num_failures = self._verify_halo_rvir_mpc_units(halo_table, num_failures)
             msg += tmp_msg
-
-            # verification_sequence = ('_verify_h5py_extension',
-            #     '_verify_hdf5_has_complete_metadata',
-            #     '_verify_metadata_consistency',
-            #     '_verify_table_read',
-            #     '_verify_has_required_data_columns',
-            #     '_verify_all_keys_begin_with_halo',
-            #     '_verify_all_positions_inside_box',
-            #     '_verify_halo_ids_are_unique',
-            #     '_verify_halo_rvir_mpc_units')
-
-            # for verification_function in verification_sequence:
-            #     func = getattr(self, verification_function)
-            #     tmp_msg, num_failures = func(num_failures)
-            #     msg += tmp_msg
 
             if num_failures > 0: 
                 self._cache_safety_message = message_preamble + msg
@@ -214,14 +199,14 @@ class HaloTableCacheLogEntry(object):
         msg = ''
 
         try:
-            data = Table.read(self.fname, path='data')
+            halo_table = Table.read(self.fname, path='data')
         except:
             num_failures += 1
             msg = (str(num_failures)+". The hdf5 file must be readable with "
                 "Astropy \nusing the following syntax:\n\n"
                 ">>> halo_data = Table.read(fname, path='data')\n\n")
-            pass
-        return msg, num_failures
+            halo_table = Table()
+        return msg, num_failures, halo_table
 
 
     def _verify_metadata_consistency(self, num_failures):
@@ -276,14 +261,13 @@ class HaloTableCacheLogEntry(object):
         return msg, num_failures
 
 
-    def _verify_all_keys_begin_with_halo(self, num_failures):
+    def _verify_all_keys_begin_with_halo(self, halo_table, num_failures):
         """
         """
         msg = ''
 
         try:
-            data = Table.read(self.fname, path='data')
-            for key in list(data.keys()):
+            for key in list(halo_table.keys()):
                 try:
                     assert key[0:5] == 'halo_'
                 except AssertionError:
@@ -296,14 +280,13 @@ class HaloTableCacheLogEntry(object):
 
         return msg, num_failures
 
-    def _verify_has_required_data_columns(self, num_failures):
+    def _verify_has_required_data_columns(self, halo_table, num_failures):
         """
         """
         msg = ''
 
         try:
-            data = Table.read(self.fname, path='data')
-            keys = list(data.keys())
+            keys = list(halo_table.keys())
             try:
                 assert 'halo_x' in keys
                 assert 'halo_y' in keys
@@ -322,20 +305,19 @@ class HaloTableCacheLogEntry(object):
 
         return msg, num_failures
 
-    def _verify_all_positions_inside_box(self, num_failures):
+    def _verify_all_positions_inside_box(self, halo_table, num_failures):
         """
         """
         msg = ''
 
         try:
-            data = Table.read(self.fname, path='data')
             f = self.h5py.File(self.fname)
             Lbox = f.attrs['Lbox']
             f.close()
             try:
-                halo_x = data['halo_x']
-                halo_y = data['halo_y']
-                halo_z = data['halo_z']
+                halo_x = halo_table['halo_x'].data
+                halo_y = halo_table['halo_y'].data
+                halo_z = halo_table['halo_z'].data
 
                 assert np.all(halo_x >= 0)
                 assert np.all(halo_x <= Lbox)
@@ -355,15 +337,14 @@ class HaloTableCacheLogEntry(object):
 
         return msg, num_failures
 
-    def _verify_halo_ids_are_unique(self, num_failures):
+    def _verify_halo_ids_are_unique(self, halo_table, num_failures):
         """
         """
         msg = ''
 
         try:
-            data = Table.read(self.fname, path='data')
             try:
-                halo_id = data['halo_id'].data
+                halo_id = halo_table['halo_id'].data
                 assert halo_id.dtype.str[1] in ('i','u')
                 assert len(halo_id) == len(set(halo_id))
             except AssertionError:
@@ -401,24 +382,22 @@ class HaloTableCacheLogEntry(object):
             msg = str(num_failures) + ". The input file must have '.hdf5' extension.\n\n"
         return msg, num_failures
 
-    def _verify_halo_rvir_mpc_units(self, num_failures):
+    def _verify_halo_rvir_mpc_units(self, halo_table, num_failures):
         """ Require that all values stored in the halo_rvir column
         are less than 50, a crude way to ensure that units are not kpc.
         """
         msg = ''
 
         try:
-            data = Table.read(self.fname, path='data')
-            try:
-                halo_rvir = data['halo_rvir']
-                assert np.all(halo_rvir < 50)
-            except AssertionError:
-                num_failures += 1
-                msg = (str(num_failures)+". All values of the "
-                    "``halo_rvir`` column\n"
-                    "must be less than 50, crudely ensuring you used Mpc/h units.\n\n"
-                    )
-        except:
+            halo_rvir = halo_table['halo_rvir']
+            assert np.all(halo_rvir.data < 50)
+        except AssertionError:
+            num_failures += 1
+            msg = (str(num_failures)+". All values of the "
+                "``halo_rvir`` column\n"
+                "must be less than 50, crudely ensuring you used Mpc/h units.\n\n"
+                )
+        except KeyError:
             pass
 
         return msg, num_failures


### PR DESCRIPTION
This PR reduces the runtime it takes to load a CachedHaloTable into memory. Speedup introduced here is ~2x. The only change is to ensure that the table is only read into memory once when performing all the self-consistency checks associated with the `safe_for_cache` test. Further speedups to continue addressing #515. 