### PR TITLE
Allow subhalo-based models to make a cut on halo catalog prior to initial mock population

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -1051,7 +1051,6 @@ class HodModelFactory(ModelFactory):
             a table, and returning a boolean numpy array that will be used
             as a fancy indexing mask. All masked halos will be ignored during
             mock population. Default is None.
-            Currently only supported for instances of `~halotools.empirical_models.HodModelFactory`.
 
         enforce_PBC : bool, optional
             If set to True, after galaxy positions are assigned the

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -170,7 +170,6 @@ class ModelFactory(object):
             a table, and returning a boolean numpy array that will be used
             as a fancy indexing mask. All masked halos will be ignored during
             mock population. Default is None.
-            Currently only supported for instances of `~halotools.empirical_models.HodModelFactory`.
 
         enforce_PBC : bool, optional
             If set to True, after galaxy positions are assigned the

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -834,7 +834,7 @@ class SubhaloModelFactory(ModelFactory):
         self.set_primary_behaviors()
         self.set_calling_sequence()
 
-    def populate_mock(self, halocat):
+    def populate_mock(self, halocat, masking_function=None):
         """
         Method used to populate a simulation with a Monte Carlo realization of a model.
 
@@ -866,6 +866,14 @@ class SubhaloModelFactory(ModelFactory):
         halocat : object
             Either an instance of `~halotools.sim_manager.CachedHaloCatalog`
             or `~halotools.sim_manager.UserSuppliedHaloCatalog`.
+
+        masking_function : function, optional
+            Function object used to place a mask on the halo table prior to
+            calling the mock generating functions. Calling signature of the
+            function should be to accept a single positional argument storing
+            a table, and returning a boolean numpy array that will be used
+            as a fancy indexing mask. All masked halos will be ignored during
+            mock population. Default is None.
 
        Examples
         ----------
@@ -903,7 +911,10 @@ class SubhaloModelFactory(ModelFactory):
         :ref:`subhalo_mock_factory_source_notes`
 
         """
-        ModelFactory.populate_mock(self, halocat)
+        if masking_function is not None:
+            ModelFactory.populate_mock(self, halocat, masking_function=masking_function)
+        else:
+            ModelFactory.populate_mock(self, halocat)
 
     def _test_dictionary_consistency(self):
         """


### PR DESCRIPTION
Good suggestion @duncandc. 