### PR TITLE
Updating numpy version for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.10
+        - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
@@ -61,9 +61,14 @@ matrix:
         - python: 3.5
           env: ASTROPY_VERSION=development
 
-        # Try older numpy version
+        # Try older numpy version, 1.9 is tested above with py3.3
         - python: 2.7
-          env: NUMPY_VERSION=1.9
+          env: NUMPY_VERSION=1.10
+
+        # Try numpy pre-release version, this runs only when a pre-release
+        # is available on pypi.
+        - python: 3.5
+          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7

--- a/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
+++ b/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
@@ -132,7 +132,7 @@ class TestOccupationComponent(TestCase):
 
             def mc_occupation(self, **kwargs):
                 table = kwargs['table']
-                result = np.random.random_integers(0, 1, len(table))
+                result = np.random.randint(0, 2, len(table))
                 table['halo_num_centrals'] = result
                 return result
 

--- a/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
@@ -139,8 +139,8 @@ def npairs_jackknife_3d(sample1, sample2, rbins, period=None, weights1=None, wei
     use randomly assigned sub-volumes as this has no impact on the calling signature:
 
     >>> N_samples = 10
-    >>> jtags1 = np.random.random_integers(1, N_samples, Npts1)
-    >>> jtags2 = np.random.random_integers(1, N_samples, Npts2)
+    >>> jtags1 = np.random.randint(1, N_samples+1, Npts1)
+    >>> jtags2 = np.random.randint(1, N_samples+1, Npts2)
 
     >>> result = npairs_jackknife_3d(sample1, sample2, rbins, period = period, jtags1=jtags1, jtags2=jtags2, N_samples = N_samples)
 

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_jackknife_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_jackknife_3d.py
@@ -57,7 +57,7 @@ def test_npairs_jackknife_3d_periodic():
     #define the jackknife sample labels
     Npts = len(random_sample)
     N_jsamples=10
-    jtags1 = np.sort(np.random.random_integers(1, N_jsamples, size=Npts))
+    jtags1 = np.sort(np.random.randint(1, N_jsamples+1, size=Npts))
 
     #define weights
     weights1 = np.random.random(Npts)
@@ -90,7 +90,7 @@ def test_npairs_jackknife_3d_nonperiodic():
     #define the jackknife sample labels
     Npts = len(random_sample)
     N_jsamples=10
-    jtags1 = np.sort(np.random.random_integers(1, N_jsamples, size=Npts))
+    jtags1 = np.sort(np.random.randint(1, N_jsamples+1, size=Npts))
 
     #define weights
     weights1 = np.random.random(Npts)

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf_one_two_halo.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf_one_two_halo.py
@@ -28,7 +28,7 @@ def test_tpcf_one_two_halo_auto_periodic():
     """
     Npts = 100
     with NumpyRNGContext(fixed_seed):
-        IDs1 = np.random.random_integers(0, 10, Npts)
+        IDs1 = np.random.randint(0, 11, Npts)
         sample1 = np.random.random((Npts, 3))
 
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=None,
@@ -45,8 +45,8 @@ def test_tpcf_one_two_halo_cross_periodic():
     """
     Npts = 100
     with NumpyRNGContext(fixed_seed):
-        IDs1 = np.random.random_integers(0, 10, Npts)
-        IDs2 = np.random.random_integers(0, 10, Npts)
+        IDs1 = np.random.randint(0, 11, Npts)
+        IDs2 = np.random.randint(0, 11, Npts)
         sample1 = np.random.random((Npts, 3))
         sample2 = np.random.random((Npts, 3))
 

--- a/halotools/sim_manager/tests/test_rockstar_hlist_reader.py
+++ b/halotools/sim_manager/tests/test_rockstar_hlist_reader.py
@@ -45,7 +45,7 @@ def write_temporary_ascii(num_halos, temp_fname):
     with NumpyRNGContext(fixed_seed):
         d['halo_spin_bullock'] = np.random.random(num_halos).astype('f4')
         d['halo_id'] = np.arange(num_halos).astype('i8')
-        d['halo_upid'] = np.random.random_integers(-1, 5, num_halos).astype('i8')
+        d['halo_upid'] = np.random.randint(-1, 6, num_halos).astype('i8')
         d['halo_x'] = np.random.random(num_halos).astype('f4')
         d['halo_y'] = np.random.random(num_halos).astype('f4')
         d['halo_z'] = np.random.random(num_halos).astype('f4')

--- a/halotools/utils/crossmatch.py
+++ b/halotools/utils/crossmatch.py
@@ -97,7 +97,7 @@ def crossmatch(x, y, skip_bounds_checking=False):
     >>> x = np.random.rand(num_galaxies)
     >>> objid = np.arange(num_galaxies)
     >>> num_groups = int(1e4)
-    >>> groupid = np.random.random_integers(0, num_groups-1, num_galaxies)
+    >>> groupid = np.random.randint(0, num_groups, num_galaxies)
     >>> galaxy_table = Table({'x': x, 'objid': objid, 'groupid': groupid})
 
     >>> groupmass = np.random.rand(num_groups)

--- a/halotools/utils/tests/test_crossmatch.py
+++ b/halotools/utils/tests/test_crossmatch.py
@@ -57,7 +57,7 @@ def test_crossmatch5():
     xmax = 100
     numx = 10000
     with NumpyRNGContext(fixed_seed):
-        x = np.random.random_integers(0, xmax, numx)
+        x = np.random.randint(0, xmax+1, numx)
 
     y = np.arange(-xmax, xmax)[::10]
     np.random.shuffle(y)


### PR DESCRIPTION
Stable numpy is 1.11 at the moment. Adding np 1.10 build as well as the occasional prerelease build. 

Latter only runs if there is a prerelease available, otherwise sets the build to be successful. 