### PR TITLE
Composite model docs

### DIFF
--- a/docs/function_usage/index.rst
+++ b/docs/function_usage/index.rst
@@ -2,17 +2,42 @@
 .. _function_usage_examples:
 
 ****************************************
-Function-usage examples by category 
+Function-usage examples by category
 ****************************************
 
-Here we present docstrings of the most commonly used functions and classes 
-grouped together by functionality. 
-Many docstrings contain example code to demonstrate basic usage. 
-For documentation of functions not listed here, see :ref:`complete_reference_api`. 
+Here we present docstrings of the most commonly used functions and classes
+grouped together by functionality.
+Many docstrings contain example code to demonstrate basic usage.
+For documentation of functions not listed here, see :ref:`complete_reference_api`.
 
 Modeling the Galaxy-Halo Connection
 =====================================
 
+Composite models
+------------------
+
+HOD models
+~~~~~~~~~~~~
+
+.. toctree::
+   :maxdepth: 1
+
+   ../quickstart_and_tutorials/tutorials/model_building/preloaded_models/zheng07_composite_model
+   ../quickstart_and_tutorials/tutorials/model_building/preloaded_models/leauthaud11_composite_model
+   ../quickstart_and_tutorials/tutorials/model_building/preloaded_models/tinker13_composite_model
+   ../quickstart_and_tutorials/tutorials/model_building/preloaded_models/hearin15_composite_model
+
+Subhalo-based models
+~~~~~~~~~~~~~~~~~~~~~
+
+.. toctree::
+   :maxdepth: 1
+
+   ../quickstart_and_tutorials/tutorials/model_building/preloaded_models/behroozi10_composite_model
+
+
+Component models
+------------------
 
 .. toctree::
    :maxdepth: 2
@@ -21,7 +46,7 @@ Modeling the Galaxy-Halo Connection
    hod_occupation_functions
    empirical_model_factory_functions
 
-Making Mock Observations 
+Making Mock Observations
 ===========================
 
 .. toctree::
@@ -29,7 +54,7 @@ Making Mock Observations
 
    mock_observables_functions
 
-Processing Simulation Data 
+Processing Simulation Data
 =============================
 
 .. toctree::
@@ -37,7 +62,7 @@ Processing Simulation Data
 
    processing_simulation_data
 
-Utility Functions 
+Utility Functions
 =============================
 
 .. toctree::

--- a/docs/quickstart_and_tutorials/index.rst
+++ b/docs/quickstart_and_tutorials/index.rst
@@ -5,11 +5,11 @@
 Quickstart Guides and Tutorials
 ***************************************
 
-This section of the documentation contains both quickstart guides 
-and detailed usage-tutorials. If you are instead looking for 
-a quick reference to the API of some 
-class or function, try looking in :ref:`function_usage_examples`, 
-or otherwise in :ref:`complete_reference_api`. 
+This section of the documentation contains both quickstart guides
+and detailed usage-tutorials. If you are instead looking for
+a quick reference to the API of some
+class or function, try looking in :ref:`function_usage_examples`,
+or otherwise in :ref:`complete_reference_api`.
 
 
 Quickstart Guides
@@ -20,7 +20,7 @@ Quickstart Guides
 
    getting_started_overview
 
-Setting up the simulation data 
+Setting up the simulation data
 ---------------------------------------------------------
 
 .. toctree::
@@ -37,12 +37,13 @@ Halo catalog analysis
 
    quickstart_guides/halo_catalog_analysis_quickstart
 
-Tutorials 
+Tutorials
 =====================
 
 .. toctree::
    :maxdepth: 1
 
+   tutorials/model_building/preloaded_models/index
    tutorials/model_building/index
    tutorials/catalog_analysis/galcat_analysis/index
    tutorials/catalog_analysis/halocat_analysis/index
@@ -52,9 +53,9 @@ Tutorials
 Developer Documentation
 =================================================
 
