### PR TITLE
Deprecation warnings

### DIFF
--- a/docs/quickstart_and_tutorials/mock_observations/mock_obs_pos_formatting.rst
+++ b/docs/quickstart_and_tutorials/mock_observations/mock_obs_pos_formatting.rst
@@ -23,7 +23,7 @@ Example of how to transform your coordinates
 Suppose you have a collection of *x, y, z* arrays 
 storing the spatial positions of halos or galaxies. 
 
->>> Npts = 1e5
+>>> Npts = int(1e5)
 >>> Lbox = 250
 >>> import numpy as np
 >>> x = np.random.uniform(0, Lbox, Npts)

--- a/halotools/conftest.py
+++ b/halotools/conftest.py
@@ -6,7 +6,7 @@ from astropy.tests.pytest_plugins import *
 
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
-#enable_deprecations_as_exceptions()
+enable_deprecations_as_exceptions()
 
 # Uncomment and customize the following lines to add/remove entries from
 # the list of packages for which version numbers are displayed when running

--- a/halotools/empirical_models/assembias_models/tests/test_assembias.py
+++ b/halotools/empirical_models/assembias_models/tests/test_assembias.py
@@ -23,7 +23,7 @@ class TestAssembias(TestCase):
     def setup_class(self):
         """
         """
-        Npts = 1e4
+        Npts = int(1e4)
         mass = np.zeros(Npts) + 1e12
         zform = np.linspace(0, 10, Npts)
 

--- a/halotools/empirical_models/component_model_templates/tests/test_binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/tests/test_binary_galprop_models.py
@@ -23,7 +23,7 @@ class TestBinaryGalpropInterpolModel(TestCase):
             galprop_abscissa = self.abscissa, galprop_ordinates = self.ordinates, 
             prim_haloprop_key = 'vpeak_host', gal_type = 'sats')
 
-        Npts = 5e3
+        Npts = int(5e3)
         self.testmass12 = np.ones(Npts)*1e12
         self.testmass135 = np.ones(Npts)*10.**13.5
         self.testmass15 = np.ones(Npts)*1e15

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -1,12 +1,6 @@
-# -*- coding: utf-8 -*-
 """
-
-Module containing the template class
-`~halotools.empirical_models.MockFactory` used to
-construct mock galaxy populations.
-The mock factory only has knowledge of a simulation halocat
-and composite model object, and provides an
-abstract interface between the two.
+Module containing the template class `~halotools.empirical_models.MockFactory` 
+used to construct mock galaxy populations.
 """
 from __future__ import absolute_import
 
@@ -380,7 +374,11 @@ class MockFactory(object):
             raise HalotoolsError(msg)
 
         nptcl = np.max([model_defaults.default_nptcls, len(self.galaxy_table)])
-        ptcl_table = randomly_downsample_data(self.ptcl_table, nptcl)
+        if nptcl < len(self.ptcl_table):
+            ptcl_table = randomly_downsample_data(self.ptcl_table, nptcl)
+        else:
+            ptcl_table = self.ptcl_table
+
         ptcl_pos = three_dim_pos_bundle(table = ptcl_table,
             key1='x', key2='y', key3='z')
 

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -1,6 +1,7 @@
-# -*- coding: utf-8 -*-
 """
-Module storing the various factories used to build galaxy-halo models. 
+Module storing the `~halotools.empirical_models.ModelFactory` class, 
+an abstract container class used to build 
+any composite model of the galaxy-halo connection.
 """
 
 __all__ = ['ModelFactory']
@@ -668,7 +669,7 @@ class ModelFactory(object):
             use_fake_sim = False
 
         if use_fake_sim is True:
-            halocat = FakeSim(num_ptcl=1e5, **halocat_kwargs)
+            halocat = FakeSim(num_ptcl=int(1e5), **halocat_kwargs)
         else:
             halocat = CachedHaloCatalog(preload_halo_table = True, **halocat_kwargs)
 

--- a/halotools/empirical_models/factories/prebuilt_model_factory.py
+++ b/halotools/empirical_models/factories/prebuilt_model_factory.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 """
-Module storing the factories used to generate 
-Halotools-provided composite models 
+Module storing `~halotools.empirical_models.PrebuiltSubhaloModelFactory` and 
+`~halotools.empirical_models.PrebuiltHodModelFactory` classes, 
+the factories used to generate Halotools-provided composite models 
 of the galaxy-halo connection. 
 """
 

--- a/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/tests/test_prebuilt_subhalo_model_factory.py
@@ -1,18 +1,12 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function)
+""" Module providing unit-testing for 
+the `~halotools.empirical_models.PrebuiltSubhaloModelFactory` class
+""" 
+from __future__ import absolute_import, division, print_function
 
 from unittest import TestCase
 from astropy.tests.helper import pytest
 
-import numpy as np 
-from copy import copy 
-
-from ...smhm_models import Behroozi10SmHm, Moster13SmHm
-from ...component_model_templates import BinaryGalpropInterpolModel
-
 from ...factories import PrebuiltSubhaloModelFactory, SubhaloModelFactory
-from ...composite_models.smhm_models.behroozi10 import behroozi10_model_dictionary
-
 
 from ....sim_manager import FakeSim
 from ....custom_exceptions import HalotoolsError

--- a/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
+++ b/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
@@ -1,105 +1,101 @@
-#!/usr/bin/env python
+""" Module providing unit-testing for the component models in 
+`halotools.empirical_models.occupation_components.leauthaud11_components` module"
+"""
 import numpy as np
