### PR TITLE
Factory docstrings

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -594,6 +594,9 @@ class HodModelFactory(ModelFactory):
                 setattr(getattr(self, new_method_name), 'gal_type', gal_type)
                 setattr(getattr(self, new_method_name), 'feature_name', feature_name)
 
+                docstring = getattr(component_model, methodname).__doc__
+                getattr(self, new_method_name).__doc__ = docstring
+                
             attrs_to_inherit = list(set(
                 component_model._attrs_to_inherit))
             for attrname in attrs_to_inherit:

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -524,6 +524,9 @@ class SubhaloModelFactory(ModelFactory):
                     component_model, methodname)
                 setattr(self, new_method_name, new_method_behavior)
 
+                docstring = getattr(component_model, methodname).__doc__
+                getattr(self, new_method_name).__doc__ = docstring
+
             attrs_to_inherit = list(set(
                 component_model._attrs_to_inherit))
             for attrname in attrs_to_inherit:

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -405,10 +405,7 @@ class Tinker13QuiescentSats(OccupationComponent):
         # by the composite model built by the HodModelFactory
         # Here we are overriding this attribute that is normally defined 
         # in the OccupationComponent super class
-        self._methods_to_inherit = (
-            ['mc_occupation', 'mean_occupation', 
-            'mean_stellar_mass', 'mean_log_halo_mass']
-            )
+        self._methods_to_inherit = ['mc_occupation', 'mean_occupation']
 
         # The _mock_generation_calling_sequence determines which methods 
         # will be called during mock population, as well as in what order they will be called
@@ -569,10 +566,7 @@ class Tinker13ActiveSats(OccupationComponent):
         # by the composite model built by the HodModelFactory
         # Here we are overriding this attribute that is normally defined 
         # in the OccupationComponent super class
-        self._methods_to_inherit = (
-            ['mc_occupation', 'mean_occupation', 
-            'mean_stellar_mass', 'mean_log_halo_mass']
-            )
+        self._methods_to_inherit = ['mc_occupation', 'mean_occupation']
 
         # The _mock_generation_calling_sequence determines which methods 
         # will be called during mock population, as well as in what order they will be called


### PR DESCRIPTION
This PR addresses #141 by setting the docstrings of composite models to be equal to those defined in the component models.