-The developer documentation contains guidlines for how to 
-stay up-to-date on Halotools development, submit bug reports and 
-contribute to the Halotools code base. 
+The developer documentation contains guidlines for how to
+stay up-to-date on Halotools development, submit bug reports and
+contribute to the Halotools code base.
 
 .. toctree::
    :maxdepth: 1
@@ -63,7 +64,7 @@ contribute to the Halotools code base.
    development/bug_reports
    development/contributors
    development/features_planned_for_next_release
- 
+
 
 
 

--- a/docs/quickstart_and_tutorials/tutorials/model_building/preloaded_models/zheng07_composite_model.rst
+++ b/docs/quickstart_and_tutorials/tutorials/model_building/preloaded_models/zheng07_composite_model.rst
@@ -6,31 +6,31 @@ Zheng et al. (2007) Composite Model
 
 .. currentmodule:: halotools.empirical_models
 
-This section of the documentation describes the basic behavior of 
-the ``zheng07`` composite HOD model. To see how this composite 
-model is built by the `~halotools.empirical_models.PrebuiltHodModelFactory` class, 
-see `~halotools.empirical_models.zheng07_model_dictionary`. 
+This section of the documentation describes the basic behavior of
+the ``zheng07`` composite HOD model. To see how this composite
+model is built by the `~halotools.empirical_models.PrebuiltHodModelFactory` class,
+see `~halotools.empirical_models.zheng07_model_dictionary`.
 
 Overview of the Zheng et al. (2007) Model Features
 ==================================================
-This HOD-style model is based on Zheng et al. (2007), arXiv:0703457. 
-There are two populations, centrals and satellites. 
-Central occupation statistics are given by a nearest integer distribution 
-with first moment given by an ``erf`` function; the class governing this 
-behavior is `~halotools.empirical_models.Zheng07Cens`. 
-Central galaxies are assumed to reside at the exact center of the host halo; 
-the class governing this behavior is `~halotools.empirical_models.TrivialPhaseSpace`. 
+This HOD-style model is based on Zheng et al. (2007), arXiv:0703457.
+There are two populations, centrals and satellites.
+Central occupation statistics are given by a nearest integer distribution
+with first moment given by an ``erf`` function; the class governing this
+behavior is `~halotools.empirical_models.Zheng07Cens`.
+Central galaxies are assumed to reside at the exact center of the host halo;
+the class governing this behavior is `~halotools.empirical_models.TrivialPhaseSpace`.
 
-Satellite occupation statistics are given by a Poisson distribution 
-with first moment given by a power law that has been truncated at the low-mass end; 
-the class governing this behavior is `~halotools.empirical_models.Zheng07Sats`; 
-satellites in this model follow an (unbiased) NFW profile, as governed by the 
-`~halotools.empirical_models.NFWPhaseSpace` class. 
+Satellite occupation statistics are given by a Poisson distribution
+with first moment given by a power law that has been truncated at the low-mass end;
+the class governing this behavior is `~halotools.empirical_models.Zheng07Sats`;
+satellites in this model follow an (unbiased) NFW profile, as governed by the
+`~halotools.empirical_models.NFWPhaseSpace` class.
 
 
-Building the Zheng et al. (2007) Model 
+Building the Zheng et al. (2007) Model
 =========================================
-You can build an instance of this model using the 
+You can build an instance of this model using the
 `~halotools.empirical_models.PrebuiltHodModelFactory` class as follows:
 
 >>> from halotools.empirical_models import PrebuiltHodModelFactory
@@ -40,64 +40,82 @@ You can build an instance of this model using the
 Customizing the Zheng et al. (2007) Model
 ===============================================
 
-There are two keyword arguments you can use to customize 
+There are two keyword arguments you can use to customize
 the instance returned by the factory:
 
-First, the ``threshold`` keyword argument pertains to the r-band absolute magnitude 
+First, the ``threshold`` keyword argument pertains to the r-band absolute magnitude
 of the luminosity of the galaxy sample:
 
 >>> model = PrebuiltHodModelFactory('zheng07', threshold = -20)
 