-from astropy.table import Table
-from copy import copy
 
 from .. import Leauthaud11Cens, Leauthaud11Sats
-
-from ...factories import HodModelFactory
-from ... import model_defaults
-from ....sim_manager import FakeSim
 
 __all__ = ('test_Leauthaud11Cens', 'test_Leauthaud11Sats')
 
 def test_Leauthaud11Cens():
-	""" Function to test 
-	`~halotools.empirical_models.Leauthaud11Cens`. 
-	"""
+    """ Function to test 
+    `~halotools.empirical_models.Leauthaud11Cens`. 
+    """
 
-	# Verify that the mean and Monte Carlo occupations are both reasonable and in agreement
-	# for halos of mass 1e12
-	model = Leauthaud11Cens()
-	ncen1 = model.mean_occupation(prim_haloprop = 1.e12)
-	mcocc = model.mc_occupation(prim_haloprop = np.ones(1e4)*1e12, seed=43)
-	#assert 0.5590 < np.mean(mcocc) < 0.5592
+    # Verify that the mean and Monte Carlo occupations are both reasonable and in agreement
+    # for halos of mass 1e12
+    model = Leauthaud11Cens()
+    ncen1 = model.mean_occupation(prim_haloprop = 1.e12)
+    mcocc = model.mc_occupation(prim_haloprop = np.ones(int(1e4))*1e12, seed=43)
+    #assert 0.5590 < np.mean(mcocc) < 0.5592
 
-	# Check that the model behavior is altered in the expected way by changing param_dict values
-	model.param_dict['scatter_model_param1'] *= 1.5
-	ncen2 = model.mean_occupation(prim_haloprop = 1.e12)
-	assert ncen2 < ncen1
+    # Check that the model behavior is altered in the expected way by changing param_dict values
+    model.param_dict['scatter_model_param1'] *= 1.5
+    ncen2 = model.mean_occupation(prim_haloprop = 1.e12)
+    assert ncen2 < ncen1
 #
-	model.param_dict['smhm_m1_0'] *= 1.1
-	ncen3 = model.mean_occupation(prim_haloprop = 1.e12)
-	assert ncen3 < ncen2
+    model.param_dict['smhm_m1_0'] *= 1.1
+    ncen3 = model.mean_occupation(prim_haloprop = 1.e12)
+    assert ncen3 < ncen2
 #
-	model.param_dict['smhm_m1_a'] *= 1.1
-	ncen4 = model.mean_occupation(prim_haloprop = 1.e12)
-	assert ncen4 == ncen3
+    model.param_dict['smhm_m1_a'] *= 1.1
+    ncen4 = model.mean_occupation(prim_haloprop = 1.e12)
+    assert ncen4 == ncen3
 
-	# Check that increasing stellar mass thresholds decreases the mean occupation
-	model2 = Leauthaud11Cens(threshold = 10.75)
-	ncen5 = model2.mean_occupation(prim_haloprop = 1.e12)
-	model3 = Leauthaud11Cens(threshold = 11.25)
-	ncen6 = model3.mean_occupation(prim_haloprop = 1.e12)
-	assert ncen6 < ncen5 < ncen1
+    # Check that increasing stellar mass thresholds decreases the mean occupation
+    model2 = Leauthaud11Cens(threshold = 10.75)
+    ncen5 = model2.mean_occupation(prim_haloprop = 1.e12)
+    model3 = Leauthaud11Cens(threshold = 11.25)
+    ncen6 = model3.mean_occupation(prim_haloprop = 1.e12)
+    assert ncen6 < ncen5 < ncen1
 
 
 def test_Leauthaud11Sats():
-	""" Function to test 
-	`~halotools.empirical_models.Leauthaud11Cens`. 
-	"""
+    """ Function to test 
+    `~halotools.empirical_models.Leauthaud11Cens`. 
+    """
 
-	# Verify that the mean and Monte Carlo occupations are both reasonable and in agreement
-	# for halos of mass 1e12
-	model = Leauthaud11Sats()
-	nsat1 = model.mean_occupation(prim_haloprop = 5.e12)
-	mcocc = model.mc_occupation(prim_haloprop = np.ones(1e4)*5e12, seed=43)
-	#assert 0.391 < np.mean(mcocc) < 0.392
+    # Verify that the mean and Monte Carlo occupations are both reasonable and in agreement
+    # for halos of mass 1e12
+    model = Leauthaud11Sats()
+    nsat1 = model.mean_occupation(prim_haloprop = 5.e12)
+    mcocc = model.mc_occupation(prim_haloprop = np.ones(int(1e4))*5e12, seed=43)
+    #assert 0.391 < np.mean(mcocc) < 0.392
 
-	# Check that the model behavior is altered in the expected way by changing param_dict values
-	model.param_dict['alphasat'] *= 1.1
-	nsat2 = model.mean_occupation(prim_haloprop = 5.e12)
-	assert nsat2 < nsat1
+    # Check that the model behavior is altered in the expected way by changing param_dict values
+    model.param_dict['alphasat'] *= 1.1
+    nsat2 = model.mean_occupation(prim_haloprop = 5.e12)
+    assert nsat2 < nsat1
 #
