### PR TITLE
Updating numpy and astropy versions for appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,12 @@ matrix:
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
+    allow_failures:
+        # The build with numpy v1.11.1rc1 halts in the middle without
+        # showing any obvious reason, thus allowing it to fail for now.
+        - python: 3.5
+          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
+
 before_install:
 
     # If there are matplotlib tests, comment these out to

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ environment:
   matrix:
 
       - PYTHON_VERSION: "2.7"
-        ASTROPY_VERSION: "1.0"
-        NUMPY_VERSION: "1.9.1"
+        ASTROPY_VERSION: "stable"
+        NUMPY_VERSION: "stable"
 
 platform:
     -x64


### PR DESCRIPTION
Does what says on the tin. 
Python3 on windows currently fails with one test that needs more debugging, thus not including it in the appveyor file yet. 

Also adding the numpy prerelease build to the allowed failures as it halts in the middle of the build without any obvious reason.