-The only purpose of this keyword is to allow you 
-to instantiate your model according to the best-fit values of the parameters 
-taken from Table 1 of Zheng et al. (2007). After instantiation, the 
-``threshold`` attribute has no impact whatsoever on the behavior of the model. 
-If you choose a different value for ``threshold`` than one of the values in Table 1 
-of Zheng et al. (2007), the model behavior will be set to the best-fit parameters 
-of the ``default_luminosity_threshold`` variable set in the 
-`~halotools.empirical_models.model_defaults` module, and you can proceed to 
-alter the ``param_dict`` however you like (see below)
+The only purpose of this keyword is to allow you
+to instantiate your model according to the best-fit values of the parameters
+taken from Table 1 of Zheng et al. (2007). After instantiation, the
+``threshold`` attribute has no impact whatsoever on the behavior of the model.
+If you choose a different value for ``threshold`` than one of the values in Table 1
+of Zheng et al. (2007), the model behavior will be set to the best-fit parameters
+of the ``default_luminosity_threshold`` variable set in the
+`~halotools.empirical_models.model_defaults` module, and you can proceed to
+alter the ``param_dict`` however you like (see below).
 
-As described in :ref:`altering_param_dict`, you can always change the model parameters 
-after instantiation by changing the values in the ``param_dict`` dictionary. For example, 
+.. note::
+
+	If you are trying to strictly reproduce the results in Zheng et al. (2007),
+	you should set the ``modulate_with_cenocc`` keyword to True.
+
+	>>> model = PrebuiltHodModelFactory('zheng07', threshold=-20, modulate_with_cenocc=True)
+
+	When ``modulate_with_cenocc`` is True, then the value of
+	:math:`\langle N_{\rm sat}\rangle(M_{\rm vir})` is multiplied by
+	:math:`\langle N_{\rm cen}\rangle(M_{\rm vir})`.
+
+	The default value is False, though in Zheng+07, their model for
+	:math:`\langle N_{\rm sat}\rangle(M_{\rm vir})` does include the prefactor.
+	For typical regions of parameter space, the choice of whether or not to include
+	this prefactor has a very small impact on the satellite occupation statistics.
+	See the `~halotools.empirical_models.Zheng07Cens` docstring for further
+	details on the ``modulate_with_cenocc`` keyword.
+
+As described in :ref:`altering_param_dict`, you can always change the model parameters
+after instantiation by changing the values in the ``param_dict`` dictionary. For example,
 
 >>> model.param_dict['logMmin'] = 12.5
 
-The above line of code changes the minimum mass for 
-a halo to host a central galaxy to :math:`10^{12.5}M_{\odot}`. 
-See :ref:`zheng07_parameters` for a description of all parameters of this model. 
+The above line of code changes the minimum mass for
+a halo to host a central galaxy to :math:`10^{12.5}M_{\odot}`.
+See :ref:`zheng07_parameters` for a description of all parameters of this model.
 
-Second, the ``redshift`` keyword argument must be set to the redshift of the 
-halo catalog you might populate with this model. 
+Second, the ``redshift`` keyword argument must be set to the redshift of the
+halo catalog you might populate with this model.
 
 >>> model = PrebuiltHodModelFactory('zheng07', threshold = -20, redshift = 2)
 
-For the ``zheng07`` model, the ``redshift`` attribute has no impact whatsoever on 
-the behavior of the model; the purpose of this keyword for factory standardization purposes only. 
+For the ``zheng07`` model, the ``redshift`` attribute has no impact whatsoever on
+the behavior of the model; the purpose of this keyword for factory standardization purposes only.
 
 Populating Mocks and Generating Zheng et al. (2007) Model Predictions
 =======================================================================
 
-As with any Halotools composite model, the model instance 
-can populate N-body simulations with mock galaxy catalogs. 
-In the following, we'll show how to do this 
-with fake simulation data via the ``halocat`` argument. 
+As with any Halotools composite model, the model instance
+can populate N-body simulations with mock galaxy catalogs.
+In the following, we'll show how to do this
+with fake simulation data via the ``halocat`` argument.
 
 >>> from halotools.sim_manager import FakeSim
 >>> halocat = FakeSim()
 >>> model = PrebuiltHodModelFactory('zheng07')