-	model.param_dict['betasat'] *= 1.1
-	nsat3 = model.mean_occupation(prim_haloprop = 5.e12)
-	assert nsat3 > nsat2
+    model.param_dict['betasat'] *= 1.1
+    nsat3 = model.mean_occupation(prim_haloprop = 5.e12)
+    assert nsat3 > nsat2
 #
-	model.param_dict['betacut'] *= 1.1
-	nsat4 = model.mean_occupation(prim_haloprop = 5.e12)
-	assert nsat4 < nsat3
+    model.param_dict['betacut'] *= 1.1
+    nsat4 = model.mean_occupation(prim_haloprop = 5.e12)
+    assert nsat4 < nsat3
 #
-	model.param_dict['bcut'] *= 1.1
-	nsat5 = model.mean_occupation(prim_haloprop = 5.e12)
-	assert nsat5 < nsat4
+    model.param_dict['bcut'] *= 1.1
+    nsat5 = model.mean_occupation(prim_haloprop = 5.e12)
+    assert nsat5 < nsat4
 #
-	model.param_dict['bsat'] *= 1.1
-	nsat6 = model.mean_occupation(prim_haloprop = 5.e12)
-	assert nsat6 < nsat5
+    model.param_dict['bsat'] *= 1.1
+    nsat6 = model.mean_occupation(prim_haloprop = 5.e12)
+    assert nsat6 < nsat5
 #
-	# Check that modulate_with_cenocc strictly decreases the mean occupations
-	model2a = Leauthaud11Sats(modulate_with_cenocc = False)
-	model2b = Leauthaud11Sats(modulate_with_cenocc = True)
-	nsat2a = model2a.mean_occupation(prim_haloprop = 5.e12)
-	nsat2b = model2b.mean_occupation(prim_haloprop = 5.e12)
-	assert model2b.central_occupation_model.mean_occupation(prim_haloprop = 5.e12) < 1
-	assert nsat2b < nsat2a
+    # Check that modulate_with_cenocc strictly decreases the mean occupations
+    model2a = Leauthaud11Sats(modulate_with_cenocc = False)
+    model2b = Leauthaud11Sats(modulate_with_cenocc = True)
+    nsat2a = model2a.mean_occupation(prim_haloprop = 5.e12)
+    nsat2b = model2b.mean_occupation(prim_haloprop = 5.e12)
+    assert model2b.central_occupation_model.mean_occupation(prim_haloprop = 5.e12) < 1
+    assert nsat2b < nsat2a
 
 
-	# Check that increasing stellar mass thresholds decreases the mean occupation
-	model10 = Leauthaud11Sats(threshold = 10)
-	model105 = Leauthaud11Sats(threshold = 10.5)
-	model11 = Leauthaud11Sats(threshold = 11)
-	nsat10 = model10.mean_occupation(prim_haloprop = 1e13)
-	nsat105 = model105.mean_occupation(prim_haloprop = 1e13)
-	nsat11 = model11.mean_occupation(prim_haloprop = 1e13)
-	assert nsat10 > nsat105 > nsat11
+    # Check that increasing stellar mass thresholds decreases the mean occupation
+    model10 = Leauthaud11Sats(threshold = 10)
+    model105 = Leauthaud11Sats(threshold = 10.5)
+    model11 = Leauthaud11Sats(threshold = 11)
+    nsat10 = model10.mean_occupation(prim_haloprop = 1e13)
+    nsat105 = model105.mean_occupation(prim_haloprop = 1e13)
+    nsat11 = model11.mean_occupation(prim_haloprop = 1e13)
+    assert nsat10 > nsat105 > nsat11
 
-	# Check that increasing stellar mass thresholds decreases the central occupations
-	ncen10 = model10.central_occupation_model.mean_occupation(prim_haloprop = 5e12)
-	ncen105 = model105.central_occupation_model.mean_occupation(prim_haloprop = 5e12)
-	ncen11 = model11.central_occupation_model.mean_occupation(prim_haloprop = 5e12)
-	assert ncen10 > ncen105 > ncen11 
+    # Check that increasing stellar mass thresholds decreases the central occupations
+    ncen10 = model10.central_occupation_model.mean_occupation(prim_haloprop = 5e12)
+    ncen105 = model105.central_occupation_model.mean_occupation(prim_haloprop = 5e12)
+    ncen11 = model11.central_occupation_model.mean_occupation(prim_haloprop = 5e12)
+    assert ncen10 > ncen105 > ncen11 
 
 
 

--- a/halotools/empirical_models/occupation_models/tests/test_zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/tests/test_zheng07_components.py
@@ -162,7 +162,7 @@ class TestZheng07Cens(TestCase):
 
         # First check that the mean occuation is ~0.5 when model is evaulated at Mmin
         mvir_midpoint = 10.**model.param_dict['logMmin']
-        Npts = 1e3
+        Npts = int(1e3)
         masses = np.ones(Npts)*mvir_midpoint
         mc_occ = model.mc_occupation(prim_haloprop=masses, seed=43)
         assert set(mc_occ).issubset([0,1])
@@ -303,7 +303,7 @@ class TestZheng07Sats(TestCase):
         model.param_dict['logM0'] = 11.25
         model.param_dict['logM1'] = model.param_dict['logM0'] + np.log10(20.)
 
-        Npts = 1e3
+        Npts = int(1e3)
         masses = np.ones(Npts)*10.**model.param_dict['logM1']
         mc_occ = model.mc_occupation(prim_haloprop=masses, seed=43)
         # We chose a specific seed that has been pre-tested, 
