### PR TITLE
Removed -march=native compiler optimization

### DIFF
--- a/halotools/mock_observables/isolation_functions/engines/setup_package.py
+++ b/halotools/mock_observables/isolation_functions/engines/setup_package.py
@@ -15,7 +15,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast', '-march=native']
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pair_counters/cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/cpairs/setup_package.py
@@ -16,7 +16,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast', '-march=native']
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
@@ -16,7 +16,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast', '-march=native']
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pairwise_velocities/engines/setup_package.py
+++ b/halotools/mock_observables/pairwise_velocities/engines/setup_package.py
@@ -16,7 +16,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast', '-march=native']
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/radial_profiles/engines/setup_package.py
+++ b/halotools/mock_observables/radial_profiles/engines/setup_package.py
@@ -13,7 +13,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast', '-march=native']
+    extra_compile_args = ['-Ofast']
 
     extensions = []
     for name, source in zip(names, sources):


### PR DESCRIPTION
This PR removes a compiler optimization flag that causes Halotools v0.2 to fail to install on some architectures (RHEL 6.8 x86-64 and also whatever version of OS X used by @nickhand) resolving #560. The source of the failure is still a little mysterious to me, since I successfully installed v0.2 on two different OS X machines, and @duncandc and @eteq both reported successful installations in their OS X platforms. However, both @yymao and @nickhand both reported the same failure. Both have also reported that simply removing this flag resolves the bug. 

The `-march=native` optimization flag was suggested by @manodeep, who reported a ~4x speedup of his pair counters when using this flag. However, on my machine I only get a ~10% speedup when using this flag. Evidently cython is intelligent enough to make up for this in other ways. 

I would like to release Halotools v0.3 **as soon as possible** once this fix is successfully incorporated into the master branch, so once I merge this PR *I would greatly appreciate it if all those tagged in this PR would confirm whether this bug fix resolves the installation problem.* Many thanks in advance. 