->>> model.populate_mock(halocat = halocat) 
+>>> model.populate_mock(halocat = halocat)
 
-See `ModelFactory.populate_mock` for information about how to  
-populate your model into different simulations.  
-See :ref:`galaxy_catalog_analysis_tutorial` for a sequence of worked examples 
-on how to use the `~halotools.mock_observables` sub-package 
-to study a wide range of astronomical statistics predicted by your model. 
+See `ModelFactory.populate_mock` for information about how to
+populate your model into different simulations.
+See :ref:`galaxy_catalog_analysis_tutorial` for a sequence of worked examples
+on how to use the `~halotools.mock_observables` sub-package
+to study a wide range of astronomical statistics predicted by your model.
 
-Studying the Zheng et al. (2007) Model Features 
+Studying the Zheng et al. (2007) Model Features
 ====================================================
 
-In addition to populating mocks, the ``zheng07`` model also gives you access to 
+In addition to populating mocks, the ``zheng07`` model also gives you access to
 its underlying analytical relations. Here are a few examples:
 
 >>> import numpy as np
@@ -114,25 +132,25 @@ To compute the mean number of each galaxy type as a function of halo mass:
 Parameters of the Zheng et al. (2007) model
 =================================================
 
-The best way to learn what the parameters of a model do is to 
-just play with the code: change parameter values, make plots of how the 
-underying analytical relations vary, and also of how the 
-mock observables vary. Here we just give a simple description of the meaning 
-of each parameter. You can also refer to the original publication, arXiv:0703457, 
-for further details. 
+The best way to learn what the parameters of a model do is to
+just play with the code: change parameter values, make plots of how the
+underying analytical relations vary, and also of how the
+mock observables vary. Here we just give a simple description of the meaning
+of each parameter. You can also refer to the original publication, arXiv:0703457,
+for further details.
 
-To see how the following parameters are implemented, see `Zheng07Cens.mean_occupation`. 
+To see how the following parameters are implemented, see `Zheng07Cens.mean_occupation`.
 
-* param_dict['logMmin'] - Minimum mass required for a halo to host a central galaxy. 
+* param_dict['logMmin'] - Minimum mass required for a halo to host a central galaxy.
 
-* param_dict['sigma_logM'] - Rate of transition from :math:`\langle N_{\rm cen} \rangle = 0 \Rightarrow \langle N_{\rm cen} = 1 \rangle`. 
+* param_dict['sigma_logM'] - Rate of transition from :math:`\langle N_{\rm cen} \rangle = 0 \Rightarrow \langle N_{\rm cen} = 1 \rangle`.
 
-To see how the following parameters are implemented, see `Zheng07Sats.mean_occupation`. 
+To see how the following parameters are implemented, see `Zheng07Sats.mean_occupation`.
 
-* param_dict['alpha'] - Power law slope of the relation between halo mass and :math:`\langle N_{\rm sat} \rangle`. 
+* param_dict['alpha'] - Power law slope of the relation between halo mass and :math:`\langle N_{\rm sat} \rangle`.
 
-* param_dict['logM0'] - Low-mass cutoff in :math:`\langle N_{\rm sat} \rangle`. 
+* param_dict['logM0'] - Low-mass cutoff in :math:`\langle N_{\rm sat} \rangle`.
 
-* param_dict['logM1'] - Characteristic halo mass where :math:`\langle N_{\rm sat} \rangle` begins to assume a power law form. 
+* param_dict['logM1'] - Characteristic halo mass where :math:`\langle N_{\rm sat} \rangle` begins to assume a power law form.
 
 

