### PR TITLE
LogNormalScatterModel.scatter_realization error is scatter=0

### DIFF
--- a/halotools/empirical_models/component_model_templates/scatter_models.py
+++ b/halotools/empirical_models/component_model_templates/scatter_models.py
@@ -138,7 +138,14 @@ class LogNormalScatterModel(object):
 
         np.random.seed(seed=seed)
 
-        return np.random.normal(loc=0, scale=scatter_scale)
+        #initialize result with zero scatter result
+        result = np.zeros(len(scatter_scale))
+
+        #only draw from a normal distribution for non-zero values of scatter
+        mask = (scatter_scale > 0.0)
+        result[mask] =  np.random.normal(loc=0, scale=scatter_scale[mask])
+
+        return result
 
     def _update_interpol(self):
         """ Private method that updates the interpolating functon used to

--- a/halotools/empirical_models/component_model_templates/tests/test_scatter_models.py
+++ b/halotools/empirical_models/component_model_templates/tests/test_scatter_models.py
@@ -1,0 +1,34 @@
+""" Module providing unit-testing for the functions in
+the `~halotools.empirical_models.component_model_templates.scatter_models` module
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from astropy.tests.helper import pytest
+
+from ..scatter_models import LogNormalScatterModel
+
+__all__=['test_nonzero_scatter', 'test_zero_scatter']
+
+from halotools.sim_manager import FakeSim
+halocat = FakeSim()
+halo_table = halocat.halo_table
+
+def test_nonzero_scatter():
+    
+    scatter_model = LogNormalScatterModel(scatter_abscissa=[10**10,10**12], scatter_ordinates=[0.1,0.1])
+    
+    scatter = scatter_model.scatter_realization(table = halo_table)
+    
+    assert len(scatter)==len(halo_table)
+
+
+def test_zero_scatter():
+    
+    scatter_model = LogNormalScatterModel(scatter_abscissa=[10**10,10**12], scatter_ordinates=[0.0,0.0])
+    
+    scatter = scatter_model.scatter_realization(table = halo_table)
+    
+    assert len(scatter)==len(halo_table)
+    assert np.all(scatter==0.0)
+


### PR DESCRIPTION
This pull request allows scatter to be 0 for all scatter_abscissa or only some.  The root problem is that numpy.random.normal() throws an error if any value of scale<=0.0.  This fix only evaluates numpy.random.normal() for non-zero values of the scatter_scale variable.  

At some point where had something set up like:
result = np.where(scatter_scale > 0, np.random.normal(loc=0, scale=scatter_scale), 0)
,but numpy.where() evaluates both options before passing back the result, so this does not work (now, maybe it did previously, because I used to be able to use 0.0 scatter.)  

This bug request fixes https://github.com/astropy/halotools/issues/555