@@ -316,7 +316,7 @@ class TestZheng07Sats(TestCase):
         cenmodel = zheng07_components.Zheng07Cens()
         satmodel_cens = zheng07_components.Zheng07Sats(modulate_with_cenocc=True)
 
-        Npts = 1e2 
+        Npts = 100
         masses = np.logspace(10, 15, Npts)
         mean_occ_satmodel_nocens = satmodel_nocens.mean_occupation(prim_haloprop=masses)
         mean_occ_satmodel_cens = satmodel_cens.mean_occupation(prim_haloprop=masses)
@@ -338,7 +338,7 @@ class TestZheng07Sats(TestCase):
     def test_alpha_scaling2_mc_occupation(self):
         logmass = self.model2.param_dict['logM1'] + np.log10(5)
         mass = 10.**logmass
-        Npts = 1e3
+        Npts = 1000
         masses = np.ones(Npts)*mass
 
         assert (self.model2.mc_occupation(prim_haloprop=masses,seed=43).mean() > 
@@ -347,7 +347,7 @@ class TestZheng07Sats(TestCase):
     def test_alpha_propagation(self):
         logmass = self.model2.param_dict['logM1'] + np.log10(5)
         mass = 10.**logmass
-        Npts = 1e3
+        Npts = 1000
         masses = np.ones(Npts)*mass
 
         alt_default_model = deepcopy(self.default_model)

--- a/halotools/empirical_models/phase_space_models/nfw_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/nfw_phase_space.py
@@ -109,7 +109,7 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
         MonteCarloGalProf.mc_vel(self, table = table)
 
 
-    def mc_generate_nfw_phase_space_points(self, Ngals = 1e4, conc=5, mass = 1e12, verbose=True):
+    def mc_generate_nfw_phase_space_points(self, Ngals = int(1e4), conc=5, mass = 1e12, verbose=True):
         """ Stand-alone convenience function for returning 
         a Monte Carlo realization of points in the phase space of an NFW halo in isotropic Jeans equilibrium.
 
@@ -142,7 +142,7 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
         ---------
         >>> nfw = NFWPhaseSpace()
         >>> mass, conc = 1e13, 8.
-        >>> data = nfw.mc_generate_nfw_phase_space_points(Ngals = 1e2, mass = mass, conc = conc, verbose=False) 
+        >>> data = nfw.mc_generate_nfw_phase_space_points(Ngals = 100, mass = mass, conc = conc, verbose=False) 
 
         Now suppose you wish to compute the radial velocity dispersion of all the returned points:
 

--- a/halotools/empirical_models/phase_space_models/profile_models/nfw_profile.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/nfw_profile.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module contains the `NFWProfile` class, 
 which is used to model the spatial distribution of mass and/or galaxies 
@@ -541,7 +540,7 @@ class NFWProfile(AnalyticDensityProf, ConcMass):
         """
         return AnalyticDensityProf.halo_radius_to_halo_mass(self, radius)
 
-    def mc_generate_nfw_radial_positions(self, num_pts = 1e4, conc = 5, **kwargs):
+    def mc_generate_nfw_radial_positions(self, num_pts = int(1e4), conc = 5, **kwargs):
         """ Stand-alone convenience function for returning a Monte Carlo realization of the radial positions of points tracing an NFW profile.
 
         See :ref:`monte_carlo_nfw_spatial_profile` for a discussion of this technique. 
@@ -628,7 +627,7 @@ class NFWProfile(AnalyticDensityProf, ConcMass):
             np.random.seed(kwargs['seed'])
 
         # Build lookup table from which to tabulate the inverse cumulative_mass_PDF
-        Npts_radius_table = 1e3
+        Npts_radius_table = int(1e3)
         radius_array = np.logspace(-4, 0, Npts_radius_table)
         logradius_array = np.log10(radius_array)
         table_ordinates = self.cumulative_mass_PDF(radius_array, conc)

--- a/halotools/empirical_models/phase_space_models/profile_models/tests/test_conc_mass.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/tests/test_conc_mass.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function, 
-    unicode_literals)
-
-__all__ = ['TestConcMass']
+""" Module providing unit-testing for `~halotools.empirical_models.ConcMass` class.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from astropy.table import Table
@@ -11,6 +9,8 @@ from unittest import TestCase
 from ..conc_mass_models import ConcMass
 
 from .... import model_defaults
+
+__all__ = ['TestConcMass']
 
 class TestConcMass(TestCase):
     """ Tests of `~halotools.empirical_models.ConcMass` class.  
@@ -37,7 +37,7 @@ class TestConcMass(TestCase):
 
         """
 
-        Npts = 1e3
+        Npts = int(1e3)
         mass = np.logspace(10, 15, Npts)
         conc = self.dutton_maccio14_model.compute_concentration(prim_haloprop=mass)
         assert np.all(conc > 1)
@@ -53,7 +53,7 @@ class TestConcMass(TestCase):
 
         * Method returns the min/max boundary values when passed halo concentrations that are out of bounds.
         """
-        Npts = 1e3
+        Npts = int(1e3)
         mass = np.logspace(10, 15, Npts)
         conc = np.random.uniform(0, 100, Npts)
         t = Table({'conc': conc, 'halo_mvir': mass})

--- a/halotools/empirical_models/phase_space_models/profile_models/tests/test_nfw_profile.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/tests/test_nfw_profile.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function, 
-    unicode_literals)
+""" Module providing unit-testing for `~halotools.empirical_models.NFWProfile` class
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np 
 
@@ -232,7 +232,7 @@ class TestNFWProfile(TestCase):
 
         """
         halo_radius = 0.5
-        num_pts = 2e6
+        num_pts = int(2e6)
         num_rbins = 20
         rbins = np.linspace(0.05, 1, num_rbins)
 

--- a/halotools/empirical_models/phase_space_models/tests/test_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/tests/test_phase_space.py
@@ -21,12 +21,12 @@ class TestNFWPhaseSpace(TestCase):
         self.nfw.setup_prof_lookup_tables((cmin, cmax, dc))
         self.nfw.build_lookup_tables()
 
-        Npts = 5e4
+        Npts = int(5e4)
         self.c15 = np.zeros(Npts) + 15
         self.c10 = np.zeros(Npts) + 10
         self.c5 = np.zeros(Npts) + 5
 
-        npts = 1e3
+        npts = int(1e3)
         Lbox = 250
         zeros = np.zeros(npts)
         x = np.random.uniform(0, Lbox, npts)
@@ -230,7 +230,7 @@ class TestNFWPhaseSpace(TestCase):
         as computed by the `~halotools.empirical_models.NFWPhaseSpace.vmax`. Method 
         verifies that these two results agree within the expected random noise level. 
         """
-        npts = 1e4
+        npts = int(1e4)
         conc = 10
         carr = np.zeros(npts) + conc
 

--- a/halotools/empirical_models/smhm_models/tests/test_smhm_components.py
+++ b/halotools/empirical_models/smhm_models/tests/test_smhm_components.py
@@ -70,9 +70,9 @@ def test_Moster13SmHm_behavior():
     mstar5_z1 = default_model.mean_stellar_mass(prim_haloprop = 1.e12, redshift=1)
     assert mstar5_z1 != mstar4_z1
 
-    mstar_realization1 = default_model.mc_stellar_mass(prim_haloprop = np.ones(1e4)*1e12, seed=43)
-    mstar_realization2 = default_model.mc_stellar_mass(prim_haloprop = np.ones(1e4)*1e12, seed=43)
-    mstar_realization3 = default_model.mc_stellar_mass(prim_haloprop = np.ones(1e4)*1e12, seed=44)
+    mstar_realization1 = default_model.mc_stellar_mass(prim_haloprop = 1.e12*np.ones(int(1e4)), seed=43)
+    mstar_realization2 = default_model.mc_stellar_mass(prim_haloprop = 1.e12*np.ones(int(1e4)), seed=43)
+    mstar_realization3 = default_model.mc_stellar_mass(prim_haloprop = 1.e12*np.ones(int(1e4)), seed=44)
     assert np.array_equal(mstar_realization1, mstar_realization2)
     assert not np.array_equal(mstar_realization1, mstar_realization3)
 
@@ -81,7 +81,7 @@ def test_Moster13SmHm_behavior():
     np.testing.assert_allclose(measured_scatter1, model_scatter, rtol=1e-3)
 
     default_model.param_dict['scatter_model_param1'] = 0.3
-    mstar_realization4 = default_model.mc_stellar_mass(prim_haloprop = np.ones(1e4)*1e12, seed=43)
+    mstar_realization4 = default_model.mc_stellar_mass(prim_haloprop = 1e12*np.ones(int(1e4)), seed=43)
     measured_scatter4 = np.std(np.log10(mstar_realization4))
     np.testing.assert_allclose(measured_scatter4, 0.3, rtol=1e-3)
 
@@ -137,7 +137,7 @@ def test_LogNormalScatterModel_behavior():
 
     default_scatter_model = LogNormalScatterModel()
 
-    Npts = 1e4
+    Npts = int(1e4)
     testmass12 = 1e12
     mass12 = np.zeros(Npts) + testmass12
     masskey = model_defaults.default_smhm_haloprop 

--- a/halotools/empirical_models/tests/test_model_helpers.py
+++ b/halotools/empirical_models/tests/test_model_helpers.py
@@ -16,7 +16,7 @@ class TestModelHelpers(TestCase):
     def test_enforce_periodicity_of_box(self):
 
         box_length = 250
-        Npts = 1e5
+        Npts = int(1e5)
         coords = np.random.uniform(0,box_length,Npts*3).reshape(Npts,3)
 
         perturbation_size = box_length/10.
@@ -31,7 +31,7 @@ class TestModelHelpers(TestCase):
 
     def test_check_multiple_box_lengths(self):
         box_length = 250
-        Npts = 1e4
+        Npts = int(1e4)
 
         x = np.linspace(-2*box_length, box_length, Npts)
         with pytest.raises(HalotoolsError) as err:
@@ -53,7 +53,7 @@ class TestModelHelpers(TestCase):
 
     def test_velocity_flip(self):
         box_length = 250
-        Npts = 1e4
+        Npts = int(1e4)
 
         x = np.linspace(-0.5*box_length, 1.5*box_length, Npts)
         vx = np.ones(Npts)

--- a/halotools/mock_observables/group_identification/test_groups/test_fof_groups.py
+++ b/halotools/mock_observables/group_identification/test_groups/test_fof_groups.py
@@ -18,7 +18,7 @@ from ..fof_groups import FoFGroups
 __all__ = ['test_fof_groups_init','test_fof_group_IDs','test_igraph_functionality']
 
 #set random seed to get consistent behavior
-N = 1e3
+N = 1000
 Lbox = np.array([1.0,1.0,1.0])
 period = Lbox
 b_perp = 0.5

--- a/halotools/mock_observables/isolation_functions/tests/test_spherical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_spherical_isolation.py
@@ -133,7 +133,7 @@ def test_shifted_randoms():
     Demonstrate that the `~halotools.mock_observables.spherical_isolation` function 
     behaves properly in all appropriate limits of ``r_max``. 
     """
-    npts = 1e3
+    npts = 1000
     with NumpyRNGContext(fixed_seed):
         sample1 = np.random.random((npts, 3))
     epsilon = 0.001

--- a/halotools/mock_observables/pair_counters/marked_npairs_3d.py
+++ b/halotools/mock_observables/pair_counters/marked_npairs_3d.py
@@ -104,7 +104,7 @@ def marked_npairs_3d(sample1, sample2, rbins,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube, using random weights. 
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rbins = np.logspace(-1, 1.5, 15)
 

--- a/halotools/mock_observables/pair_counters/npairs_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_3d.py
@@ -87,7 +87,7 @@ def npairs_3d(sample1, sample2, rbins, period = None,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rbins = np.logspace(-1, 1.5, 15)
 

--- a/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
@@ -115,7 +115,7 @@ def npairs_jackknife_3d(sample1, sample2, rbins, period=None, weights1=None, wei
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rbins = np.logspace(-1, 1.5, 15)
 

--- a/halotools/mock_observables/pair_counters/npairs_per_object_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_per_object_3d.py
@@ -79,7 +79,7 @@ def npairs_per_object_3d(sample1, sample2, rbins, period = None,
     --------
     For illustration purposes, we'll create some fake data and call the pair counter:
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rbins = np.logspace(-1, 1.5, 15)
 

--- a/halotools/mock_observables/pair_counters/npairs_projected.py
+++ b/halotools/mock_observables/pair_counters/npairs_projected.py
@@ -94,7 +94,7 @@ def npairs_projected(sample1, sample2, rp_bins, pi_max, period = None,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rp_bins = np.logspace(-1, 1.5, 15)
     >>> pi_max = 40.

--- a/halotools/mock_observables/pair_counters/npairs_s_mu.py
+++ b/halotools/mock_observables/pair_counters/npairs_s_mu.py
@@ -117,7 +117,7 @@ def npairs_s_mu(sample1, sample2, s_bins, mu_bins, period = None,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 200.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 200.
     >>> period = [Lbox, Lbox, Lbox]
     >>> s_bins = np.logspace(-1, 1.25, 15)
     >>> mu_bins = np.linspace(-0.5, 0.5)

--- a/halotools/mock_observables/pair_counters/npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/npairs_xy_z.py
@@ -98,7 +98,7 @@ def npairs_xy_z(sample1, sample2, rp_bins, pi_bins, period = None,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
 
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rp_bins = np.logspace(-1, 1.5, 15)
     >>> pi_bins = [20, 40, 60]

--- a/halotools/mock_observables/pair_counters/pairwise_distance_3d.py
+++ b/halotools/mock_observables/pair_counters/pairwise_distance_3d.py
@@ -85,7 +85,7 @@ def pairwise_distance_3d(data1, data2, rmax, period = None,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
     
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rmax = 1.0
     

--- a/halotools/mock_observables/pair_counters/pairwise_distance_xy_z.py
+++ b/halotools/mock_observables/pair_counters/pairwise_distance_xy_z.py
@@ -86,7 +86,7 @@ def pairwise_distance_xy_z(data1, data2, rp_max, pi_max, period = None,
     For demonstration purposes we create randomly distributed sets of points within a
     periodic unit cube.
     
-    >>> Npts1, Npts2, Lbox = 1e3, 1e3, 250.
+    >>> Npts1, Npts2, Lbox = 1000, 1000, 250.
     >>> period = [Lbox, Lbox, Lbox]
     >>> rp_max = 1.0
     >>> pi_max = 2.0

--- a/halotools/mock_observables/pair_counters/rectangular_mesh.py
+++ b/halotools/mock_observables/pair_counters/rectangular_mesh.py
@@ -108,7 +108,7 @@ class RectangularMesh(object):
 
         Examples
         ---------
-        >>> Npts, Lbox = 1e4, 1000
+        >>> Npts, Lbox = int(1e4), 1000
         >>> xperiod, yperiod, zperiod = Lbox, Lbox, Lbox
         >>> approx_xcell_size = Lbox/10.
         >>> approx_ycell_size = Lbox/10.

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_pairwise_distance_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_pairwise_distance_3d.py
@@ -174,7 +174,7 @@ def test_pairwise_distance_3d_nonperiodic_tight_locus2():
 
 @pytest.mark.slow
 def test_3d_brute_force_elementwise_comparison():
-    Npts1, Npts2 = 1e2, 1e2
+    Npts1, Npts2 = int(1e2), int(1e2)
 
     with NumpyRNGContext(fixed_seed):
         sample1 = np.random.random((Npts1, 3))
@@ -195,7 +195,7 @@ def test_3d_brute_force_elementwise_comparison():
 
 @pytest.mark.slow
 def test_xy_z_brute_force_elementwise_comparison():
-    Npts1, Npts2 = 1e2, 1e2
+    Npts1, Npts2 = int(1e2), int(1e2)
 
     with NumpyRNGContext(fixed_seed):
         sample1 = np.random.random((Npts1, 3))

--- a/halotools/mock_observables/radial_profiles/tests/test_radial_profile_3d.py
+++ b/halotools/mock_observables/radial_profiles/tests/test_radial_profile_3d.py
@@ -78,8 +78,8 @@ def test_radial_profile_3d_test2():
     npts2 = len(sample2)
 
     a, b = 0.5, 1.5
-    quantity_a = np.zeros(npts2/2) + a
-    quantity_b = np.zeros(npts2/2) + b
+    quantity_a = np.zeros(int(npts2/2)) + a
+    quantity_b = np.zeros(int(npts2/2)) + b
     quantity = np.concatenate([quantity_a, quantity_b])
 
     result, counts = radial_profile_3d(sample1, sample2, quantity, 
@@ -129,8 +129,8 @@ def test_radial_profile_3d_test3():
     npts2 = len(sample2)
 
     with NumpyRNGContext(fixed_seed):
-        inner_ring_values = np.random.uniform(-1, 1, npts2/2)
-        outer_ring_values = np.random.uniform(-1, 1, npts2/2)
+        inner_ring_values = np.random.uniform(-1, 1, int(npts2/2))
+        outer_ring_values = np.random.uniform(-1, 1, int(npts2/2))
 
     quantity = np.concatenate([inner_ring_values, outer_ring_values])
 
@@ -169,7 +169,7 @@ def test_radial_profile_3d_test4():
     sample2 = np.concatenate([sample2_p1_r1, sample2_p2_r1, sample2_p1_r2, sample2_p2_r2])
     npts2 = len(sample2)
 
-    quantity_a, quantity_b = np.zeros(npts2/2) + 0.5, np.zeros(npts2/2) + 1.5
+    quantity_a, quantity_b = np.zeros(int(npts2/2)) + 0.5, np.zeros(int(npts2/2)) + 1.5
     quantity = np.concatenate([quantity_a, quantity_b])
 
     result, counts = radial_profile_3d(sample1, sample2, quantity, rbins_normalized=rbins_normalized, 

--- a/halotools/mock_observables/two_point_clustering/clustering_helpers.py
+++ b/halotools/mock_observables/two_point_clustering/clustering_helpers.py
@@ -79,14 +79,17 @@ def process_optional_input_sample2(sample1, sample2, do_cross):
         _sample1_is_sample2 = True
     else:
         sample2 = enforce_sample_has_correct_shape(sample2)
-        if np.all(sample1==sample2):
-            _sample1_is_sample2 = True
-            msg = ("\n `sample1` and `sample2` are exactly the same, \n"
-                   "only the auto-correlation will be returned.\n")
-            warn(msg)
-            do_cross = False
-        else: 
+        if sample1.shape != sample2.shape:
             _sample1_is_sample2 = False
+        else:
+            if np.all(sample1==sample2):
+                _sample1_is_sample2 = True
+                msg = ("\n `sample1` and `sample2` are exactly the same, \n"
+                       "only the auto-correlation will be returned.\n")
+                warn(msg)
+                do_cross = False
+            else: 
+                _sample1_is_sample2 = False
 
     return sample2, _sample1_is_sample2, do_cross
 

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -533,7 +533,7 @@ def cuboid_subvolume_labels(sample, Nsub, Lbox):
         msg = ("Input ``sample`` must have shape (Npts, 3)")
         raise TypeError(msg)
 
-    Nsub = np.atleast_1d(Nsub).astype('f4')
+    Nsub = np.atleast_1d(Nsub).astype('i4')
     if len(Nsub) == 1:
         Nsub = np.array([Nsub[0], Nsub[0], Nsub[0]])
     elif len(Nsub) != 3:
@@ -548,7 +548,7 @@ def cuboid_subvolume_labels(sample, Nsub, Lbox):
         raise TypeError(msg)
         
     dL = Lbox/Nsub # length of subvolumes along each dimension
-    N_sub_vol = np.prod(Nsub) # total the number of subvolumes
+    N_sub_vol = int(np.prod(Nsub)) # total the number of subvolumes
     # create an array of unique integer IDs for each subvolume
     inds = np.arange(1, N_sub_vol+1).reshape(Nsub[0], Nsub[1], Nsub[2])
     

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -48,7 +48,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
     def setUp(self):
         """ Pre-load various arrays into memory for use by all tests.
         """
-        self.Nhalos = 1e2
+        self.Nhalos = 100
         self.Lbox = 100
         self.redshift = 0.0
         self.halo_x = np.linspace(0, self.Lbox, self.Nhalos)
@@ -62,7 +62,7 @@ class TestUserSuppliedHaloCatalog(TestCase):
             )
         self.toy_list = [elt for elt in self.halo_x]
 
-        self.num_ptcl = 1e4
+        self.num_ptcl = int(1e4)
         self.good_ptcl_table = Table(
             {'x': np.zeros(self.num_ptcl),
             'y': np.zeros(self.num_ptcl),

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -113,7 +113,7 @@ class UserSuppliedHaloCatalog(object):
 
         Here's an example of how to use this argument using some fake data:
 
-        >>> num_ptcls = 1e4
+        >>> num_ptcls = int(1e4)
         >>> ptcl_x = np.random.uniform(0, Lbox, num_ptcls)
         >>> ptcl_y = np.random.uniform(0, Lbox, num_ptcls)
         >>> ptcl_z = np.random.uniform(0, Lbox, num_ptcls)

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -70,7 +70,7 @@ class UserSuppliedPtclCatalog(object):
         >>> redshift = 0.0
         >>> Lbox = 250.
         >>> particle_mass = 1e9
-        >>> num_ptcls = 1e4
+        >>> num_ptcls = int(1e4)
         >>> x = np.random.uniform(0, Lbox, num_ptcls)
         >>> y = np.random.uniform(0, Lbox, num_ptcls)
         >>> z = np.random.uniform(0, Lbox, num_ptcls)

--- a/halotools/utils/array_utils.py
+++ b/halotools/utils/array_utils.py
@@ -195,8 +195,8 @@ def randomly_downsample_data(array, num_downsample):
 
     Examples 
     --------
-    >>> x = np.linspace(0, 1000, num=1e5)
-    >>> desired_sample_size = 1e3
+    >>> x = np.linspace(0, 1000, num=int(1e5))
+    >>> desired_sample_size = int(1e3)
     >>> downsampled_x = randomly_downsample_data(x, desired_sample_size)
 
     """

--- a/halotools/utils/crossmatch.py
+++ b/halotools/utils/crossmatch.py
@@ -62,13 +62,13 @@ def crossmatch(x, y, skip_bounds_checking = False):
     The example below demonstrates how to transfer column data from ``table2`` 
     into ``table1`` for the subset of objects that appear in both tables. 
 
-    >>> num_table1 = 1e6
+    >>> num_table1 = int(1e6)
     >>> x = np.random.rand(num_table1)
     >>> objid = np.arange(num_table1)
     >>> from astropy.table import Table
     >>> table1 = Table({'x': x, 'objid': objid})
 
-    >>> num_table2 = 1e6
+    >>> num_table2 = int(1e6)
     >>> objid = np.arange(5e5, num_table2+5e5)
     >>> y = np.random.rand(num_table2)
     >>> table2 = Table({'y': y, 'objid': objid})
@@ -92,10 +92,10 @@ def crossmatch(x, y, skip_bounds_checking = False):
     First create some new dummy data to demonstrate this application of 
     the `crossmatch` function:
 
-    >>> num_galaxies = 1e6
+    >>> num_galaxies = int(1e6)
     >>> x = np.random.rand(num_galaxies)
     >>> objid = np.arange(num_galaxies)
-    >>> num_groups = 1e4
+    >>> num_groups = int(1e4)
     >>> groupid = np.random.random_integers(0, num_groups-1, num_galaxies)
     >>> galaxy_table = Table({'x': x, 'objid': objid, 'groupid': groupid})
 

--- a/halotools/utils/tests/test_array_utils.py
+++ b/halotools/utils/tests/test_array_utils.py
@@ -31,7 +31,7 @@ def test_find_idx_nearest_val():
 
     # Check that you never differ by more than 0.5 when 
     # your inputs are within the range spanned by x
-    Npts = 1e4
+    Npts = int(1e4)
     v = np.random.uniform(x.min()-0.5, x.max()+0.5,Npts)
     result = np.empty(Npts)
     for ii, elt in enumerate(v):

--- a/halotools/utils/tests/test_table_utils.py
+++ b/halotools/utils/tests/test_table_utils.py
@@ -58,7 +58,7 @@ class TestSampleSelector(TestCase):
 class TestComputeConditionalPercentiles(TestCase):
 
     def setup_class(self):
-        Npts = 1e4
+        Npts = int(1e4)
         mass1 = np.zeros(Npts/2) + 1e12
         mass2 = np.zeros(Npts/2) + 1e14
         mass = np.append(mass1, mass2)

--- a/halotools/utils/tests/test_table_utils.py
+++ b/halotools/utils/tests/test_table_utils.py
@@ -59,8 +59,8 @@ class TestComputeConditionalPercentiles(TestCase):
 
     def setup_class(self):
         Npts = int(1e4)
-        mass1 = np.zeros(Npts/2) + 1e12
-        mass2 = np.zeros(Npts/2) + 1e14
+        mass1 = np.zeros(int(Npts/2)) + 1e12
+        mass2 = np.zeros(int(Npts/2)) + 1e14
         mass = np.append(mass1, mass2)
         zform1 = np.linspace(0, 10, Npts/2)
         zform2 = np.linspace(20, 30, Npts/2)


### PR DESCRIPTION
This PR eliminates all code that previously generated some DeprecationWarning, resolving #460. Thanks to @bsipocz for calling attention to the `enable_deprecations_as_exceptions` package-template feature, which is very useful and is now turned on to help ensure long-term stability of Halotools. 

CC @duncandc - This is just FYI. There were really just a couple of syntax choices responsible for all warnings. 

1. Numpy functions such as `np.zeros(npts)` and `np.random.random(npts)` currently accept floats for `npts`, but will not in the future. Fixing this in all cases meant something as simple as `1e3 --> int(1e3)`. 
2. `np.all(arr1, arr2)` currently returns `False` if `arr1` and `arr2` have different shape, but in the future this will trigger an exception. So there were just a couple of places where I had to add one extra line of control flow to ensure that `np.all` would only be evaluated in branches where `arr1` and `arr2` are guaranteed to have the same shape. 