--- a/halotools/empirical_models/composite_models/smhm_models/behroozi10.py
+++ b/halotools/empirical_models/composite_models/smhm_models/behroozi10.py
@@ -20,6 +20,8 @@ def behroozi10_model_dictionary(redshift=sim_defaults.default_redshift, **kwargs
     published in Behroozi et al. (2010),
     `arXiv:1205.5807 <http://arxiv.org/abs/astro-ph/1205.5807/>`_.
 
+    For a tutorial on this composite model, see :ref:`behroozi10_composite_model`.
+
     Parameters
     ----------
     redshift : float, optional

--- a/halotools/empirical_models/factories/prebuilt_model_factory.py
+++ b/halotools/empirical_models/factories/prebuilt_model_factory.py
@@ -19,6 +19,7 @@ class PrebuiltSubhaloModelFactory(SubhaloModelFactory):
     `SubhaloModelFactory` models that come prebuilt with Halotools.
     For documentation on the methods bound to `PrebuiltSubhaloModelFactory`,
     see the docstring of `~halotools.empirical_models.SubhaloModelFactory`.
+    For a tutorial on all prebuilt models, see :ref:`preloaded_models_overview`.
 
     """
     prebuilt_model_nickname_list = ['behroozi10']
@@ -137,6 +138,7 @@ class PrebuiltHodModelFactory(HodModelFactory):
     `HodModelFactory` models that come prebuilt with Halotools.
     For documentation on the methods bound to `PrebuiltHodModelFactory`,
     see the docstring of `~halotools.empirical_models.HodModelFactory`.
+    For a tutorial on all prebuilt models, see :ref:`preloaded_models_overview`.
     """
 
     prebuilt_model_nickname_list = ['zheng07', 'leauthaud11', 'tinker13', 'hearin15']
@@ -177,9 +179,10 @@ class PrebuiltHodModelFactory(HodModelFactory):
         `PrebuiltHodModelFactory` will in turn be passed on to
         `~halotools.empirical_models.zheng07_model_dictionary`.
 
-        >>> model_instance = PrebuiltHodModelFactory('zheng07', threshold = -20)
+        >>> model_instance = PrebuiltHodModelFactory('zheng07', threshold=-20)
+        >>> model_instance = PrebuiltHodModelFactory('zheng07', threshold=-20, modulate_with_cenocc=True)
 
-        The same applies to all pre-built models.
+        This same syntax applies to all pre-built models.
 
         >>> model_instance = PrebuiltHodModelFactory('hearin15', threshold = 10.5, redshift = 2)
 

--- a/halotools/empirical_models/occupation_models/leauthaud11_components.py
+++ b/halotools/empirical_models/occupation_models/leauthaud11_components.py
@@ -22,6 +22,13 @@ __all__ = ('Leauthaud11Cens', 'Leauthaud11Sats',
 class Leauthaud11Cens(OccupationComponent):
     """ HOD-style model for any central galaxy occupation that derives from
     a stellar-to-halo-mass relation.
+
+    .. note::
+
+        The `Leauthaud11Cens` model is part of the ``leauthaud11``
+        prebuilt composite HOD-style model. For a tutorial on the ``leauthaud11``
+        composite model, see :ref:`leauthaud11_composite_model`.
+
     """
 
     def __init__(self, threshold=model_defaults.default_stellar_mass_threshold,
@@ -176,6 +183,12 @@ class Leauthaud11Cens(OccupationComponent):
 class Leauthaud11Sats(OccupationComponent):
     """ HOD-style model for any satellite galaxy occupation that derives from
     a stellar-to-halo-mass relation.
+
+    .. note::
+
+        The `Leauthaud11Sats` model is part of the ``leauthaud11``
+        prebuilt composite HOD-style model. For a tutorial on the ``leauthaud11``
+        composite model, see :ref:`leauthaud11_composite_model`.
     """
 
     def __init__(self, threshold=model_defaults.default_stellar_mass_threshold,

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -25,6 +25,13 @@ __all__ = ('Tinker13Cens', 'Tinker13QuiescentSats',
 class Tinker13Cens(OccupationComponent):
     """ HOD-style model for a central galaxy occupation that derives from
     two distinct active/quiescent stellar-to-halo-mass relations.
+
+    .. note::
+
+        The `Tinker13Cens` model is part of the ``tinker13``
+        prebuilt composite HOD-style model. For a tutorial on the ``tinker13``
+        composite model, see :ref:`tinker13_composite_model`.
+
     """
 
     def __init__(self, threshold=model_defaults.default_stellar_mass_threshold,
@@ -355,6 +362,12 @@ class AssembiasTinker13Cens(Tinker13Cens, HeavisideAssembias):
 class Tinker13QuiescentSats(OccupationComponent):
     """ HOD-style model for a central galaxy occupation that derives from
     two distinct active/quiescent stellar-to-halo-mass relations.
+
+    .. note::
+
+        The `Tinker13QuiescentSats` model is part of the ``tinker13``
+        prebuilt composite HOD-style model. For a tutorial on the ``tinker13``
+        composite model, see :ref:`tinker13_composite_model`.
     """
 
     def __init__(self, threshold=model_defaults.default_stellar_mass_threshold,
@@ -516,6 +529,12 @@ class Tinker13QuiescentSats(OccupationComponent):
 class Tinker13ActiveSats(OccupationComponent):
     """ HOD-style model for a central galaxy occupation that derives from
     two distinct active/active stellar-to-halo-mass relations.
+
+    .. note::
+
+        The `Tinker13ActiveSats` model is part of the ``tinker13``
+        prebuilt composite HOD-style model. For a tutorial on the ``tinker13``
+        composite model, see :ref:`tinker13_composite_model`.
     """
 
     def __init__(self, threshold=model_defaults.default_stellar_mass_threshold,

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -21,6 +21,13 @@ class Zheng07Cens(OccupationComponent):
     """ ``Erf`` function model for the occupation statistics of central galaxies,
     introduced in Zheng et al. 2005, arXiv:0408564. This implementation uses
     Zheng et al. 2007, arXiv:0703457, to assign fiducial parameter values.
+
+    .. note::
+
+        The `Zheng07Cens` model is part of the ``zheng07``
+        prebuilt composite HOD-style model. For a tutorial on the ``zheng07``
+        composite model, see :ref:`zheng07_composite_model`.
+
     """
 
     def __init__(self,
@@ -202,7 +209,13 @@ class Zheng07Sats(OccupationComponent):
     introduced in Kravtsov et al. 2004, arXiv:0308519. This implementation uses
     Zheng et al. 2007, arXiv:0703457, to assign fiducial parameter values.
 
-    :math:`\\langle N_{sat} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha}`
+    :math:`\\langle N_{sat} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha}`.
+
+    .. note::
+
+        The `Zheng07Sats` model is part of the ``zheng07``
+        prebuilt composite HOD-style model. For a tutorial on the ``zheng07``
+        composite model, see :ref:`zheng07_composite_model`.
 
     """
 

--- a/halotools/empirical_models/smhm_models/behroozi10.py
+++ b/halotools/empirical_models/smhm_models/behroozi10.py
@@ -17,7 +17,14 @@ __all__ = ['Behroozi10SmHm']
 
 class Behroozi10SmHm(PrimGalpropModel):
     """ Stellar-to-halo-mass relation based on Behroozi et al. (2010),
-    `arXiv:1205.5807 <http://arxiv.org/abs/astro-ph/1205.5807/>`_.
+    `arXiv:1205.5807 <http://arxiv.org/abs/astro-ph/1205.5807/>`_..
+
+    .. note::
+
+        The `Behroozi10SmHm` model is part of the ``behroozi10``
+        prebuilt composite subhalo-based model. For a tutorial on the ``behroozi10``
+        composite model, see :ref:`behroozi10_composite_model`.
+
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This PR addresses #543 by improving the documentation/tutorial of the Zheng+07 class. The default behavior remains the same, but the docs now explicitly state that you need to choose `modulate_with_cenocc` keyword to True if you are attempting to reproduce Zheng+07. 

There are other, smaller changes to the documentation that are part of this PR. Most of these changes are about improving the discoverability of the composite model tutorials, which should help make it easier for users to get pointed to the `modulate_with_cenocc` feature, and generally get pointed to sections of the docs that are relevant to doing science with a composite model. 