### PR TITLE
Expose random seed keyword argument to mock population

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4 (unreleased)
 ----------------
 
-- No changes yet
+- All models now support an optional ``seed`` keyword argument, allowing for deterministic Monte Carlo realizations of models. As a result of this feature, it is now mandatory that all user-defined models obey a new constraint. Any function appearing in the ``mock_generation_calling_sequence`` must now use the kwargs Python syntax to catch any additional inputs passed to these functions by the MockFactory.
 
 
 0.3 (2016-06-28)

--- a/docs/quickstart_and_tutorials/tutorials/model_building/composing_models/hod_modeling/hod_modeling_tutorial3.rst
+++ b/docs/quickstart_and_tutorials/tutorials/model_building/composing_models/hod_modeling/hod_modeling_tutorial3.rst
@@ -6,76 +6,76 @@ Example 3: An HOD-style model with a feature of your own creation
 
 .. currentmodule:: halotools.empirical_models
 
-In this section of the :ref:`hod_modeling_tutorial0`, 
-we'll build a composite model that includes a component model that 
-is not part of Halotools, but that you yourself have written. 
+In this section of the :ref:`hod_modeling_tutorial0`,
+we'll build a composite model that includes a component model that
+is not part of Halotools, but that you yourself have written.
 
-There is also an IPython Notebook in the following location that can be 
+There is also an IPython Notebook in the following location that can be
 used as a companion to the material in this section of the tutorial:
 
 
     **halotools/docs/notebooks/hod_modeling/hod_modeling_tutorial3.ipynb**
 
-By following this tutorial together with this notebook, 
-you can play around with your own variations of the models we'll build 
-as you learn the basic syntax. 
-The notebook also covers supplementary material that you may find clarifying, 
-so we recommend that you read the notebook side by side with this documentation. 
+By following this tutorial together with this notebook,
+you can play around with your own variations of the models we'll build
+as you learn the basic syntax.
+The notebook also covers supplementary material that you may find clarifying,
+so we recommend that you read the notebook side by side with this documentation.
 
 Overview of the new model
 =============================
 
-The model we'll build will be based on the ``zheng07`` HOD, 
-and we will use the ``baseline_model_instance`` feature 
-described in the :ref:`baseline_model_instance_mechanism_hod_building` 
-section of the documentation. 
-In addition to the basic ``zheng07`` features, we'll add 
-a component model that governs galaxy size. 
-Our model for size will have no physical motivation whatsoever. That 
-part is up to you. This tutorial just teaches you the mechanics of 
-incorporating a new feature into the factory. 
+The model we'll build will be based on the ``zheng07`` HOD,
+and we will use the ``baseline_model_instance`` feature
+described in the :ref:`baseline_model_instance_mechanism_hod_building`
+section of the documentation.
+In addition to the basic ``zheng07`` features, we'll add
+a component model that governs galaxy size.
+Our model for size will have no physical motivation whatsoever. That
+part is up to you. This tutorial just teaches you the mechanics of
+incorporating a new feature into the factory.
 
 Building the new component model
 ==================================
 
-All component models are instances of python classes, 
-so we will define a new class for our new feature. 
-You can always brush up on python classes by reading the  
-`Python documentation on classes <https://docs.python.org/2/tutorial/classes.html>`_. 
-But for our purposes there is really only one basic thing to know. 
-If you define a **__init__** method inside your class, then this 
-method is what gets called whenever your class is instantiated. This means that 
-any data that gets bound to *self* inside **__init__** will be bound to any 
-instance of your class. 
+All component models are instances of python classes,
+so we will define a new class for our new feature.
+You can always brush up on python classes by reading the
+`Python documentation on classes <https://docs.python.org/2/tutorial/classes.html>`_.
+But for our purposes there is really only one basic thing to know.
+If you define a **__init__** method inside your class, then this
+method is what gets called whenever your class is instantiated. This means that
+any data that gets bound to *self* inside **__init__** will be bound to any
+instance of your class.
 
-The example source code below shows the basic pattern 
-you need to match when writing your own component model. 
+The example source code below shows the basic pattern
+you need to match when writing your own component model.
 We'll unpack each line of this code in the discussion that follows.
-However, for now, while reading this code take note of the big picture. 
+However, for now, while reading this code take note of the big picture.
 
-    1. You need to provide a few pieces of boilerplate data in the **__init__** method so that the Halotools factory knows how to interface with your model. 
+    1. You need to provide a few pieces of boilerplate data in the **__init__** method so that the Halotools factory knows how to interface with your model.
 
-    2. You need to write the "physics function" that is responsible for the behavior of the model (**assign_size,** in this case). 
+    2. You need to write the "physics function" that is responsible for the behavior of the model (**assign_size,** in this case).
 
 .. code:: python
 
     class Size(object):
-        
+
         def __init__(self, gal_type):
 
             self.gal_type = gal_type
             self._mock_generation_calling_sequence = ['assign_size']
             self._galprop_dtypes_to_allocate = np.dtype([('galsize', 'f4')])
             self.list_of_haloprops_needed = ['halo_spin']
-            
+
         def assign_size(self, **kwargs):
             table = kwargs['table']
             table['galsize'][:] = table['halo_spin']/5.
 
-Now we'll build an instance of the *Size* component model for centrals and satellites 
+Now we'll build an instance of the *Size* component model for centrals and satellites
 and incorporate this feature into a composite model:
 
-.. code:: python 
+.. code:: python
 
     cen_size = Size('centrals')
     sat_size = Size('satellites')
@@ -89,113 +89,123 @@ and incorporate this feature into a composite model:
     new_model.populate_mock(halocat)
 
 
-The **__init__** method of your component model 
+The **__init__** method of your component model
 ===========================================================================
 
-There are four lines of code here, and each of them binds some new data 
-to the class instance. Thus the *component_model_instance* above 
-will have four attributes: ``gal_type``, ``_mock_generation_calling_sequence``, 
-``_galprop_dtypes_to_allocate`` and ``list_of_haloprops_needed``. 
-Each of these attributes plays an important role in structuring the interface 
-between your model and the `HodModelFactory`, so we'll now discuss 
-them one by one. 
+There are four lines of code here, and each of them binds some new data
+to the class instance. Thus the *component_model_instance* above
+will have four attributes: ``gal_type``, ``_mock_generation_calling_sequence``,
+``_galprop_dtypes_to_allocate`` and ``list_of_haloprops_needed``.
+Each of these attributes plays an important role in structuring the interface
+between your model and the `HodModelFactory`, so we'll now discuss
+them one by one.
 
 .. _role_of_hod_mock_generation_calling_sequence:
 
 The role of the `_mock_generation_calling_sequence`
 -----------------------------------------------------
 
-During the generation of a mock catalog, the `HodMockFactory` calls upon 
-the component models one-by-one to assign their properties to the ``galaxy_table``. 
-When each component is called upon, every method whose name appears in 
-the component model's ``_mock_generation_calling_sequence`` gets passed 
-the ``galaxy_table``. These methods are called in the order they appear 
-in the ``_mock_generation_calling_sequence`` list. So the purpose of 
-the ``_mock_generation_calling_sequence`` list is to inform the 
-`HodModelFactory` what to do when it comes time for the 
-component model to play its role in creating the mock galaxy distribution. 
+During the generation of a mock catalog, the `HodMockFactory` calls upon
+the component models one-by-one to assign their properties to the ``galaxy_table``.
+When each component is called upon, every method whose name appears in
+the component model's ``_mock_generation_calling_sequence`` gets passed
+the ``galaxy_table``. These methods are called in the order they appear
+in the ``_mock_generation_calling_sequence`` list. So the purpose of
+the ``_mock_generation_calling_sequence`` list is to inform the
+`HodModelFactory` what to do when it comes time for the
+component model to play its role in creating the mock galaxy distribution.
 
-See the :ref:`mock_generation_calling_sequence_mechanism` section of the 
-:ref:`composite_model_constructor_bookkeeping_mechanisms` page 
-for further discussion. 
+See the :ref:`mock_generation_calling_sequence_mechanism` section of the
+:ref:`composite_model_constructor_bookkeeping_mechanisms` page
+for further discussion.
 
 The role of the `_galprop_dtypes_to_allocate`
 -----------------------------------------------------
-One of the tasks handled by the `HodMockFactory` is the allocation of 
-the appropriate memory that will be stored in your ``galaxy_table``. 
-For every galaxy property in a composite model, there needs to be a 
-corresponding column of the ``galaxy_table`` of the appropriate data type. 
-The ``_galprop_dtypes_to_allocate`` ensures that this is the case. 
+One of the tasks handled by the `HodMockFactory` is the allocation of
+the appropriate memory that will be stored in your ``galaxy_table``.
+For every galaxy property in a composite model, there needs to be a
+corresponding column of the ``galaxy_table`` of the appropriate data type.
+The ``_galprop_dtypes_to_allocate`` ensures that this is the case.
 
-The way this works is that every component model must declare a 
-`numpy.dtype` object and bind it to the 
-``_galprop_dtypes_to_allocate`` attribute of the composite model instance. 
-You can read more about Numpy `~numpy.dtype` objects in the Numpy documentation, 
-but the basic syntax is illustrated in the source code above: 
-our new column will be named ``galsize``, and each row stores a float. 
+The way this works is that every component model must declare a
+`numpy.dtype` object and bind it to the
+``_galprop_dtypes_to_allocate`` attribute of the composite model instance.
+You can read more about Numpy `~numpy.dtype` objects in the Numpy documentation,
+but the basic syntax is illustrated in the source code above:
+our new column will be named ``galsize``, and each row stores a float.
 
-You can see how to alter the syntax for the case of a component model that assigns 
-more than one galaxy property in the next example of this tutorial. 
-See the :ref:`galprop_dtypes_to_allocate_mechanism` section of the 
-:ref:`composite_model_constructor_bookkeeping_mechanisms` documentation page 
-for further discussion. 
+You can see how to alter the syntax for the case of a component model that assigns
+more than one galaxy property in the next example of this tutorial.
+See the :ref:`galprop_dtypes_to_allocate_mechanism` section of the
+:ref:`composite_model_constructor_bookkeeping_mechanisms` documentation page
+for further discussion.
 
 The role of the `list_of_haloprops_needed`
 -----------------------------------------------------
 
-This attribute provides a list of all the keys of the ``halo_table`` that 
-the functions appearing ``_mock_generation_calling_sequence`` will need to access 
-during mock population. For example, the **assign_size** method requires 
-access to the ``halo_spin`` column, and so the ``halo_spin`` string appears in 
-``list_of_haloprops_needed``. This is fairly self-explanatory, but you can 
-read more about the under-the-hood details in the 
-:ref:`list_of_haloprops_needed_mechanism` section of the 
-:ref:`composite_model_constructor_bookkeeping_mechanisms` documentation page. 
+This attribute provides a list of all the keys of the ``halo_table`` that
+the functions appearing ``_mock_generation_calling_sequence`` will need to access
+during mock population. For example, the **assign_size** method requires
+access to the ``halo_spin`` column, and so the ``halo_spin`` string appears in
+``list_of_haloprops_needed``. This is fairly self-explanatory, but you can
+read more about the under-the-hood details in the
+:ref:`list_of_haloprops_needed_mechanism` section of the
+:ref:`composite_model_constructor_bookkeeping_mechanisms` documentation page.
 
 The role of the HOD `gal_type`
 -----------------------------------------------------
 
-Each of the component model methods appearing in 
-``_mock_generation_calling_sequence`` will not only be called 
-by the composite model during mock generation, but these methods will also 
-be passed on as methods that the composite model itself can use for other 
-applications. The only difference will be that your choice for the ``gal_type`` 
-string will be appended to these method names. For example, 
-in the source code above, the composite model instance will have two methods:  
-``assign_size_centrals`` and ``assign_size_satellites``. Besides mock population, 
-you may find it useful to call upon these methods to make plots or 
-study the behavior of your model. 
+Each of the component model methods appearing in
+``_mock_generation_calling_sequence`` will not only be called
+by the composite model during mock generation, but these methods will also
+be passed on as methods that the composite model itself can use for other
+applications. The only difference will be that your choice for the ``gal_type``
+string will be appended to these method names. For example,
+in the source code above, the composite model instance will have two methods:
+``assign_size_centrals`` and ``assign_size_satellites``. Besides mock population,
+you may find it useful to call upon these methods to make plots or
+study the behavior of your model.
 
-.. _physics_function_hod_explanation: 
+.. _physics_function_hod_explanation:
 
-The "physics function" of your component model 
+The "physics function" of your component model
 ==================================================
 
-In the example above, there is just one function responsible for 
-the physics underlying this model: **assign_size.** 
-The behavior of this simple function is pretty trivial: 
-whatever the spin of the halo is, divide it by five and call the result 
-the size of the galaxy. Obviously this is physically silly, but the 
-calling signature illustrates how to write your more physically realistic model. 
+In the example above, there is just one function responsible for
+the physics underlying this model: **assign_size.**
+The behavior of this simple function is pretty trivial:
+whatever the spin of the halo is, divide it by five and call the result
+the size of the galaxy. Obviously this is physically silly, but the
+calling signature illustrates how to write your more physically realistic model.
 
-Any method in your ``_mock_generation_calling_sequence`` must accept a ``table`` keyword 
-argument. That is because when the `MockFactory` calls your component model 
-methods, it will pass the ``galaxy_table`` that is being built to each of your 
-physics functions via a ``table`` keyword argument. 
-The simplest way to handle this in a way that will be compatible with future Halotools 
-updates is to have your physics functions use the Python built-in kwargs mechanism, 
-as demonstrated in the source code above. 
+Any method in your ``_mock_generation_calling_sequence`` must accept a ``table`` keyword
+argument. That is because when the `MockFactory` calls your component model
+methods, it will pass the ``galaxy_table`` that is being built to each of your
+physics functions via a ``table`` keyword argument.
+The simplest way to handle this in a way that will be compatible with future Halotools
+updates is to have your physics functions use the Python built-in kwargs mechanism,
+as demonstrated in the source code above.
 
-In order for your model's underlying physics to propagate into the properties 
-of the mock galaxy population, your physics function(s) must write 
-values to the appropriate column of the ``table``. In this case, 
-we wrote to the ``galsize`` column. The **[:]** syntax is not strictly necessary, 
-but it is good practice to use it because it ensures that an exception will be raised 
-if you attempt to write to column that does not exist in the ``galaxy_table``; 
-you can omit the **[:]** if you want to eschew this safety mechanism, 
-but there is no difference in performance and so this is syntax is recommended 
-as a sanity check on all the bookkeeping. 
+.. note::
 
-This tutorial continues with :ref:`hod_modeling_tutorial4`. 
+    As of v0.4, any physics functions *must* use the Python kwargs mechanism.
+    This is so that the Halotools mock factories can pass arbitrary supplementary
+    data to the component model functions, such as a random number seed.
+    Rather than enumerating the list of necessary arguments that need to be caught,
+    if you simply tack on the ``**kwargs`` argument at the end of the signature of
+    your physics function, then the factories can pass in any additional data that
+    your function can trivially ignore.
+
+In order for your model's underlying physics to propagate into the properties
+of the mock galaxy population, your physics function(s) must write
+values to the appropriate column of the ``table``. In this case,
+we wrote to the ``galsize`` column. The **[:]** syntax is not strictly necessary,
+but it is good practice to use it because it ensures that an exception will be raised
+if you attempt to write to column that does not exist in the ``galaxy_table``;
+you can omit the **[:]** if you want to eschew this safety mechanism,
+but there is no difference in performance and so this is syntax is recommended
+as a sanity check on all the bookkeeping.
+
+This tutorial continues with :ref:`hod_modeling_tutorial4`.
 
 

--- a/halotools/empirical_models/component_model_templates/binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/binary_galprop_models.py
@@ -7,6 +7,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 from astropy.extern import six
 from abc import ABCMeta
+from astropy.utils.misc import NumpyRNGContext
 
 from .. import model_defaults
 from .. import model_helpers
@@ -110,11 +111,11 @@ class BinaryGalpropModel(object):
             Array storing the values of the primary galaxy property
             of the galaxies living in the input halos.
         """
-        np.random.seed(seed=seed)
 
         mean_func = getattr(self, 'mean_'+self.galprop_name+'_fraction')
         mean_galprop_fraction = mean_func(**kwargs)
-        mc_generator = np.random.random(custom_len(mean_galprop_fraction))
+        with NumpyRNGContext(seed):
+            mc_generator = np.random.random(custom_len(mean_galprop_fraction))
         result = np.where(mc_generator < mean_galprop_fraction, True, False)
         if 'table' in kwargs:
             kwargs['table'][self.galprop_name] = result

--- a/halotools/empirical_models/component_model_templates/scatter_models.py
+++ b/halotools/empirical_models/component_model_templates/scatter_models.py
@@ -2,10 +2,10 @@
 Module containing the `~halotools.empirical_models.LogNormalScatterModel` class
 used to model stochasticity in the mapping between stellar mass and halo properties.
 """
-from __future__ import (
-    division, print_function, absolute_import, unicode_literals)
+from __future__ import division, print_function, absolute_import, unicode_literals
 
 import numpy as np
+from astropy.utils.misc import NumpyRNGContext
 
 from .. import model_defaults
 from .. import model_helpers as model_helpers
@@ -134,14 +134,13 @@ class LogNormalScatterModel(object):
 
         scatter_scale = self.mean_scatter(**kwargs)
 
-        np.random.seed(seed=seed)
-
         #initialize result with zero scatter result
         result = np.zeros(len(scatter_scale))
 
         #only draw from a normal distribution for non-zero values of scatter
         mask = (scatter_scale > 0.0)
-        result[mask] =  np.random.normal(loc=0, scale=scatter_scale[mask])
+        with NumpyRNGContext(seed):
+            result[mask] = np.random.normal(loc=0, scale=scatter_scale[mask])
 
         return result
 

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -281,7 +281,7 @@ class MockFactory(object):
                 approx_cell1_size=[rmax, rmax, rmax])
             return rbin_centers, xi11, xi12, xi22
 
-    def compute_galaxy_matter_cross_clustering(self, include_complement=False, **kwargs):
+    def compute_galaxy_matter_cross_clustering(self, include_complement=False, seed=None, **kwargs):
         """
         Built-in method for all mock catalogs to compute the galaxy-matter cross-correlation function.
 
@@ -312,6 +312,11 @@ class MockFactory(object):
         num_threads : int, optional
             Number of CPU cores to use in the calculation.
             Default is maximum number available.
+
+        seed : integer, optional
+            Random number seed used when drawing random numbers with `numpy.random`.
+            Useful when deterministic results are desired, such as during unit-testing.
+            Default is None, producing stochastic results.
 
         Returns
         --------
@@ -374,7 +379,7 @@ class MockFactory(object):
 
         nptcl = np.max([model_defaults.default_nptcls, len(self.galaxy_table)])
         if nptcl < len(self.ptcl_table):
-            ptcl_table = randomly_downsample_data(self.ptcl_table, nptcl)
+            ptcl_table = randomly_downsample_data(self.ptcl_table, nptcl, seed=seed)
         else:
             ptcl_table = self.ptcl_table
 

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -181,6 +181,10 @@ class ModelFactory(object):
             no longer apply.
             Currently only supported for instances of `~halotools.empirical_models.HodModelFactory`.
 
+        seed : int, optional
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
+
         Examples
         ----------
         We'll use a pre-built HOD-style model to demonstrate basic usage.
@@ -229,7 +233,7 @@ class ModelFactory(object):
             pass
         self.mock = self.mock_factory(**mock_factory_init_args)
 
-        additional_potential_kwargs = ('masking_function', '_testing_mode', 'enforce_PBC')
+        additional_potential_kwargs = ('masking_function', '_testing_mode', 'enforce_PBC', 'seed')
         mockpop_keys = set(additional_potential_kwargs) & set(kwargs)
         mockpop_kwargs = {key: kwargs[key] for key in mockpop_keys}
         self.mock.populate(**mockpop_kwargs)

--- a/halotools/empirical_models/factories/subhalo_mock_factory.py
+++ b/halotools/empirical_models/factories/subhalo_mock_factory.py
@@ -156,7 +156,7 @@ class SubhaloMockFactory(MockFactory):
                     "and returns a length-N array of strings.\n")
                 raise HalotoolsError(msg)
 
-    def populate(self):
+    def populate(self, seed=None):
         """
         Method populating subhalos with mock galaxies.
         By calling the `populate` method of your mock, you will repopulate
@@ -166,6 +166,12 @@ class SubhaloMockFactory(MockFactory):
 
         For an in-depth discussion of how this method is implemented,
         see the :ref:`subhalo_mock_factory_source_notes` section of the documentation.
+
+        Parameters
+        ----------
+        seed : int, optional
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Examples
         ----------
@@ -199,17 +205,17 @@ class SubhaloMockFactory(MockFactory):
         :ref:`subhalo_mock_factory_source_notes`
 
         """
-        self._allocate_memory()
+        self._allocate_memory(seed=seed)
 
         for method in self.model._mock_generation_calling_sequence:
             func = getattr(self.model, method)
-            func(table=self.galaxy_table)
+            func(table=self.galaxy_table, seed=seed)
 
         if hasattr(self.model, 'galaxy_selection_func'):
             mask = self.model.galaxy_selection_func(self.galaxy_table)
             self.galaxy_table = self.galaxy_table[mask]
 
-    def _allocate_memory(self):
+    def _allocate_memory(self, seed=None):
         """
         """
         Ngals = len(self.galaxy_table)

--- a/halotools/empirical_models/factories/subhalo_model_factory.py
+++ b/halotools/empirical_models/factories/subhalo_model_factory.py
@@ -834,7 +834,7 @@ class SubhaloModelFactory(ModelFactory):
         self.set_primary_behaviors()
         self.set_calling_sequence()
 
-    def populate_mock(self, halocat, masking_function=None):
+    def populate_mock(self, halocat, masking_function=None, **kwargs):
         """
         Method used to populate a simulation with a Monte Carlo realization of a model.
 
@@ -912,9 +912,9 @@ class SubhaloModelFactory(ModelFactory):
 
         """
         if masking_function is not None:
-            ModelFactory.populate_mock(self, halocat, masking_function=masking_function)
+            ModelFactory.populate_mock(self, halocat, masking_function=masking_function, **kwargs)
         else:
-            ModelFactory.populate_mock(self, halocat)
+            ModelFactory.populate_mock(self, halocat, **kwargs)
 
     def _test_dictionary_consistency(self):
         """

--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy.stats import poisson
 from astropy.extern import six
 from abc import ABCMeta
+from astropy.utils.misc import NumpyRNGContext
 
 from .. import model_defaults, model_helpers
 
@@ -153,8 +154,8 @@ class OccupationComponent(object):
         mc_abundance : array
             Integer array giving the number of galaxies in each of the input table.
         """
-        np.random.seed(seed=seed)
-        mc_generator = np.random.random(custom_len(first_occupation_moment))
+        with NumpyRNGContext(seed):
+            mc_generator = np.random.random(custom_len(first_occupation_moment))
 
         result = np.where(mc_generator < first_occupation_moment, 1, 0)
         if 'table' in kwargs:
@@ -179,13 +180,13 @@ class OccupationComponent(object):
         mc_abundance : array
             Integer array giving the number of galaxies in each of the input table.
         """
-        np.random.seed(seed=seed)
         # The scipy built-in Poisson number generator raises an exception
         # if its input is zero, so here we impose a simple workaround
         first_occupation_moment = np.where(first_occupation_moment <=0,
             model_defaults.default_tiny_poisson_fluctuation, first_occupation_moment)
 
-        result = poisson.rvs(first_occupation_moment)
+        with NumpyRNGContext(seed):
+            result = poisson.rvs(first_occupation_moment)
         if 'table' in kwargs:
             kwargs['table']['halo_num_'+self.gal_type] = result
         return result

--- a/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
+++ b/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
@@ -6,6 +6,7 @@ from copy import copy, deepcopy
 from astropy.tests.helper import pytest
 from unittest import TestCase
 import warnings
+from astropy.utils.misc import NumpyRNGContext
 
 from ..occupation_model_template import OccupationComponent
 
@@ -130,9 +131,10 @@ class TestOccupationComponent(TestCase):
             def mean_occupation(self, **kwargs):
                 return None
 
-            def mc_occupation(self, **kwargs):
+            def mc_occupation(self, seed=None, **kwargs):
                 table = kwargs['table']
-                result = np.random.randint(0, 2, len(table))
+                with NumpyRNGContext(seed):
+                    result = np.random.randint(0, 2, len(table))
                 table['halo_num_centrals'] = result
                 return result
 

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -5,12 +5,12 @@ This module contains occupation components used by the Tinker13 composite model.
 import numpy as np
 import math
 from scipy.special import erf
+from astropy.utils.misc import NumpyRNGContext
 
 from .occupation_model_template import OccupationComponent
 
 from .. import model_defaults, model_helpers
 from ..smhm_models import Behroozi10SmHm
-
 from ..assembias_models import HeavisideAssembias
 from ..model_helpers import bounds_enforcing_decorator_factory
 
@@ -162,14 +162,13 @@ class Tinker13Cens(OccupationComponent):
 
         return fraction
 
-    def mc_sfr_designation(self, **kwargs):
+    def mc_sfr_designation(self, seed=None, **kwargs):
         """
         """
         quiescent_fraction = self.mean_quiescent_fraction(**kwargs)
 
-        if 'seed' in kwargs:
-            np.random.seed(seed=kwargs['seed'])
-        mc_generator = np.random.random(custom_len(quiescent_fraction))
+        with NumpyRNGContext(seed):
+            mc_generator = np.random.random(custom_len(quiescent_fraction))
 
         result = np.where(mc_generator < quiescent_fraction, 'quiescent', 'active')
         if 'table' in kwargs:

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -471,7 +471,7 @@ class Tinker13QuiescentSats(OccupationComponent):
 
         return mean_nsat
 
-    def mc_sfr_designation(self, table):
+    def mc_sfr_designation(self, table, **kwargs):
         """
         """
         table[self.sfr_designation_key][:] = 'quiescent'
@@ -637,7 +637,7 @@ class Tinker13ActiveSats(OccupationComponent):
 
         return mean_nsat
 
-    def mc_sfr_designation(self, table):
+    def mc_sfr_designation(self, table, **kwargs):
         """
         """
         table[self.sfr_designation_key][:] = 'active'

--- a/halotools/empirical_models/phase_space_models/nfw_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/nfw_phase_space.py
@@ -85,7 +85,7 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
 
         self._mock_generation_calling_sequence = ['assign_phase_space']
 
-    def assign_phase_space(self, table):
+    def assign_phase_space(self, table, seed=None):
         """ Primary method of the `NFWPhaseSpace` class called during the mock-population sequence.
 
         Parameters
@@ -94,6 +94,10 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             Data table storing halo catalog.
             After calling the `assign_phase_space` method, the `x`, `y`, `z`, `vx`, `vy`, and `vz`
             columns of the input ``table`` will be over-written.
+
+        seed : int, optional
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Notes
         ------
@@ -105,10 +109,11 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
         * `~halotools.empirical_models.monte_carlo_helpers.MonteCarloGalProf.mc_vel`
 
         """
-        MonteCarloGalProf.mc_pos(self, table=table)
-        MonteCarloGalProf.mc_vel(self, table=table)
+        MonteCarloGalProf.mc_pos(self, table=table, seed=seed)
+        MonteCarloGalProf.mc_vel(self, table=table, seed=seed)
 
-    def mc_generate_nfw_phase_space_points(self, Ngals=int(1e4), conc=5, mass=1e12, verbose=True):
+    def mc_generate_nfw_phase_space_points(self, Ngals=int(1e4), conc=5, mass=1e12,
+            verbose=True, seed=None):
         """ Stand-alone convenience function for returning
         a Monte Carlo realization of points in the phase space of an NFW halo in isotropic Jeans equilibrium.
 
@@ -129,6 +134,10 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
         verbose : bool, optional
             If True, a message prints with an estimate of the build time.
             Default is True.
+
+        seed : int, optional
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Returns
         --------
@@ -170,14 +179,14 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
         rvir = NFWProfile.halo_mass_to_halo_radius(self, total_mass=m)
 
         x, y, z = MonteCarloGalProf.mc_halo_centric_pos(self, c,
-            halo_radius=rvir)
+            halo_radius=rvir, seed=seed)
         r = np.sqrt(x**2 + y**2 + z**2)
         scaled_radius = r/rvir
 
-        vrad = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c)
-        vx = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c)
-        vy = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c)
-        vz = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c)
+        vrad = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c, seed=seed)
+        vx = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c, seed=seed)
+        vy = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c, seed=seed)
+        vz = MonteCarloGalProf.mc_radial_velocity(self, scaled_radius, m, c, seed=seed)
 
         t = Table({'x': x, 'y': y, 'z': z,
             'vx': vx, 'vy': vy, 'vz': vz,
@@ -687,7 +696,8 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             Length-Ngals numpy array storing the concentrations of the mock galaxies.
 
         seed : int, optional
-            Random number seed used in Monte Carlo realization. Default is None.
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Returns
         -------
@@ -713,7 +723,8 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             Number of 3d points to generate
 
         seed : int, optional
-            Random number seed used in Monte Carlo realization. Default is None.
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Returns
         -------
@@ -741,7 +752,8 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             If ``table`` is not passed, ``concentration_array`` must be passed.
 
         seed : int, optional
-            Random number seed used in Monte Carlo realization. Default is None.
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Returns
         -------
@@ -777,7 +789,8 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             ``table`` must be passed.
 
         seed : int, optional
-            Random number seed used in Monte Carlo realization. Default is None.
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Returns
         -------
@@ -829,6 +842,10 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             assumes that the ``x``, ``y``, and ``z`` columns already store
             the position of the host halo center.
 
+        seed : int, optional
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
+
         Notes
         ------
         This method is tested by the `~halotools.empirical_models.test_phase_space.TestNFWPhaseSpace.test_mc_pos` function.
@@ -879,7 +896,8 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             Length-Ngals numpy array storing the concentrations of the mock galaxies.
 
         seed : int, optional
-            Random number seed used in Monte Carlo realization. Default is None.
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
 
         Returns
         -------
@@ -894,7 +912,7 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
         return MonteCarloGalProf.mc_radial_velocity(self,
             scaled_radius, total_mass, *concentration_array, **kwargs)
 
-    def mc_vel(self, table):
+    def mc_vel(self, table, seed=None):
         """ Method assigns a Monte Carlo realization of the Jeans velocity
         solution to the halos in the input ``table``.
 
@@ -905,8 +923,12 @@ class NFWPhaseSpace(NFWProfile, NFWJeansVelocity, MonteCarloGalProf):
             Calling the `mc_vel` method will over-write the existing values of
             the ``vx``, ``vy`` and ``vz`` columns.
 
+        seed : int, optional
+            Random number seed used in the Monte Carlo realization.
+            Default is None, which will produce stochastic results.
+
         Notes
         ------
         This method is tested by the `~halotools.empirical_models.test_phase_space.TestNFWPhaseSpace.test_mc_vel` function.
         """
-        MonteCarloGalProf.mc_vel(self, table)
+        MonteCarloGalProf.mc_vel(self, table, seed=seed)

--- a/halotools/empirical_models/phase_space_models/profile_models/tests/test_conc_mass.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/tests/test_conc_mass.py
@@ -5,12 +5,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.table import Table
 from unittest import TestCase
+from astropy.utils.misc import NumpyRNGContext
 
 from ..conc_mass_models import ConcMass
 
 from .... import model_defaults
 
 __all__ = ['TestConcMass']
+
+fixed_seed = 43
 
 
 class TestConcMass(TestCase):
@@ -57,7 +60,8 @@ class TestConcMass(TestCase):
         """
         Npts = int(1e3)
         mass = np.logspace(10, 15, Npts)
-        conc = np.random.uniform(0, 100, Npts)
+        with NumpyRNGContext(fixed_seed):
+            conc = np.random.uniform(0, 100, Npts)
         t = Table({'conc': conc, 'halo_mvir': mass})
         conc_result = self.direct_model.compute_concentration(table=t)
 

--- a/halotools/empirical_models/phase_space_models/profile_models/tests/test_nfw_profile.py
+++ b/halotools/empirical_models/phase_space_models/profile_models/tests/test_nfw_profile.py
@@ -254,3 +254,22 @@ class TestNFWProfile(TestCase):
                     analytic_nfw_density_outer_shell_normalization(rbin_midpoints, conc))
 
                 assert np.allclose(monte_carlo_ratio, analytical_ratio, 0.02)
+
+    def test_mc_generate_nfw_radial_positions_stochasticity(self):
+        halo_radius = 0.5
+        num_pts = int(100)
+        num_rbins = 20
+        rbins = np.linspace(0.05, 1, num_rbins)
+
+        conc = 5
+        model = self.default_nfw
+
+        r1 = model.mc_generate_nfw_radial_positions(
+            halo_radius=halo_radius, conc=conc, num_pts=num_pts, seed=43)
+        r2 = model.mc_generate_nfw_radial_positions(
+            halo_radius=halo_radius, conc=conc, num_pts=num_pts, seed=43)
+        r3 = model.mc_generate_nfw_radial_positions(
+            halo_radius=halo_radius, conc=conc, num_pts=num_pts, seed=44)
+        assert np.allclose(r1, r2, rtol=0.001)
+        assert not np.allclose(r1, r3, rtol=0.001)
+

--- a/halotools/empirical_models/phase_space_models/trivial_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/trivial_phase_space.py
@@ -53,7 +53,7 @@ class TrivialPhaseSpace(object):
         self.mdef = mdef
         self.halo_boundary_key = model_defaults.get_halo_boundary_key(self.mdef)
 
-    def assign_phase_space(self, table):
+    def assign_phase_space(self, table, **kwargs):
         """
         """
         phase_space_keys = ['x', 'y', 'z', 'vx', 'vy', 'vz']

--- a/halotools/empirical_models/tests/test_model_helpers.py
+++ b/halotools/empirical_models/tests/test_model_helpers.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
+"""
+"""
 
 import numpy as np
 from unittest import TestCase
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from .. import model_helpers as occuhelp
 from ...custom_exceptions import HalotoolsError
 
 __all__ = ['TestModelHelpers']
+
+fixed_seed = 43
 
 
 class TestModelHelpers(TestCase):
@@ -18,11 +22,13 @@ class TestModelHelpers(TestCase):
 
         box_length = 250
         Npts = int(1e5)
-        coords = np.random.uniform(0, box_length, Npts*3).reshape(Npts, 3)
+        with NumpyRNGContext(fixed_seed):
+            coords = np.random.uniform(0, box_length, Npts*3).reshape(Npts, 3)
 
         perturbation_size = box_length/10.
-        coord_perturbations = np.random.uniform(
-            -perturbation_size, perturbation_size, Npts*3).reshape(Npts, 3)
+        with NumpyRNGContext(fixed_seed):
+            coord_perturbations = np.random.uniform(
+                -perturbation_size, perturbation_size, Npts*3).reshape(Npts, 3)
 
         coords += coord_perturbations
 

--- a/halotools/mock_observables/isolation_functions/tests/test_conditional_cylindrical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_conditional_cylindrical_isolation.py
@@ -62,8 +62,8 @@ def test_conditional_cylindrical_isolation_cond_func1():
     `~halotools.mock_observables.conditional_cylindrical_isolation` function
     always returns False when every mark1 exceeds every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
 
     rp_max, pi_max = 0.2, 0.2
     iso = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=[1, 1, 1])
@@ -87,8 +87,8 @@ def test_conditional_cylindrical_isolation_cond_func2():
     `~halotools.mock_observables.conditional_cylindrical_isolation` function
     always returns True when every mark1 exceeds every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
 
     rp_max, pi_max = 0.2, 0.2
     iso = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=[1, 1, 1])
@@ -112,8 +112,8 @@ def test_conditional_cylindrical_isolation_cond_func3():
     `~halotools.mock_observables.conditional_cylindrical_isolation` function
     always returns True when every mark1 is distinct from every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
 
     rp_max, pi_max = 0.2, 0.2
     iso = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=[1, 1, 1])
@@ -139,8 +139,8 @@ def test_conditional_cylindrical_isolation_cond_func4():
     `~halotools.mock_observables.conditional_cylindrical_isolation` function
     always returns False when every mark1 is distinct from every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
 
     rp_max, pi_max = 0.2, 0.2
     iso = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=[1, 1, 1])
@@ -167,8 +167,8 @@ def test_conditional_cylindrical_isolation_cond_func5():
     always returns the appropriate answer in both appropriate limits of
     w_1[0] to (w_2[0]+w_1[1]).
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
 
     # First verify that the two points are not isolated when ignoring the marks
     rp_max, pi_max = 0.2, 0.2

--- a/halotools/mock_observables/isolation_functions/tests/test_conditional_spherical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_conditional_spherical_isolation.py
@@ -67,8 +67,8 @@ def test_conditional_spherical_isolation_cond_func1():
     `~halotools.mock_observables.conditional_spherical_isolation` function
     always returns False when every mark1 exceeds every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     r_max = 0.2
     marks1 = np.ones(len(sample1))
     marks2 = np.zeros(len(sample2))
@@ -91,8 +91,8 @@ def test_conditional_spherical_isolation_cond_func2():
     `~halotools.mock_observables.conditional_spherical_isolation` function
     always returns True when every mark1 exceeds every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     r_max = 0.2
     marks1 = np.ones(len(sample1))
     marks2 = np.zeros(len(sample2))
@@ -115,8 +115,8 @@ def test_conditional_spherical_isolation_cond_func3():
     `~halotools.mock_observables.conditional_spherical_isolation` function
     always returns True when every mark1 is distinct from every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     r_max = 0.2
     marks1 = np.ones(len(sample1))
     marks2 = np.zeros(len(sample2))
@@ -140,8 +140,8 @@ def test_conditional_spherical_isolation_cond_func4():
     `~halotools.mock_observables.conditional_spherical_isolation` function
     always returns False when every mark1 is distinct from every mark2, and conversely.
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     r_max = 0.2
     marks1 = np.ones(len(sample1))
     marks2 = np.zeros(len(sample2))
@@ -166,8 +166,8 @@ def test_conditional_spherical_isolation_cond_func5():
     always returns the appropriate answer in both appropriate limits of
     w_1[0] to (w_2[0]+w_1[1]).
     """
-    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05)
-    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95)
+    sample1 = generate_locus_of_3d_points(10, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(10, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     r_max = 0.25
 
     # First verify that the two points are not isolated when ignoring the marks

--- a/halotools/mock_observables/isolation_functions/tests/test_cylindrical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_cylindrical_isolation.py
@@ -33,8 +33,8 @@ def test_cylindrical_isolation2():
     """ Verify that the `~halotools.mock_observables.cylindrical_isolation` function
     returns no points as isolated when a subset of ``sample2`` lies within ``sample1``
     """
-    sample1 = generate_locus_of_3d_points(100, xc=0.1, yc=0.1, zc=0.1)
-    sample2 = generate_locus_of_3d_points(100, xc=0.1, yc=0.1, zc=0.1)
+    sample1 = generate_locus_of_3d_points(100, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    sample2 = generate_locus_of_3d_points(100, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
     pi_max = 0.1
     rp_max = 0.1
     iso = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=1)

--- a/halotools/mock_observables/large_scale_density/tests/test_large_scale_density_spherical_annulus.py
+++ b/halotools/mock_observables/large_scale_density/tests/test_large_scale_density_spherical_annulus.py
@@ -11,13 +11,15 @@ from ....custom_exceptions import HalotoolsError
 
 __all__ = ('test_large_scale_density_spherical_annulus_exception_handling', )
 
+fixed_seed = 43
+
 
 def test_large_scale_density_spherical_annulus_exception_handling():
     """
     """
     npts1, npts2 = 100, 200
-    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1, seed=fixed_seed)
     inner_radius, outer_radius = 0.1, 0.2
 
     with pytest.raises(HalotoolsError) as err:
@@ -49,8 +51,8 @@ def test_large_scale_density_spherical_annulus1():
     """
     """
     npts1, npts2 = 10, 200
-    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1, seed=fixed_seed)
     inner_radius, outer_radius = 0.04, 0.1
     result = large_scale_density_spherical_annulus(
         sample, tracers, inner_radius, outer_radius, period=1)
@@ -66,8 +68,8 @@ def test_large_scale_density_spherical_annulus2():
     """
     """
     npts1, npts2 = 100, 200
-    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    tracers = generate_locus_of_3d_points(npts2, xc=0.95, yc=0.1, zc=0.1)
+    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    tracers = generate_locus_of_3d_points(npts2, xc=0.95, yc=0.1, zc=0.1, seed=fixed_seed)
     inner_radius, outer_radius = 0.1, 0.2
     result = large_scale_density_spherical_annulus(
         sample, tracers, inner_radius, outer_radius,

--- a/halotools/mock_observables/large_scale_density/tests/test_large_scale_density_spherical_volume.py
+++ b/halotools/mock_observables/large_scale_density/tests/test_large_scale_density_spherical_volume.py
@@ -11,13 +11,15 @@ from ....custom_exceptions import HalotoolsError
 
 __all__ = ('test_large_scale_density_spherical_volume1', )
 
+fixed_seed = 43
+
 
 def test_large_scale_density_spherical_volume_exception_handling():
     """
     """
     npts1, npts2 = 100, 200
-    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1, seed=fixed_seed)
     radius = 0.1
 
     with pytest.raises(HalotoolsError) as err:
@@ -43,8 +45,8 @@ def test_large_scale_density_spherical_volume1():
     """
     """
     npts1, npts2 = 100, 200
-    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1)
+    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    tracers = generate_locus_of_3d_points(npts2, xc=0.15, yc=0.1, zc=0.1, seed=fixed_seed)
     radius = 0.1
     result = large_scale_density_spherical_volume(
         sample, tracers, radius, period=1)
@@ -58,8 +60,8 @@ def test_large_scale_density_spherical_volume2():
     """
     """
     npts1, npts2 = 100, 200
-    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    tracers = generate_locus_of_3d_points(npts2, xc=0.95, yc=0.1, zc=0.1)
+    sample = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    tracers = generate_locus_of_3d_points(npts2, xc=0.95, yc=0.1, zc=0.1, seed=fixed_seed)
     radius = 0.2
     result = large_scale_density_spherical_volume(
         sample, tracers, radius, period=[1, 1, 1], norm_by_mean_density=True)

--- a/halotools/mock_observables/pair_counters/rectangular_mesh.py
+++ b/halotools/mock_observables/pair_counters/rectangular_mesh.py
@@ -120,10 +120,10 @@ class RectangularMesh(object):
 
         Let's create some fake data to demonstrate the mesh structure:
 
-        >>> np.random.seed(43)
-        >>> x = np.random.uniform(0, Lbox, Npts)
-        >>> y = np.random.uniform(0, Lbox, Npts)
-        >>> z = np.random.uniform(0, Lbox, Npts)
+        >>> from astropy.utils.misc import NumpyRNGContext
+        >>> fixed_seed = 43
+        >>> with NumpyRNGContext(fixed_seed): pos = np.random.uniform(0, Lbox, 3*Npts).reshape(Npts, 3)
+        >>> x, y, z = pos[:,0], pos[:,1], pos[:,2]
         >>> mesh = RectangularMesh(x, y, z, xperiod, yperiod, zperiod, approx_xcell_size, approx_ycell_size, approx_zcell_size)
 
         Since we used approximate cell sizes *Lbox/10* that

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_npairs_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_npairs_3d.py
@@ -1,8 +1,10 @@
-#!/usr/bin/env python
+"""
+"""
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..pairs import wnpairs as pure_python_weighted_pairs
 from ..marked_npairs_3d import marked_npairs_3d, _func_signature_int_from_wfunc
@@ -17,6 +19,8 @@ error_msg = ("\nThe `test_marked_npairs_wfuncs_behavior` function performs \n"
     "One such check failed.\n")
 
 __all__ = ('test_marked_npairs_3d_periodic', )
+
+fixed_seed = 43
 
 
 def retrieve_mock_data(Npts, Npts2, Lbox):
@@ -43,8 +47,9 @@ def test_marked_npairs_3d_periodic():
     Function tests marked_npairs with periodic boundary conditions.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
-    ran_weights1 = np.random.random((Npts, 1))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+        ran_weights1 = np.random.random((Npts, 1))
 
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.array([0.0, 0.1, 0.2, 0.3])
@@ -64,8 +69,9 @@ def test_marked_npairs_parallelization():
     """
 
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
-    ran_weights1 = np.random.random((Npts, 1))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+        ran_weights1 = np.random.random((Npts, 1))
 
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.array([0.0, 0.1, 0.2, 0.3])
@@ -91,8 +97,9 @@ def test_marked_npairs_nonperiodic():
     """
 
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
-    ran_weights1 = np.random.random((Npts, 1))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+        ran_weights1 = np.random.random((Npts, 1))
 
     rbins = np.array([0.0, 0.1, 0.2, 0.3])
 
@@ -112,7 +119,8 @@ def test_marked_npairs_3d_wfuncs_signatures():
     Loop over all wfuncs and ensure that the wfunc signature is handled correctly.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     rbins = np.array([0.0, 0.1, 0.2, 0.3])
     rmax = rbins.max()
     period = np.array([1.0, 1.0, 1.0])
@@ -130,14 +138,16 @@ def test_marked_npairs_3d_wfuncs_signatures():
     # Now loop over all all available weight_func_id indices
     for wfunc_index in range(1, num_wfuncs):
         signature = _func_signature_int_from_wfunc(wfunc_index)
-        weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
+        with NumpyRNGContext(fixed_seed):
+            weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
         result = marked_npairs_3d(random_sample, random_sample, rbins, period=period,
             weights1=weights, weights2=weights, weight_func_id=wfunc_index,
             approx_cell1_size=[rmax, rmax, rmax])
 
         with pytest.raises(HalotoolsError):
             signature = _func_signature_int_from_wfunc(wfunc_index) + 1
-            weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
+            with NumpyRNGContext(fixed_seed):
+                weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
             result = marked_npairs_3d(random_sample, random_sample, rbins, period=period,
                 weights1=weights, weights2=weights, weight_func_id=wfunc_index)
 

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_marked_npairs_xy_z.py
@@ -1,8 +1,10 @@
-#!/usr/bin/env python
+"""
+"""
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..pairs import xy_z_wnpairs as pure_python_weighted_pairs
 from ..marked_npairs_xy_z import marked_npairs_xy_z
@@ -18,6 +20,8 @@ error_msg = ("\nThe `test_marked_npairs_wfuncs_behavior` function performs \n"
     "One such check failed.\n")
 
 __all__ = ('test_marked_npairs_xy_z_periodic', )
+
+fixed_seed = 43
 
 
 def retrieve_mock_data(Npts, Npts2, Lbox):
@@ -44,8 +48,9 @@ def test_marked_npairs_xy_z_periodic():
     Function tests marked_npairs with periodic boundary conditions.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
-    ran_weights1 = np.random.random((Npts, 1))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+        ran_weights1 = np.random.random((Npts, 1))
 
     period = np.array([1.0, 1.0, 1.0])
     rp_bins = np.array([0.0, 0.1, 0.2, 0.3])
@@ -67,8 +72,9 @@ def test_marked_npairs_xy_z_nonperiodic():
     """
 
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
-    ran_weights1 = np.random.random((Npts, 1))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+        ran_weights1 = np.random.random((Npts, 1))
 
     rp_bins = np.array([0.0, 0.1, 0.2, 0.3])
     pi_bins = np.array([0, 0.15])
@@ -89,8 +95,9 @@ def test_marked_npairs_parallelization():
     """
 
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
-    ran_weights1 = np.random.random((Npts, 1))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+        ran_weights1 = np.random.random((Npts, 1))
 
     period = np.array([1.0, 1.0, 1.0])
     rp_bins = np.array([0.0, 0.1, 0.2, 0.3])
@@ -118,7 +125,8 @@ def test_marked_npairs_3d_wfuncs_signatures():
     Loop over all wfuncs and ensure that the wfunc signature is handled correctly.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     rp_bins = np.array([0.0, 0.1, 0.2, 0.3])
     pi_bins = np.array([0, 0.15])
     rmax = rp_bins.max()
@@ -137,14 +145,16 @@ def test_marked_npairs_3d_wfuncs_signatures():
     # Now loop over all all available weight_func_id indices
     for wfunc_index in range(1, num_wfuncs):
         signature = _func_signature_int_from_wfunc(wfunc_index)
-        weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
+        with NumpyRNGContext(fixed_seed):
+            weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
         result = marked_npairs_xy_z(random_sample, random_sample, rp_bins, pi_bins,
             period=period, weights1=weights, weights2=weights, weight_func_id=wfunc_index,
             approx_cell1_size=[rmax, rmax, rmax])
 
         with pytest.raises(HalotoolsError):
             signature = _func_signature_int_from_wfunc(wfunc_index) + 1
-            weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
+            with NumpyRNGContext(fixed_seed):
+                weights = np.random.random(Npts*signature).reshape(Npts, signature) - 0.5
             result = marked_npairs_xy_z(random_sample, random_sample, rp_bins, pi_bins,
                 period=period, weights1=weights, weights2=weights, weight_func_id=wfunc_index)
 

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_3d.py
@@ -24,8 +24,8 @@ def test_rectangular_mesh_pairs_tight_locus1():
     In this test, PBCs are irrelevant
     """
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rbins = np.array((0.05, 0.15, 0.3))
     result = npairs_3d(data1, data2, rbins, period=1)
@@ -39,8 +39,8 @@ def test_rectangular_mesh_pairs_tight_locus2():
     In this test, PBCs are important.
     """
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.05)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.95)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.05, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.95, seed=fixed_seed)
 
     rbins = np.array((0.05, 0.15, 0.3))
     result = npairs_3d(data1, data2, rbins, period=1)
@@ -54,8 +54,8 @@ def test_rectangular_mesh_pairs_tight_locus3():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -70,8 +70,8 @@ def test_rectangular_mesh_pairs_tight_locus4():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -86,8 +86,8 @@ def test_rectangular_mesh_pairs_tight_locus5():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -102,8 +102,8 @@ def test_rectangular_mesh_pairs_tight_locus6():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -118,8 +118,8 @@ def test_rectangular_mesh_pairs_tight_locus7():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -136,8 +136,8 @@ def test_rectangular_mesh_pairs_tight_locus8():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -153,8 +153,8 @@ def test_rectangular_mesh_pairs_tight_locus9():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 200
-    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25)
+    points1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    points2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.25, seed=fixed_seed)
     rbins = np.array([0.1, 0.2, 0.3])
     correct_result = np.array([0, npts1*npts2, npts1*npts2])
 
@@ -254,8 +254,8 @@ def test_npairs_brute_force_nonperiodic():
 
 def test_sensible_num_threads():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rbins = np.array((0.05, 0.15, 0.3))
     with pytest.raises(ValueError) as err:
@@ -267,8 +267,8 @@ def test_sensible_num_threads():
 
 def test_sensible_rbins():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rbins = 0.1
     with pytest.raises(ValueError) as err:
@@ -279,8 +279,8 @@ def test_sensible_rbins():
 
 def test_sensible_period():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
     rbins = np.array((0.05, 0.15, 0.3))
 
     with pytest.raises(ValueError) as err:

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_3d.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function,
-    unicode_literals)
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..npairs_3d import npairs_3d
 from ..pairs import npairs as pure_python_brute_force_npairs_3d
@@ -12,6 +13,8 @@ from ...tests.cf_helpers import generate_locus_of_3d_points
 from ...tests.cf_helpers import generate_3d_regular_mesh
 
 __all__ = ('test_rectangular_mesh_pairs_tight_locus1', )
+
+fixed_seed = 43
 
 
 def test_rectangular_mesh_pairs_tight_locus1():
@@ -210,7 +213,8 @@ def test_npairs_brute_force_periodic():
     Function tests npairs with periodic boundary conditions.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.array([0.001, 0.1, 0.2, 0.3])
 
@@ -232,7 +236,8 @@ def test_npairs_brute_force_nonperiodic():
     """
 
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     rbins = np.array([0.001, 0.1, 0.2, 0.3])
 
     result = npairs_3d(random_sample, random_sample, rbins, period=None)

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_jackknife_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_jackknife_3d.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 
@@ -9,14 +9,18 @@ from ..npairs_jackknife_3d import npairs_jackknife_3d
 # load comparison simple pair counters
 
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
+
 slow = pytest.mark.slow
 
 __all__ = ('test_npairs_jackknife_3d_periodic', 'test_npairs_jackknife_3d_nonperiodic')
 
+fixed_seed = 43
+
 # set up random points to test pair counters
-np.random.seed(1)
 Npts = 1000
-random_sample = np.random.random((Npts, 3))
+with NumpyRNGContext(fixed_seed):
+    random_sample = np.random.random((Npts, 3))
 period = np.array([1.0, 1.0, 1.0])
 num_threads = 2
 
@@ -57,7 +61,8 @@ def test_npairs_jackknife_3d_periodic():
     #define the jackknife sample labels
     Npts = len(random_sample)
     N_jsamples=10
-    jtags1 = np.sort(np.random.randint(1, N_jsamples+1, size=Npts))
+    with NumpyRNGContext(fixed_seed):
+        jtags1 = np.sort(np.random.randint(1, N_jsamples+1, size=Npts))
 
     #define weights
     weights1 = np.random.random(Npts)
@@ -90,10 +95,10 @@ def test_npairs_jackknife_3d_nonperiodic():
     #define the jackknife sample labels
     Npts = len(random_sample)
     N_jsamples=10
-    jtags1 = np.sort(np.random.randint(1, N_jsamples+1, size=Npts))
-
-    #define weights
-    weights1 = np.random.random(Npts)
+    with NumpyRNGContext(fixed_seed):
+        jtags1 = np.sort(np.random.randint(1, N_jsamples+1, size=Npts))
+        #define weights
+        weights1 = np.random.random(Npts)
 
     result = npairs_jackknife_3d(random_sample, random_sample, rbins, period=None,
         jtags1=jtags1, jtags2=jtags1, N_samples=10,

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_projected.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_projected.py
@@ -24,8 +24,8 @@ def test_rectangular_mesh_pairs_tight_locus_xy1():
     In this test, PBCs are irrelevant
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = np.max(rp_bins)
@@ -41,8 +41,8 @@ def test_rectangular_mesh_pairs_tight_locus_z1():
     In this test, PBCs are irrelevant
     """
     npts1, npts2 = 100, 110
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
 
@@ -62,8 +62,8 @@ def test_rectangular_mesh_pairs_tight_locus_xy2():
     In this test, PBCs are important.
     """
     npts1, npts2 = 100, 300
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.05, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.95, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.05, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.95, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = 0.1
@@ -82,8 +82,8 @@ def test_rectangular_mesh_pairs_tight_locus_z2():
     In this test, PBCs are important.
     """
     npts1, npts2 = 100, 101
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.05)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.95)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.05, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.95, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
 
@@ -112,8 +112,8 @@ def test_rectangular_mesh_pairs_tight_locus_cell1_sizes():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = np.max(rp_bins)
@@ -146,8 +146,8 @@ def test_rectangular_mesh_pairs_tight_locus_cell2_sizes():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = np.max(rp_bins)
@@ -180,8 +180,8 @@ def test_rectangular_mesh_pairs_tight_locus_cell1_cell2_sizes():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = np.max(rp_bins)
@@ -343,8 +343,8 @@ def test_npairs_projected_brute_force_non_periodic():
 
 def test_sensible_num_threads():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = 0.1
@@ -358,8 +358,8 @@ def test_sensible_num_threads():
 
 def test_sensible_rp_bins():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rp_bins = 0.1
     pi_max = 0.1
@@ -372,8 +372,8 @@ def test_sensible_rp_bins():
 
 def test_sensible_period():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = 0.1
 

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_projected.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_projected.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function,
-    unicode_literals)
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..npairs_projected import npairs_projected
 from ..pairs import xy_z_npairs as pure_python_brute_force_npairs_projected
@@ -12,6 +13,8 @@ from ...tests.cf_helpers import generate_locus_of_3d_points
 from ...tests.cf_helpers import generate_3d_regular_mesh
 
 __all__ = ('test_rectangular_mesh_pairs_tight_locus_xy1', )
+
+fixed_seed = 43
 
 
 def test_rectangular_mesh_pairs_tight_locus_xy1():
@@ -294,7 +297,8 @@ def test_npairs_projected_brute_force_periodic():
     Function tests npairs with periodic boundary conditions.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     period = np.array([1.0, 1.0, 1.0])
     rp_bins = np.array([0.001, 0.1, 0.2, 0.3])
     pi_max = 0.1
@@ -318,7 +322,8 @@ def test_npairs_projected_brute_force_non_periodic():
     Function tests npairs with periodic boundary conditions.
     """
     Npts = 1000
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     rp_bins = np.array([0.001, 0.1, 0.2, 0.3])
     pi_max = 0.1
     pi_bins = [0, pi_max]

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_s_mu.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_s_mu.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+"""
+"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
@@ -9,14 +10,17 @@ from ....mock_observables import npairs_3d
 # load comparison simple pair counters
 
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
+
 slow = pytest.mark.slow
+fixed_seed = 43
 
 __all__ = ('test_npairs_s_mu_periodic', 'test_npairs_s_mu_nonperiodic')
 
 # set up random points to test pair counters
-np.random.seed(1)
 Npts = 1000
-random_sample = np.random.random((Npts, 3))
+with NumpyRNGContext(fixed_seed):
+    random_sample = np.random.random((Npts, 3))
 period = np.array([1.0, 1.0, 1.0])
 num_threads = 2
 

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_xy_z.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function,
-    unicode_literals)
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..npairs_xy_z import npairs_xy_z
 from ..pairs import xy_z_npairs as pure_python_brute_force_npairs_xy_z
@@ -12,6 +13,8 @@ from ...tests.cf_helpers import generate_locus_of_3d_points
 from ...tests.cf_helpers import generate_3d_regular_mesh
 
 __all__ = ('test_npairs_xy_z_tight_locus1', )
+
+fixed_seed = 43
 
 
 def test_npairs_xy_z_tight_locus1():
@@ -228,8 +231,9 @@ def test_npairs_xy_z_brute_force_periodic():
     test npairs_xy_z with periodic boundary conditions.
     """
     npts1, npts2 = 100, 90
-    data1 = np.random.random((npts1, 3))
-    data2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        data1 = np.random.random((npts1, 3))
+        data2 = np.random.random((npts2, 3))
 
     rp_bins = np.arange(0, 0.31, 0.1)
     pi_bins = np.arange(0, 0.31, 0.1)
@@ -246,8 +250,9 @@ def test_npairs_xy_z_brute_force_non_periodic():
     test npairs_xy_z with periodic boundary conditions.
     """
     npts1, npts2 = 100, 90
-    data1 = np.random.random((npts1, 3))
-    data2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        data1 = np.random.random((npts1, 3))
+        data2 = np.random.random((npts2, 3))
 
     rp_bins = np.arange(0, 0.31, 0.1)
     pi_bins = np.arange(0, 0.31, 0.1)

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_xy_z.py
@@ -25,7 +25,7 @@ def test_npairs_xy_z_tight_locus1():
     """
     npts1, npts2 = 100, 90
     data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.105, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_bins = np.array([0, 0.15])

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_npairs_xy_z.py
@@ -24,8 +24,8 @@ def test_npairs_xy_z_tight_locus1():
     In this test, PBCs are irrelevant
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_bins = np.array([0, 0.15])
@@ -42,8 +42,8 @@ def test_rectangular_mesh_pairs_tight_locus2():
     In this test, PBCs are important.
     """
     npts1, npts2 = 100, 300
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.05, zc=0.05)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.95, zc=0.95)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.05, zc=0.05, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.95, zc=0.95, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.25, 0.3))
     pi_bins = np.array([0.05, 0.15])
@@ -65,8 +65,8 @@ def test_npairs_xy_z_tight_locus_cell1_sizes():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_bins = np.array([0, 0.3])
@@ -99,8 +99,8 @@ def test_npairs_xy_z_tight_locus_cell2_sizes():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_bins = np.array([0, 0.3])
@@ -133,8 +133,8 @@ def test_npairs_xy_z_tight_locus_cell1_cell2_sizes():
     For this test, PBCs have no impact.
     """
     npts1, npts2 = 100, 90
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.2, zc=0.1, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_bins = np.array([0, 0.3])
@@ -266,8 +266,8 @@ def test_npairs_xy_z_brute_force_non_periodic():
 
 def test_sensible_num_threads():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = 0.1
@@ -282,8 +282,8 @@ def test_sensible_num_threads():
 
 def test_sensible_rp_bins():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
 
     rp_bins = 0.1
     pi_max = 0.1
@@ -297,8 +297,8 @@ def test_sensible_rp_bins():
 
 def test_sensible_period():
     npts1, npts2 = 100, 100
-    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1)
-    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2)
+    data1 = generate_locus_of_3d_points(npts1, xc=0.1, yc=0.1, zc=0.1, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(npts2, xc=0.1, yc=0.1, zc=0.2, seed=fixed_seed)
     rp_bins = np.array((0.05, 0.15, 0.3))
     pi_max = 0.1
     pi_bins = np.array([0, pi_max])

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_pairwise_distance_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_pairwise_distance_3d.py
@@ -103,8 +103,8 @@ def test_pairwise_distance_3d_periodic_tight_locus1():
     #tigh locus
     Npts1 = 10
     Npts2 = 10
-    data1 = generate_locus_of_3d_points(Npts1, xc=0.05, yc=0.05, zc=0.05)
-    data2 = generate_locus_of_3d_points(Npts2, xc=0.95, yc=0.95, zc=0.95)
+    data1 = generate_locus_of_3d_points(Npts1, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(Npts2, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     period = 1.0
 
     #should be no connections
@@ -129,8 +129,8 @@ def test_pairwise_distance_3d_nonperiodic_tight_locus1():
     #tight locus
     Npts1 = 10
     Npts2 = 10
-    data1 = generate_locus_of_3d_points(Npts1, xc=0.05, yc=0.05, zc=0.05)
-    data2 = generate_locus_of_3d_points(Npts2, xc=0.95, yc=0.95, zc=0.95)
+    data1 = generate_locus_of_3d_points(Npts1, xc=0.05, yc=0.05, zc=0.05, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(Npts2, xc=0.95, yc=0.95, zc=0.95, seed=fixed_seed)
     period = 1.0
 
     #should be no connections
@@ -155,8 +155,8 @@ def test_pairwise_distance_3d_nonperiodic_tight_locus2():
     #tight locus
     Npts1 = 10
     Npts2 = 10
-    data1 = generate_locus_of_3d_points(Npts1, xc=0.5, yc=0.5, zc=0.5)
-    data2 = generate_locus_of_3d_points(Npts2, xc=0.6, yc=0.6, zc=0.6)
+    data1 = generate_locus_of_3d_points(Npts1, xc=0.5, yc=0.5, zc=0.5, seed=fixed_seed)
+    data2 = generate_locus_of_3d_points(Npts2, xc=0.6, yc=0.6, zc=0.6, seed=fixed_seed)
     period = 1.0
 
     #should be no connections

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_pairwise_distance_3d.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_pairwise_distance_3d.py
@@ -1,6 +1,6 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 
@@ -84,7 +84,8 @@ def test_pairwise_distance_3d_nonperiodic_random_1():
     """
     #random points
     Npts = 10
-    random_sample = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
     period = 1.0
 
     rmax=10.0

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_rectangular_mesh.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_rectangular_mesh.py
@@ -107,8 +107,8 @@ def test_mesh_variations():
         xc1, yc1, zc1 = 0.1*xperiod, 0.1*yperiod, 0.1*zperiod
         zc_multiplier = options[1]
         zc2 = zc_multiplier*period
-        points1 = generate_locus_of_3d_points(npts1, xc=xc1, yc=yc1, zc=zc1)
-        points2 = generate_locus_of_3d_points(npts2, xc=xc1, yc=yc1, zc=zc2)
+        points1 = generate_locus_of_3d_points(npts1, xc=xc1, yc=yc1, zc=zc1, seed=fixed_seed)
+        points2 = generate_locus_of_3d_points(npts2, xc=xc1, yc=yc1, zc=zc2, seed=fixed_seed)
         approx_x1cell_size, approx_y1cell_size, approx_z1cell_size = 3*[options[2]]
         approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = 3*[options[3]]
         search_xlength, search_ylength, search_zlength = 3*[options[4]]

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_rectangular_mesh.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_rectangular_mesh.py
@@ -1,15 +1,19 @@
-#!/usr/bin/env python
+"""
+"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import itertools
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..rectangular_mesh import RectangularDoubleMesh, sample1_cell_size
 
 from ...tests.cf_helpers import generate_locus_of_3d_points
 
 __all__ = ('test_mesh_variations', )
+
+fixed_seed = 43
 
 
 def enforce_cell_size_divide_box_size(mesh):
@@ -140,8 +144,9 @@ def test_sample1_cell_size():
 
 
 def test_search_length_enforcement():
-    points1 = np.random.random((100, 3))
-    points2 = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        points1 = np.random.random((100, 3))
+        points2 = np.random.random((100, 3))
     approx_x1cell_size, approx_y1cell_size, approx_z1cell_size = 0.1, 0.1, 0.1
     approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = 0.1, 0.1, 0.1
     search_xlength, search_ylength, search_zlength = 0.5, 0.5, 0.5

--- a/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
@@ -22,7 +22,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
         velocities2=None, period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
-        approx_cell1_size=None, approx_cell2_size=None):
+        approx_cell1_size=None, approx_cell2_size=None, seed=None):
     """
     Calculate the pairwise line-of-sight (LOS) velocity dispersion (PVD), :math:`\\sigma_{z12}(r_p)`.
 
@@ -67,6 +67,10 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
         Defines maximum size of the sample that will be passed to the pair counter.
         If sample size exeeds max_sample_size, the sample will be randomly down-sampled
         such that the subsample is equal to max_sample_size.
+
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
 
     Returns
     -------
@@ -139,7 +143,7 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
     #process input arguments
     function_args = (sample1, velocities1, sample2, velocities2, period,
         do_auto, do_cross, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size)
+        approx_cell1_size, approx_cell2_size, seed)
     sample1, velocities1, sample2, velocities2,\
         period, do_auto, do_cross,\
         num_threads, _sample1_is_sample2, PBCs =\

--- a/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
@@ -19,11 +19,10 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 
 
 def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
-                            sample2=None, velocities2=None,
-                            period=None, do_auto=True, do_cross=True,
-                            num_threads=1, max_sample_size=int(1e6),
-                            approx_cell1_size=None,
-                            approx_cell2_size=None):
+        sample2=None, velocities2=None,
+        period=None, do_auto=True, do_cross=True,
+        num_threads=1, max_sample_size=int(1e6),
+        approx_cell1_size=None, approx_cell2_size=None, seed=None):
     """
     Calculate the mean pairwise line-of-sight (LOS) velocity
     as a function of projected separation, :math:`\\bar{v}_{z,12}(r_p)`.
@@ -84,6 +83,10 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
         Analogous to ``approx_cell1_size``, but for `sample2`.  See comments for
         ``approx_cell1_size`` for details.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     vz_12 : numpy.array
@@ -137,7 +140,7 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
     """
 
     function_args = (sample1, velocities1, sample2, velocities2, period,
-        do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size, seed)
 
     sample1, velocities1, sample2, velocities2, period, do_auto, do_cross,\
         num_threads, _sample1_is_sample2, PBCs = _pairwise_velocity_stats_process_args(*function_args)

--- a/halotools/mock_observables/pairwise_velocities/mean_radial_velocity_vs_r.py
+++ b/halotools/mock_observables/pairwise_velocities/mean_radial_velocity_vs_r.py
@@ -12,8 +12,6 @@ from .pairwise_velocities_helpers import _pairwise_velocity_stats_process_args
 
 from .velocity_marked_npairs_3d import velocity_marked_npairs_3d
 
-from ..mock_observables_helpers import get_separation_bins_array
-
 __all__ = ('mean_radial_velocity_vs_r', )
 __author__ = ['Duncan Campbell']
 
@@ -24,7 +22,7 @@ def mean_radial_velocity_vs_r(sample1, velocities1, rbins,
         sample2=None, velocities2=None,
         period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
-        approx_cell1_size=None, approx_cell2_size=None):
+        approx_cell1_size=None, approx_cell2_size=None, seed=None):
     """
     Calculate the mean pairwise velocity, :math:`\\bar{v}_{12}(r)`.
 
@@ -86,6 +84,10 @@ def mean_radial_velocity_vs_r(sample1, velocities1, rbins,
         Analogous to ``approx_cell1_size``, but for `sample2`.  See comments for
         ``approx_cell1_size`` for details.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     v_12 : numpy.array
@@ -146,7 +148,7 @@ def mean_radial_velocity_vs_r(sample1, velocities1, rbins,
     """
 
     function_args = (sample1, velocities1, sample2, velocities2, period,
-        do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size, seed)
 
     sample1, velocities1, sample2, velocities2, period, do_auto, do_cross,\
         num_threads, _sample1_is_sample2, PBCs = _pairwise_velocity_stats_process_args(*function_args)

--- a/halotools/mock_observables/pairwise_velocities/pairwise_velocities_helpers.py
+++ b/halotools/mock_observables/pairwise_velocities/pairwise_velocities_helpers.py
@@ -2,25 +2,24 @@
 Helper functions used by modules in `~halotools.mock_observables.pairwise_velocities`
 to process arguments and raise appropriate exceptions.
 """
-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 from warnings import warn
-from multiprocessing import cpu_count
+from astropy.utils.misc import NumpyRNGContext
 
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
-    get_separation_bins_array, get_period, get_num_threads)
+    get_period, get_num_threads)
 
 from ...custom_exceptions import HalotoolsError
-from ...utils.array_utils import convert_to_ndarray, array_is_monotonic
+from ...utils.array_utils import array_is_monotonic
 
 __all__ = ['_pairwise_velocity_stats_process_args', '_process_radial_bins', '_process_rp_bins']
 __author__ = ['Duncan Campbell']
 
 
 def _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size):
+        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.pairwise_velocity_stats`.
@@ -54,7 +53,8 @@ def _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocit
     if _sample1_is_sample2 is True:
         if (len(sample1) > max_sample_size):
             inds = np.arange(0, len(sample1))
-            np.random.shuffle(inds)
+            with NumpyRNGContext(seed):
+                np.random.shuffle(inds)
             inds = inds[0:max_sample_size]
             sample1 = sample1[inds]
             velocities1 = velocities1[inds]
@@ -62,14 +62,16 @@ def _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocit
     else:
         if len(sample1) > max_sample_size:
             inds = np.arange(0, len(sample1))
-            np.random.shuffle(inds)
+            with NumpyRNGContext(seed):
+                np.random.shuffle(inds)
             inds = inds[0:max_sample_size]
             sample1 = sample1[inds]
             velocities1 = velocities1[inds]
             print('\n downsampling `sample1`...')
         if len(sample2) > max_sample_size:
             inds = np.arange(0, len(sample2))
-            np.random.shuffle(inds)
+            with NumpyRNGContext(seed):
+                np.random.shuffle(inds)
             inds = inds[0:max_sample_size]
             sample2 = sample2[inds]
             velocities2 = velocities2[inds]

--- a/halotools/mock_observables/pairwise_velocities/radial_pvd_vs_r.py
+++ b/halotools/mock_observables/pairwise_velocities/radial_pvd_vs_r.py
@@ -21,7 +21,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 def radial_pvd_vs_r(sample1, velocities1, rbins, sample2=None,
         velocities2=None, period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
-        approx_cell1_size=None, approx_cell2_size=None):
+        approx_cell1_size=None, approx_cell2_size=None, seed=None):
     """
     Calculate the pairwise velocity dispersion (PVD), :math:`\\sigma_{12}(r)`.
 
@@ -65,6 +65,10 @@ def radial_pvd_vs_r(sample1, velocities1, rbins, sample2=None,
         Defines maximum size of the sample that will be passed to the pair counter.
         If sample size exeeds max_sample_size, the sample will be randomly down-sampled
         such that the subsample is equal to max_sample_size.
+
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
 
     Returns
     -------
@@ -124,7 +128,7 @@ def radial_pvd_vs_r(sample1, velocities1, rbins, sample2=None,
     #process input arguments
     function_args = (sample1, velocities1, sample2, velocities2, period,
         do_auto, do_cross, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size)
+        approx_cell1_size, approx_cell2_size, seed)
     sample1, velocities1, sample2, velocities2,\
         period, do_auto, do_cross,\
         num_threads, _sample1_is_sample2, PBCs =\

--- a/halotools/mock_observables/pairwise_velocities/tests/test_los_pvd_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/tests/test_los_pvd_vs_rp.py
@@ -1,5 +1,7 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function)
+"""
+"""
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 from astropy.tests.helper import pytest
 from astropy.utils.misc import NumpyRNGContext

--- a/halotools/mock_observables/pairwise_velocities/tests/test_pairwise_velocity_helpers.py
+++ b/halotools/mock_observables/pairwise_velocities/tests/test_pairwise_velocity_helpers.py
@@ -29,7 +29,8 @@ def test_pairwise_velocity_stats_process_args1():
 
     with pytest.raises(ValueError) as err:
         result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-            period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+            period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+            fixed_seed)
     substr = "Both ``do_auto`` and ``do_cross`` have been set to False"
     assert substr in err.value.args[0]
 
@@ -50,7 +51,8 @@ def test_pairwise_velocity_stats_process_args2():
         velocities2 = np.random.random((10, 3))
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, None, None,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
     assert (do_auto is True) & (do_cross is False)
@@ -72,7 +74,8 @@ def test_pairwise_velocity_stats_process_args3():
         velocities2 = np.random.random((10, 3))
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
 
@@ -95,7 +98,8 @@ def test_pairwise_velocity_stats_process_args4():
     max_sample_size = 5
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
     assert _sample1_is_sample2 is False
@@ -121,7 +125,8 @@ def test_pairwise_velocity_stats_process_args5():
     max_sample_size = 5
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, None, None,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
 
@@ -140,7 +145,8 @@ def test_pairwise_velocity_stats_process_args6():
         velocities1 = np.random.random((10, 3))
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample1, velocities1,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size)
+        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
 

--- a/halotools/mock_observables/pairwise_velocities/tests/test_pairwise_velocity_stats.py
+++ b/halotools/mock_observables/pairwise_velocities/tests/test_pairwise_velocity_stats.py
@@ -4,25 +4,26 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..los_pvd_vs_rp import los_pvd_vs_rp
 from ..mean_los_velocity_vs_rp import mean_los_velocity_vs_rp
-from ...tests.cf_helpers import generate_locus_of_3d_points
 
 __all__ = ('test_mean_los_velocity_vs_rp_auto_consistency', )
 
+fixed_seed = 43
 
 @pytest.mark.slow
 def test_mean_los_velocity_vs_rp_auto_consistency():
-    np.random.seed(43)
 
     npts = 200
-    sample1 = np.random.rand(npts, 3)
-    velocities1 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
-    sample2 = np.random.rand(npts, 3)
-    velocities2 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.rand(npts, 3)
+        velocities1 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
+        sample2 = np.random.rand(npts, 3)
+        velocities2 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
 
     rbins = np.linspace(0, 0.3, 10)
     pi_max = 0.2
@@ -38,15 +39,15 @@ def test_mean_los_velocity_vs_rp_auto_consistency():
 
 @pytest.mark.slow
 def test_mean_los_velocity_vs_rp_cross_consistency():
-    np.random.seed(43)
 
     npts = 200
-    sample1 = np.random.rand(npts, 3)
-    velocities1 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
-    sample2 = np.random.rand(npts, 3)
-    velocities2 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.rand(npts, 3)
+        velocities1 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
+        sample2 = np.random.rand(npts, 3)
+        velocities2 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
 
     rbins = np.linspace(0, 0.3, 10)
     pi_max = 0.3
@@ -61,15 +62,15 @@ def test_mean_los_velocity_vs_rp_cross_consistency():
 
 @pytest.mark.slow
 def test_los_pvd_vs_rp_auto_consistency():
-    np.random.seed(43)
 
     npts = 200
-    sample1 = np.random.rand(npts, 3)
-    velocities1 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
-    sample2 = np.random.rand(npts, 3)
-    velocities2 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.rand(npts, 3)
+        velocities1 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
+        sample2 = np.random.rand(npts, 3)
+        velocities2 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
 
     rbins = np.linspace(0, 0.3, 10)
     pi_max = 0.2
@@ -85,15 +86,15 @@ def test_los_pvd_vs_rp_auto_consistency():
 
 @pytest.mark.slow
 def test_los_pvd_vs_rp_cross_consistency():
-    np.random.seed(43)
 
     npts = 200
-    sample1 = np.random.rand(npts, 3)
-    velocities1 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
-    sample2 = np.random.rand(npts, 3)
-    velocities2 = np.random.normal(
-        loc=0, scale=100, size=npts*3).reshape((npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.rand(npts, 3)
+        velocities1 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
+        sample2 = np.random.rand(npts, 3)
+        velocities2 = np.random.normal(
+            loc=0, scale=100, size=npts*3).reshape((npts, 3))
 
     rbins = np.linspace(0, 0.3, 10)
     pi_max = 0.3

--- a/halotools/mock_observables/radial_profiles/tests/test_radial_profile_3d.py
+++ b/halotools/mock_observables/radial_profiles/tests/test_radial_profile_3d.py
@@ -1,6 +1,5 @@
 """ Module providing unit-testing of `~halotools.mock_observables.radial_profile_3d`.
 """
-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
@@ -190,8 +189,9 @@ def test_args_processing1a():
 
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.ones(len(sample2))
     dummy_rbins = np.array([0.0001, 0.0002, 0.0003])
@@ -208,8 +208,9 @@ def test_args_processing1b():
 
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.ones(len(sample2))
     dummy_rbins = np.array([0.0001, 0.0002, 0.0003])
@@ -227,8 +228,9 @@ def test_args_processing1c():
 
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.ones(len(sample2))
     dummy_rbins = np.array([0.0001, 0.0002, 0.0003])
@@ -246,8 +248,9 @@ def test_args_processing1d():
 
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.ones(len(sample2))
     dummy_rbins = np.array([0.0001, 0.0002, 0.0003])
@@ -265,8 +268,9 @@ def test_args_processing1e():
 
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.ones(len(sample2))
     dummy_rbins = np.array([0.000, 0.0002, 0.0003])
@@ -284,8 +288,9 @@ def test_args_processing2():
     have the same number of elements.
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.ones(len(sample2))
     rbins_normalized = np.array([0.0001, 0.0002, 0.0003])
@@ -302,8 +307,9 @@ def test_args_processing3():
     have the same number of elements.
     """
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.arange(5)
     rbins_absolute = np.array([0.0001, 0.0002, 0.0003])
@@ -317,8 +323,9 @@ def test_args_processing3():
 def test_enforce_search_length():
 
     npts1, npts2 = 100, 200
-    sample1 = np.random.random((npts1, 3))
-    sample2 = np.random.random((npts2, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
 
     quantity = np.zeros(npts2)
     rbins_absolute = np.array([0.0001, 0.0002, 0.4])

--- a/halotools/mock_observables/tests/cf_helpers.py
+++ b/halotools/mock_observables/tests/cf_helpers.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function)
+"""
+"""
+from __future__ import absolute_import, division, print_function
 import numpy as np
 
 from astropy.utils.misc import NumpyRNGContext

--- a/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
+++ b/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
@@ -1,7 +1,7 @@
 """ Module providing unit-testing for the functions in
 `~halotools.mock_observables.catalog_analysis_helpers` module.
 """
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from unittest import TestCase
 

--- a/halotools/mock_observables/tests/test_mock_survey.py
+++ b/halotools/mock_observables/tests/test_mock_survey.py
@@ -5,15 +5,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..mock_survey import ra_dec_z
 
 __all__ = ('test_ra_dec_z', )
 
+fixed_seed = 43
+
 #create some toy data to test functions
 N=100
-x = np.random.random((N, 3))
-v = np.random.random((N, 3))*0.1
+with NumpyRNGContext(fixed_seed):
+    x = np.random.random((N, 3))
+    v = np.random.random((N, 3))*0.1
 period = np.array([1.0, 1.0, 1.0])
 
 

--- a/halotools/mock_observables/two_point_clustering/clustering_helpers.py
+++ b/halotools/mock_observables/two_point_clustering/clustering_helpers.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from warnings import warn
+from astropy.utils.misc import NumpyRNGContext
 
 from ..mock_observables_helpers import enforce_sample_has_correct_shape
 
@@ -96,7 +97,7 @@ def process_optional_input_sample2(sample1, sample2, do_cross):
 
 
 def downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size):
+        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=None):
     """ Function used to downsample sample1 and/or sample2
     if either samples exceed max_sample_size
 
@@ -110,6 +111,10 @@ def downsample_inputs_exceeding_max_sample_size(
 
     max_sample_size : int
 
+    seed : int, optional
+        Random number seed used to randomly downsample data.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     ---------
     sample1 : array_like
@@ -120,7 +125,8 @@ def downsample_inputs_exceeding_max_sample_size(
     if _sample1_is_sample2 is True:
         if (len(sample1) > max_sample_size):
             inds = np.arange(0, len(sample1))
-            np.random.shuffle(inds)
+            with NumpyRNGContext(seed):
+                np.random.shuffle(inds)
             inds = inds[0:max_sample_size]
             sample1 = sample1[inds]
             msg = ("\n `sample1` exceeds `max_sample_size` \n"
@@ -131,7 +137,8 @@ def downsample_inputs_exceeding_max_sample_size(
     else:
         if len(sample1) > max_sample_size:
             inds = np.arange(0, len(sample1))
-            np.random.shuffle(inds)
+            with NumpyRNGContext(seed):
+                np.random.shuffle(inds)
             inds = inds[0:max_sample_size]
             sample1 = sample1[inds]
             msg = ("\n `sample1` exceeds `max_sample_size` \n"
@@ -141,7 +148,8 @@ def downsample_inputs_exceeding_max_sample_size(
             pass
         if len(sample2) > max_sample_size:
             inds = np.arange(0, len(sample2))
-            np.random.shuffle(inds)
+            with NumpyRNGContext(seed):
+                np.random.shuffle(inds)
             inds = inds[0:max_sample_size]
             sample2 = sample2[inds]
             msg = ("\n `sample2` exceeds `max_sample_size` \n"

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
@@ -28,7 +28,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         period=None, do_auto=True, do_cross=True, estimator='Natural',
         num_threads=1, max_sample_size=int(1e6), approx_cell1_size=None,
-        approx_cell2_size=None, approx_cellran_size=None):
+        approx_cell2_size=None, approx_cellran_size=None, seed=None):
     """
     Calculate the redshift space correlation function, :math:`\\xi(r_{p}, \\pi)`
 
@@ -131,6 +131,10 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         Analogous to ``approx_cell1_size``, but for randoms.  See comments for
         ``approx_cell1_size`` for details.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     correlation_function(s) : numpy.ndarray
@@ -187,7 +191,7 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
 
     function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
         do_cross, estimator, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size)
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
 
     sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
         _sample1_is_sample2, PBCs = _rp_pi_tpcf_process_args(*function_args)
@@ -342,7 +346,7 @@ def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
 
 def _rp_pi_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
         period, do_auto, do_cross, estimator, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size):
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.redshift_space_tpcf`.
@@ -355,7 +359,7 @@ def _rp_pi_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
         randoms = np.atleast_1d(randoms)
 
     sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size)
+        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rp_bins = get_separation_bins_array(rp_bins)
     rp_max = np.amax(rp_bins)

--- a/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
@@ -25,7 +25,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         period=None, do_auto=True, do_cross=True, estimator='Natural',
         num_threads=1, max_sample_size=int(1e6), approx_cell1_size=None,
-        approx_cell2_size=None, approx_cellran_size=None):
+        approx_cell2_size=None, approx_cellran_size=None, seed=None):
     """
     Calculate the redshift space correlation function, :math:`\\xi(s, \\mu)`
 
@@ -124,6 +124,10 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         Analogous to ``approx_cell1_size``, but for randoms.  See comments for
         ``approx_cell1_size`` for details.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     correlation_function(s) : np.ndarray
@@ -203,7 +207,7 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
     #process arguments
     function_args = (sample1, s_bins, mu_bins, sample2, randoms, period,
         do_auto, do_cross, estimator, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size)
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
 
     sample1, s_bins, mu_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
         _sample1_is_sample2, PBCs = _s_mu_tpcf_process_args(*function_args)
@@ -376,7 +380,7 @@ def pair_counts(sample1, sample2, s_bins, mu_bins, period,
 
 def _s_mu_tpcf_process_args(sample1, s_bins, mu_bins, sample2, randoms,
         period, do_auto, do_cross, estimator, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size):
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.s_mu_tpcf`.
@@ -391,7 +395,7 @@ def _s_mu_tpcf_process_args(sample1, s_bins, mu_bins, sample2, randoms,
         randoms = np.atleast_1d(randoms)
 
     sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size)
+        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     #process radial bins
     s_bins = get_separation_bins_array(s_bins)

--- a/halotools/mock_observables/two_point_clustering/tests/test_marked_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_marked_tpcf.py
@@ -31,7 +31,8 @@ def test_marked_tpcf_auto_periodic():
     period = 1
 
     weight_func_id = 1
-    weights1 = np.random.random(Npts)
+    with NumpyRNGContext(fixed_seed):
+        weights1 = np.random.random(Npts)
 
     #with randoms
     result = marked_tpcf(sample1, rbins, sample2=None, marks1=weights1, marks2=None,
@@ -51,7 +52,8 @@ def test_marked_tpcf_auto_nonperiodic():
     rbins = np.linspace(0.001, 0.25, 5)
 
     weight_func_id = 1
-    weights1 = np.random.random(Npts)
+    with NumpyRNGContext(fixed_seed):
+        weights1 = np.random.random(Npts)
 
     #with randoms
     result = marked_tpcf(sample1, rbins, sample2=None, marks1=weights1, marks2=None,
@@ -71,8 +73,9 @@ def test_marked_tpcf_cross1():
     rbins = np.linspace(0.001, 0.25, 5)
     period = 1
 
-    weights1 = np.random.random(Npts)
-    weights2 = np.random.random(Npts)
+    with NumpyRNGContext(fixed_seed):
+        weights1 = np.random.random(Npts)
+        weights2 = np.random.random(Npts)
     weight_func_id = 1
 
     result = marked_tpcf(sample1, rbins, sample2=sample2,
@@ -91,8 +94,9 @@ def test_marked_tpcf_cross_consistency():
     rbins = np.linspace(0.001, 0.25, 5)
     period = 1
 
-    weights1 = np.random.random(Npts)
-    weights2 = np.random.random(Npts)
+    with NumpyRNGContext(fixed_seed):
+        weights1 = np.random.random(Npts)
+        weights2 = np.random.random(Npts)
     weight_func_id = 1
 
     cross_mark1 = marked_tpcf(sample1, rbins, sample2=sample2,

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf.py
@@ -29,9 +29,9 @@ def test_tpcf_auto():
     """
     test the tpcf auto-correlation functionality
     """
-
-    sample1 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -57,10 +57,10 @@ def test_tpcf_cross():
     """
     test the tpcf cross-correlation functionality
     """
-
-    sample1 = np.random.random((100, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((100, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -85,10 +85,10 @@ def test_tpcf_estimators():
     """
     test the tpcf different estimators functionality
     """
-
-    sample1 = np.random.random((100, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((100, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
 
@@ -130,10 +130,10 @@ def test_tpcf_sample_size_limit():
     """
     test the tpcf sample size limit functionality functionality
     """
-
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((1000, 3))
-    randoms = np.random.random((1000, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((1000, 3))
+        randoms = np.random.random((1000, 3))
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
 
@@ -150,10 +150,10 @@ def test_tpcf_randoms():
     """
     test the tpcf possible randoms + PBCs combinations
     """
-
-    sample1 = np.random.random((100, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((100, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -197,10 +197,10 @@ def test_tpcf_period_API():
     """
     test the tpcf period API functionality.
     """
-
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -235,10 +235,10 @@ def test_tpcf_cross_consistency_w_auto():
     """
     test the tpcf cross-correlation mode consistency with auto-correlation mode
     """
-
-    sample1 = np.random.random((200, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((300, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((200, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((300, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -285,10 +285,10 @@ def test_tpcf_cross_consistency_w_auto():
 
 
 def test_RR_precomputed_exception_handling1():
-
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -305,10 +305,10 @@ def test_RR_precomputed_exception_handling1():
 
 
 def test_RR_precomputed_exception_handling2():
-
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -326,10 +326,10 @@ def test_RR_precomputed_exception_handling2():
 
 
 def test_RR_precomputed_exception_handling3():
-
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((100, 3))
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((100, 3))
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -358,9 +358,10 @@ def test_RR_precomputed_natural_estimator_auto():
     exactly the same results as if we did not pre-compute RR.
 
     """
-    sample1 = np.random.random((1000, 3))
-    sample2 = sample1
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = sample1
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -438,9 +439,10 @@ def test_RR_precomputed_Landy_Szalay_estimator_auto():
     exactly the same results as if we did not pre-compute RR.
 
     """
-    sample1 = np.random.random((1000, 3))
-    sample2 = sample1
-    randoms = np.random.random((100, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = sample1
+        randoms = np.random.random((100, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
     rmax = rbins.max()
@@ -511,7 +513,8 @@ def test_RR_precomputed_Landy_Szalay_estimator_auto():
 
 
 def test_tpcf_raises_warning_for_large_samples():
-    sample1 = np.random.random((1000, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.001, 0.3, 5)
 
@@ -522,7 +525,8 @@ def test_tpcf_raises_warning_for_large_samples():
 
 
 def test_tpcf_raises_exception_for_non_monotonic_rbins():
-    sample1 = np.random.random((1000, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(10, 0.3, 5)
 
@@ -533,7 +537,8 @@ def test_tpcf_raises_exception_for_non_monotonic_rbins():
 
 
 def test_tpcf_raises_exception_for_large_search_length():
-    sample1 = np.random.random((1000, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.1, 0.5, 5)
 
@@ -544,8 +549,9 @@ def test_tpcf_raises_exception_for_large_search_length():
 
 
 def test_tpcf_raises_exception_for_incompatible_data_shapes():
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((1000, 2))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((1000, 2))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.1, 0.3, 5)
 
@@ -556,8 +562,9 @@ def test_tpcf_raises_exception_for_incompatible_data_shapes():
 
 
 def test_tpcf_raises_exception_for_bad_do_auto_instructions():
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((1000, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((1000, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.1, 0.3, 5)
 
@@ -569,8 +576,9 @@ def test_tpcf_raises_exception_for_bad_do_auto_instructions():
 
 
 def test_tpcf_raises_exception_for_unavailable_estimator():
-    sample1 = np.random.random((1000, 3))
-    sample2 = np.random.random((1000, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((1000, 3))
+        sample2 = np.random.random((1000, 3))
     period = np.array([1.0, 1.0, 1.0])
     rbins = np.linspace(0.1, 0.3, 5)
 

--- a/halotools/mock_observables/two_point_clustering/tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf.py
@@ -149,7 +149,7 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
         max_sample_size=int(1e6), approx_cell1_size=None,
         approx_cell2_size=None, approx_cellran_size=None,
-        RR_precomputed=None, NR_precomputed=None):
+        RR_precomputed=None, NR_precomputed=None, seed=None):
     """
     Calculate the real space two-point correlation function, :math:`\\xi(r)`.
 
@@ -254,6 +254,10 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
         you must also provide the ``RR_precomputed`` argument.
         Default is None.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     correlation_function(s) : numpy.array
@@ -322,7 +326,7 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
     function_args = (sample1, rbins, sample2, randoms, period,
         do_auto, do_cross, estimator, num_threads, max_sample_size,
         approx_cell1_size, approx_cell2_size, approx_cellran_size,
-        RR_precomputed, NR_precomputed)
+        RR_precomputed, NR_precomputed, seed)
 
     #pass arguments in, and get out processed arguments, plus some control flow variables
     (sample1, rbins, sample2, randoms, period,
@@ -399,7 +403,7 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
 def _tpcf_process_args(sample1, rbins, sample2, randoms,
         period, do_auto, do_cross, estimator, num_threads, max_sample_size,
         approx_cell1_size, approx_cell2_size, approx_cellran_size,
-        RR_precomputed, NR_precomputed):
+        RR_precomputed, NR_precomputed, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.tpcf`.
@@ -413,7 +417,7 @@ def _tpcf_process_args(sample1, rbins, sample2, randoms,
         randoms = np.atleast_1d(randoms)
 
     sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size)
+        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rbins = get_separation_bins_array(rbins)
     rmax = np.amax(rbins)

--- a/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
@@ -31,12 +31,12 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 
 def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
-                             sample2=None, sample2_host_halo_id=None,
-                             randoms=None, period=None,
-                             do_auto=True, do_cross=True, estimator='Natural',
-                             num_threads=1, max_sample_size=int(1e6),
-                             approx_cell1_size=None, approx_cell2_size=None,
-                             approx_cellran_size=None):
+        sample2=None, sample2_host_halo_id=None,
+        randoms=None, period=None,
+        do_auto=True, do_cross=True, estimator='Natural',
+        num_threads=1, max_sample_size=int(1e6),
+        approx_cell1_size=None, approx_cell2_size=None,
+        approx_cellran_size=None, seed=None):
     """
     Calculate the real space one-halo and two-halo decomposed two-point correlation
     functions, :math:`\\xi^{1h}(r)` and :math:`\\xi^{2h}(r)`.
@@ -136,6 +136,10 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
         Analogous to ``approx_cell1_size``, but for randoms.  See comments for
         ``approx_cell1_size`` for details.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     correlation_function(s) : numpy.array
@@ -193,7 +197,7 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
     #check input arguments using clustering helper functions
     function_args = (sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id,
         randoms, period, do_auto, do_cross, estimator, num_threads,
-        max_sample_size, approx_cell1_size, approx_cell2_size, approx_cellran_size)
+        max_sample_size, approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
 
     #pass arguments in, and get out processed arguments, plus some control flow variables
     sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id, randoms, period,\
@@ -396,7 +400,7 @@ def marked_pair_counts(sample1, sample2, rbins, period, num_threads,
 def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
         sample2, sample2_host_halo_id, randoms,
         period, do_auto, do_cross, estimator, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size):
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.tpcf_one_two_halo_decomp`.
@@ -430,7 +434,7 @@ def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
         raise HalotoolsError(msg)
 
     sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size)
+        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rbins = get_separation_bins_array(rbins)
     rmax = np.max(rbins)

--- a/halotools/mock_observables/two_point_clustering/wp.py
+++ b/halotools/mock_observables/two_point_clustering/wp.py
@@ -20,7 +20,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
         max_sample_size=int(1e6), approx_cell1_size=None, approx_cell2_size=None,
-        approx_cellran_size=None):
+        approx_cellran_size=None, seed=None):
     """
     Calculate the projected two point correlation function, :math:`w_{p}(r_p)`,
     where :math:`r_p` is the separation perpendicular to the line-of-sight (LOS).
@@ -129,6 +129,10 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         Analogous to ``approx_cell1_size``, but for randoms.  See comments for
         ``approx_cell1_size`` for details.
 
+    seed : int, optional
+        Random number seed used to randomly downsample data, if applicable.
+        Default is None, in which case downsampling will be stochastic.
+
     Returns
     -------
     correlation_function(s) : numpy.array
@@ -200,7 +204,7 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
     #process input parameters
     function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
         do_cross, estimator, num_threads, max_sample_size,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size)
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
     sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
         _sample1_is_sample2, PBCs = _rp_pi_tpcf_process_args(*function_args)
 

--- a/halotools/mock_observables/void_statistics/tests/test_underdensity_prob_func.py
+++ b/halotools/mock_observables/void_statistics/tests/test_underdensity_prob_func.py
@@ -95,7 +95,7 @@ def test_upf4():
     Npts = 1000
     Lbox = 1
     period = np.array([Lbox, Lbox, Lbox])
-    sample1 = generate_locus_of_3d_points(Npts)
+    sample1 = generate_locus_of_3d_points(Npts, seed=fixed_seed)
     n_ran = 1000
 
     rbins = np.logspace(-1.5, -1, 5)

--- a/halotools/mock_observables/void_statistics/tests/test_underdensity_prob_func.py
+++ b/halotools/mock_observables/void_statistics/tests/test_underdensity_prob_func.py
@@ -5,6 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..underdensity_prob_func import underdensity_prob_func
 from ..void_prob_func import void_prob_func
@@ -12,6 +13,8 @@ from ..void_prob_func import void_prob_func
 from ...tests.cf_helpers import generate_locus_of_3d_points
 
 __all__ = ('test_upf1', 'test_upf2', 'test_upf3', 'test_upf4')
+
+fixed_seed = 43
 
 
 def test_upf1():
@@ -22,7 +25,8 @@ def test_upf1():
     Npts = 100
     Lbox = 1
     period = np.array([Lbox, Lbox, Lbox])
-    sample1 = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts, 3))
     n_ran = 100
 
     rbins = np.logspace(-2, -1, 20)
@@ -44,7 +48,8 @@ def test_upf2():
     Lbox = 1
     period = np.array([Lbox, Lbox, Lbox])
     sample1 = np.random.random((Npts, 3))
-    random_sphere_centers = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        random_sphere_centers = np.random.random((Npts, 3))
 
     rbins = np.logspace(-1.5, -1, 5)
     upf = underdensity_prob_func(sample1, rbins,
@@ -65,8 +70,9 @@ def test_upf3():
     Npts = 1000
     Lbox = 1
     period = np.array([Lbox, Lbox, Lbox])
-    sample1 = np.random.random((Npts, 3))
-    random_sphere_centers = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts, 3))
+        random_sphere_centers = np.random.random((Npts, 3))
 
     rbins = np.logspace(-2, -0.5, 5)
 

--- a/halotools/mock_observables/void_statistics/tests/test_void_prob_func.py
+++ b/halotools/mock_observables/void_statistics/tests/test_void_prob_func.py
@@ -4,12 +4,15 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
 
 from ..void_prob_func import void_prob_func
 
 from ...tests.cf_helpers import generate_locus_of_3d_points
 
 __all__ = ('test_vpf1', 'test_vpf2', 'test_vpf3')
+
+fixed_seed = 43
 
 
 def test_vpf1():
@@ -22,14 +25,15 @@ def test_vpf1():
     Npts = 100
     Lbox = 1
     period = np.array([Lbox, Lbox, Lbox])
-    sample1 = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts, 3))
     n_ran = 100
 
     rbins = np.logspace(-2, -1, 20)
-    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period, seed=fixed_seed)
 
     rbins = np.linspace(0.1, 0.3, 10)
-    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period, seed=fixed_seed)
 
 
 def test_vpf2():
@@ -42,11 +46,12 @@ def test_vpf2():
     Npts = 100
     Lbox = 1
     period = None
-    sample1 = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts, 3))
     n_ran = 100
 
     rbins = np.logspace(-2, -1, 20)
-    vpf = void_prob_func(sample1, rbins, n_ran, period)
+    vpf = void_prob_func(sample1, rbins, n_ran, period, seed=fixed_seed)
 
 
 @pytest.mark.slow
@@ -54,16 +59,15 @@ def test_vpf3():
     """ Verify that the VPF returns consistent results
     regardless of the value of approx_cell1_size.
     """
-    np.random.seed(43)
-
     Npts = 1000
     Lbox = 1
     period = Lbox
-    sample1 = np.random.random((Npts, 3))
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts, 3))
     n_ran = 1000
 
     rbins = np.logspace(-2, -1, 5)
-    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period)
+    vpf = void_prob_func(sample1, rbins, n_ran=n_ran, period=period, seed=fixed_seed)
     vpf2 = void_prob_func(sample1, rbins, n_ran=n_ran, period=period,
-        approx_cell1_size=[0.2, 0.2, 0.2])
-    assert np.allclose(vpf, vpf2, rtol=0.1)
+        approx_cell1_size=[0.2, 0.2, 0.2], seed=fixed_seed)
+    assert np.allclose(vpf, vpf2, rtol=0.01)

--- a/halotools/sim_manager/fake_sim.py
+++ b/halotools/sim_manager/fake_sim.py
@@ -5,6 +5,7 @@ Primary use is to test the `~halotools.empirical_models` modules,
 particularly with doctests.
 """
 import numpy as np
+from astropy.utils.misc import NumpyRNGContext
 
 from .user_supplied_halo_catalog import UserSuppliedHaloCatalog
 from .user_supplied_ptcl_catalog import UserSuppliedPtclCatalog
@@ -76,7 +77,6 @@ class FakeSim(UserSuppliedHaloCatalog):
         self.redshift = redshift
 
         self.seed = seed
-        np.random.seed(self.seed)
 
         self.num_massbins = num_massbins
         self.num_halos_per_massbin = num_halos_per_massbin
@@ -85,16 +85,19 @@ class FakeSim(UserSuppliedHaloCatalog):
         self.cosmology = cosmology
 
         halo_id = np.arange(1e5, 1e5+2*self.num_halos, dtype='i8')
-        np.random.shuffle(halo_id)
+        with NumpyRNGContext(self.seed):
+            np.random.shuffle(halo_id)
         halo_id = halo_id[:self.num_halos]
 
-        randomizer = np.random.random(self.num_halos)
+        with NumpyRNGContext(self.seed):
+            randomizer = np.random.random(self.num_halos)
         subhalo_fraction = 0.1
         upid = np.where(randomizer > subhalo_fraction, -1, 1)
 
         host_mask = upid == -1
         host_ids = halo_id[host_mask]
-        upid[~host_mask] = np.random.choice(host_ids, len(upid[~host_mask]))
+        with NumpyRNGContext(self.seed):
+            upid[~host_mask] = np.random.choice(host_ids, len(upid[~host_mask]))
 
         halo_hostid = np.zeros(len(halo_id), dtype='i8')
         halo_hostid[host_mask] = halo_id[host_mask]
@@ -108,29 +111,32 @@ class FakeSim(UserSuppliedHaloCatalog):
         logvmaxbins = -4.25 + 0.5*(np.log10(massbins) - logrvirbins)
         vmax = np.repeat(10.**logvmaxbins, self.num_halos_per_massbin, axis=0)
         vpeak = vmax
-        spin = np.random.random(self.num_halos)
-        conc = np.random.uniform(4, 15, self.num_halos)
-        rs = rvir/conc
-        zhalf = np.random.uniform(0, 10, self.num_halos)
-        dmdt = np.random.uniform(-1, 10, self.num_halos)
+
+        with NumpyRNGContext(self.seed):
+            spin = np.random.random(self.num_halos)
+            conc = np.random.uniform(4, 15, self.num_halos)
+            rs = rvir/conc
+            zhalf = np.random.uniform(0, 10, self.num_halos)
+            dmdt = np.random.uniform(-1, 10, self.num_halos)
+
+            x = np.random.uniform(0, Lbox, self.num_halos)
+            y = np.random.uniform(0, Lbox, self.num_halos)
+            z = np.random.uniform(0, Lbox, self.num_halos)
+            vx = np.random.uniform(-500, 500, self.num_halos)
+            vy = np.random.uniform(-500, 500, self.num_halos)
+            vz = np.random.uniform(-500, 500, self.num_halos)
+
+            px = np.random.uniform(0, Lbox, self.num_ptcl)
+            py = np.random.uniform(0, Lbox, self.num_ptcl)
+            pz = np.random.uniform(0, Lbox, self.num_ptcl)
+            pvx = np.random.uniform(-1000, 1000, self.num_ptcl)
+            pvy = np.random.uniform(-1000, 1000, self.num_ptcl)
+            pvz = np.random.uniform(-1000, 1000, self.num_ptcl)
 
         idxA, idxB = crossmatch(halo_hostid, halo_id)
         halo_mvir_host_halo = np.copy(mvir)
         halo_mvir_host_halo[idxA] = mvir[idxB]
 
-        x = np.random.uniform(0, Lbox, self.num_halos)
-        y = np.random.uniform(0, Lbox, self.num_halos)
-        z = np.random.uniform(0, Lbox, self.num_halos)
-        vx = np.random.uniform(-500, 500, self.num_halos)
-        vy = np.random.uniform(-500, 500, self.num_halos)
-        vz = np.random.uniform(-500, 500, self.num_halos)
-
-        px = np.random.uniform(0, Lbox, self.num_ptcl)
-        py = np.random.uniform(0, Lbox, self.num_ptcl)
-        pz = np.random.uniform(0, Lbox, self.num_ptcl)
-        pvx = np.random.uniform(-1000, 1000, self.num_ptcl)
-        pvy = np.random.uniform(-1000, 1000, self.num_ptcl)
-        pvz = np.random.uniform(-1000, 1000, self.num_ptcl)
         ptclcat = UserSuppliedPtclCatalog(
             Lbox=Lbox, redshift=redshift, particle_mass=particle_mass,
             x=px, y=py, z=pz, vx=pvx, vy=pvy, vz=pvz)
@@ -197,7 +203,6 @@ class FakeSimHalosNearBoundaries(UserSuppliedHaloCatalog):
         self.version_name = 'dummy_version'
 
         self.seed = seed
-        np.random.seed(self.seed)
 
         self.num_massbins = num_massbins
         self.num_halos_per_massbin = num_halos_per_massbin
@@ -206,7 +211,8 @@ class FakeSimHalosNearBoundaries(UserSuppliedHaloCatalog):
 
         halo_id = np.arange(1e9, 1e9+self.num_halos)
 
-        randomizer = np.random.random(self.num_halos)
+        with NumpyRNGContext(self.seed):
+            randomizer = np.random.random(self.num_halos)
         subhalo_fraction = 0.1
         upid = np.where(randomizer > subhalo_fraction, -1, 1)
 
@@ -224,31 +230,35 @@ class FakeSimHalosNearBoundaries(UserSuppliedHaloCatalog):
         vmax = np.repeat(10.**logvmaxbins, self.num_halos_per_massbin, axis=0)
         vpeak = vmax
 
-        conc = np.random.uniform(4, 15, self.num_halos)
-        rs = rvir/conc
-        zhalf = np.random.uniform(0, 10, self.num_halos)
+        with NumpyRNGContext(self.seed):
+            conc = np.random.uniform(4, 15, self.num_halos)
+            rs = rvir/conc
+            zhalf = np.random.uniform(0, 10, self.num_halos)
 
         x = np.zeros(self.num_halos)
         y = np.zeros(self.num_halos)
         z = np.zeros(self.num_halos)
         middle_index = int(self.num_halos/2.)
-        x[:middle_index] = np.random.uniform(0, 0.001, len(x[:middle_index]))
-        x[middle_index:] = np.random.uniform(Lbox-0.001, Lbox, len(x[middle_index:]))
-        y[:middle_index] = np.random.uniform(0, 0.001, len(y[:middle_index]))
-        y[middle_index:] = np.random.uniform(Lbox-0.001, Lbox, len(y[middle_index:]))
-        z[:middle_index] = np.random.uniform(0, 0.001, len(z[:middle_index]))
-        z[middle_index:] = np.random.uniform(Lbox-0.001, Lbox, len(z[middle_index:]))
 
-        vx = np.random.uniform(-500, 500, self.num_halos)
-        vy = np.random.uniform(-500, 500, self.num_halos)
-        vz = np.random.uniform(-500, 500, self.num_halos)
+        with NumpyRNGContext(self.seed):
+            x[:middle_index] = np.random.uniform(0, 0.001, len(x[:middle_index]))
+            x[middle_index:] = np.random.uniform(Lbox-0.001, Lbox, len(x[middle_index:]))
+            y[:middle_index] = np.random.uniform(0, 0.001, len(y[:middle_index]))
+            y[middle_index:] = np.random.uniform(Lbox-0.001, Lbox, len(y[middle_index:]))
+            z[:middle_index] = np.random.uniform(0, 0.001, len(z[:middle_index]))
+            z[middle_index:] = np.random.uniform(Lbox-0.001, Lbox, len(z[middle_index:]))
 
-        px = np.random.uniform(0, Lbox, self.num_ptcl)
-        py = np.random.uniform(0, Lbox, self.num_ptcl)
-        pz = np.random.uniform(0, Lbox, self.num_ptcl)
-        pvx = np.random.uniform(-1000, 1000, self.num_ptcl)
-        pvy = np.random.uniform(-1000, 1000, self.num_ptcl)
-        pvz = np.random.uniform(-1000, 1000, self.num_ptcl)
+            vx = np.random.uniform(-500, 500, self.num_halos)
+            vy = np.random.uniform(-500, 500, self.num_halos)
+            vz = np.random.uniform(-500, 500, self.num_halos)
+
+            px = np.random.uniform(0, Lbox, self.num_ptcl)
+            py = np.random.uniform(0, Lbox, self.num_ptcl)
+            pz = np.random.uniform(0, Lbox, self.num_ptcl)
+            pvx = np.random.uniform(-1000, 1000, self.num_ptcl)
+            pvy = np.random.uniform(-1000, 1000, self.num_ptcl)
+            pvz = np.random.uniform(-1000, 1000, self.num_ptcl)
+
         ptclcat = UserSuppliedPtclCatalog(
             Lbox=Lbox, redshift=redshift, particle_mass=particle_mass,
             x=px, y=py, z=pz, vx=pvx, vy=pvy, vz=pvz)

--- a/halotools/sim_manager/tests/test_fake_sim.py
+++ b/halotools/sim_manager/tests/test_fake_sim.py
@@ -1,36 +1,55 @@
-#!/usr/bin/env python
+"""
+"""
 from __future__ import (absolute_import, division, print_function)
-
-from unittest import TestCase
 
 import numpy as np
 
 from ..fake_sim import FakeSim, FakeSimHalosNearBoundaries
 from ...custom_exceptions import HalotoolsError
 
-__all__ = ['TestFakeSim', 'TestFakeSimHalosNearBoundaries']
+__all__ = ('test_fake_sim_default_size', )
 
 
-class TestFakeSim(TestCase):
-    """
-    """
+def test_fake_sim_default_size():
+    fake_sim = FakeSim()
+    try:
+        assert fake_sim.num_halos_per_massbin == 100
+    except AssertionError:
+        msg = ("\nThe test suite runs slowly and is excessively "
+            "memory intensive if the default ``num_halos_per_massbin`` "
+            "is larger than 100 or so.\nOnly change it if you have a good reason.\n")
+        raise HalotoolsError(msg)
 
-    def setUp(self):
-        self.fake_sim = FakeSim()
 
-    def test_fake_sim_default_size(self):
-        try:
-            assert self.fake_sim.num_halos_per_massbin == 100
-        except AssertionError:
-            msg = ("\nThe test suite runs slowly and is excessively "
-                "memory intensive if the default ``num_halos_per_massbin`` "
-                "is larger than 100 or so.\nOnly change it if you have a good reason.\n")
-            raise HalotoolsError(msg)
+def test_attrs():
+    fake_sim = FakeSim()
+    keylist = ['halo_hostid']
+    for key in keylist:
+        assert key in list(fake_sim.halo_table.keys())
 
-    def test_attrs(self):
-        keylist = ['halo_hostid']
-        for key in keylist:
-            assert key in list(self.fake_sim.halo_table.keys())
+
+def test_stochasticity():
+    fake_sim1 = FakeSim()
+    fake_sim2 = FakeSim()
+    fake_sim3 = FakeSim(seed=44)
+
+    fake_sim3_is_identical = True
+    for key in fake_sim1.halo_table.keys():
+        col1 = fake_sim1.halo_table[key]
+        col2 = fake_sim2.halo_table[key]
+        assert np.all(col1 == col2)
+        col3 = fake_sim3.halo_table[key]
+        if np.any(col3 != col2):
+            fake_sim3_is_identical = False
+
+    assert fake_sim3_is_identical is False
+
+
+def test_attrs2():
+    fake_sim = FakeSimHalosNearBoundaries()
+    keylist = ['halo_hostid']
+    for key in keylist:
+        assert key in list(fake_sim.halo_table.keys())
 
     def test_halo_mvir_host_halo(self):
         assert 'halo_mvir_host_halo' in self.fake_sim.halo_table.keys()
@@ -43,18 +62,24 @@ class TestFakeSim(TestCase):
         del self.fake_sim
 
 
-class TestFakeSimHalosNearBoundaries(TestCase):
-    """
-    """
+def test_positions2():
+    fake_sim = FakeSimHalosNearBoundaries()
+    assert not np.any((fake_sim.halo_table['halo_x'] > 1) &
+        (fake_sim.halo_table['halo_x'] < fake_sim.Lbox - 1))
 
-    def setUp(self):
-        self.fake_sim = FakeSimHalosNearBoundaries()
 
-    def test_attrs(self):
-        keylist = ['halo_hostid']
-        for key in keylist:
-            assert key in list(self.fake_sim.halo_table.keys())
+def test_stochasticity2():
+    fake_sim1 = FakeSimHalosNearBoundaries()
+    fake_sim2 = FakeSimHalosNearBoundaries()
+    fake_sim3 = FakeSimHalosNearBoundaries(seed=44)
 
-    def test_positions(self):
-        assert not np.any((self.fake_sim.halo_table['halo_x'] > 1) &
-            (self.fake_sim.halo_table['halo_x'] < self.fake_sim.Lbox - 1))
+    fake_sim3_is_identical = True
+    for key in fake_sim1.halo_table.keys():
+        col1 = fake_sim1.halo_table[key]
+        col2 = fake_sim2.halo_table[key]
+        assert np.all(col1 == col2)
+        col3 = fake_sim3.halo_table[key]
+        if np.any(col3 != col2):
+            fake_sim3_is_identical = False
+
+    assert fake_sim3_is_identical is False

--- a/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
+++ b/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
@@ -1,13 +1,18 @@
-#!/usr/bin/env python
+"""
+"""
 import numpy as np
 
 from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
+
 from unittest import TestCase
 import warnings
 
 from ...sim_manager import FakeSim
 
 __all__ = ['TestHodModelFactoryTutorial']
+
+fixed_seed = 43
 
 
 class TestHodModelFactoryTutorial(TestCase):
@@ -229,7 +234,8 @@ class TestHodModelFactoryTutorial(TestCase):
                     halo_mass = kwargs['prim_haloprop']
 
                 disrupted_fraction = self.disrupted_fraction_vs_halo_mass(halo_mass)
-                randomizer = np.random.uniform(0, 1, len(halo_mass))
+                with NumpyRNGContext(fixed_seed):
+                    randomizer = np.random.uniform(0, 1, len(halo_mass))
                 is_disrupted = randomizer < disrupted_fraction
 
                 if 'table' in list(kwargs.keys()):
@@ -241,7 +247,8 @@ class TestHodModelFactoryTutorial(TestCase):
                 table = kwargs['table']
                 mask = table['disrupted'] == True
                 num_disrupted = len(table['disrupted'][mask])
-                table['axis_ratio'][mask] = np.random.random(num_disrupted)
+                with NumpyRNGContext(fixed_seed):
+                    table['axis_ratio'][mask] = np.random.random(num_disrupted)
                 table['axis_ratio'][~mask] = 0.3
 
             def disrupted_fraction_vs_halo_mass(self, mass):
@@ -307,7 +314,8 @@ class TestHodModelFactoryTutorial(TestCase):
 
             def assign_shape(self, **kwargs):
                 table = kwargs['table']
-                randomizer = np.random.random(len(table))
+                with NumpyRNGContext(fixed_seed):
+                    randomizer = np.random.random(len(table))
                 table['shape'][:] = np.where(randomizer > 0.5, 'elliptical', 'disk')
 
         class Size(object):
@@ -368,7 +376,8 @@ class TestHodModelFactoryTutorial(TestCase):
 
             def assign_shape(self, **kwargs):
                 table = kwargs['table']
-                randomizer = np.random.random(len(table))
+                with NumpyRNGContext(fixed_seed):
+                    randomizer = np.random.random(len(table))
                 table['shape'][:] = np.where(randomizer > 0.5, 'elliptical', 'disk')
 
         class Size(object):

--- a/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
+++ b/halotools/tests/docs_code_block_tests/test_hod_model_factory_tutorial.py
@@ -186,7 +186,7 @@ class TestHodModelFactoryTutorial(TestCase):
                 self._galprop_dtypes_to_allocate = np.dtype([('galsize', 'f4')])
                 self.list_of_haloprops_needed = ['halo_spin']
 
-            def assign_size(self, table):
+            def assign_size(self, table, **kwargs):
 
                 table['galsize'][:] = table['halo_spin']/5.
 

--- a/halotools/tests/test_seed.py
+++ b/halotools/tests/test_seed.py
@@ -1,0 +1,44 @@
+""" Module contains functions used to guarantee that only American spellings
+are used throughout the package.
+"""
+
+import os
+import fnmatch
+
+from .test_amurrica import source_code_string_generator
+from ..custom_exceptions import HalotoolsError
+
+msg = ("The test suite detected a call to np.random.seed in the following filename:\n"
+    "{0} \nCalls to np.random.seed choose the random number seed \n"
+    "by setting a global environment variable, \n"
+    "which is not good coding practice for Halotools source code.\n"
+    "Any time you use a np.random function, you should instead call that function \n"
+    "within the namespace of the astropy.utils.misc.NumpyRNGContext context manager.\n"
+    "The NumpyRNGContext context manager sets the number seed to that of its input variable, \n"
+    "calls the requested np.random function, and then returns the value of the global seed \n"
+    "to whatever value it had prior to the function call.\n"
+    "See the Astropy documentation for further information.\n"
+    "Example usages of NumpyRNGContext appear throughout Halotools, and also below:\n\n"
+    ">>> bad_random_x_position = np.random.uniform(0, 250, 100) # BAD \n\n"
+    ">>> from astropy.utils.misc import NumpyRNGContext \n"
+    ">>> fixed_seed = 43 \n"
+    ">>> good_random_x_position = with NumpyRNGContext(fixed_seed): np.random.uniform(0, 250, 100) # GOOD \n\n")
+
+
+def filtered_filename_generator(filepat, top):
+    for path, dirlist, filelist in os.walk(top):
+        for name in fnmatch.filter(filelist, filepat):
+            if 'test_seed' not in name:
+                yield os.path.join(path, name)
+
+
+def test_halotools_usage_of_np_random_seed():
+    dirname_current_module = os.path.dirname(os.path.realpath(__file__))
+    base_dirname = os.path.dirname(dirname_current_module)
+    source_code_file_generator = filtered_filename_generator('*.py', base_dirname)
+
+    for fname in source_code_file_generator:
+        for i, line in source_code_string_generator(fname):
+            line = line.lower()
+            if "np.random.seed" in line:
+                raise HalotoolsError(msg.format(fname))

--- a/halotools/utils/array_utils.py
+++ b/halotools/utils/array_utils.py
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
 """
-
 Modules performing small, commonly used tasks throughout the package.
-
 """
 
 import numpy as np
 from astropy.table import Table
+from astropy.utils.misc import NumpyRNGContext
 
 from ..custom_exceptions import HalotoolsError
 
@@ -179,7 +177,7 @@ def find_idx_nearest_val(array, value):
             return idx_nearest
 
 
-def randomly_downsample_data(array, num_downsample):
+def randomly_downsample_data(array, num_downsample, seed=None):
     """ Method returns a length-num_downsample random downsampling of the input array.
 
     Parameters
@@ -207,7 +205,8 @@ def randomly_downsample_data(array, num_downsample):
         raise SyntaxError("Length of the desired downsampling = %i, "
             "which exceeds input array length = %i " % (num_downsample, input_array_length))
     else:
-        randomizer = np.random.random(input_array_length)
+        with NumpyRNGContext(seed):
+            randomizer = np.random.random(input_array_length)
         idx_sorted = np.argsort(randomizer)
         return array[idx_sorted[0:num_downsample]]
 

--- a/halotools/utils/tests/test_array_utils.py
+++ b/halotools/utils/tests/test_array_utils.py
@@ -1,5 +1,7 @@
-#!/usr/bin/env python
+"""
+"""
 import numpy as np
+from astropy.utils.misc import NumpyRNGContext
 
 from .. import array_utils
 
@@ -12,12 +14,15 @@ __all__ = ('test_find_idx_nearest_val',
     'test_convert_to_ndarray11', 'test_convert_to_ndarray12',
     'test_convert_to_ndarray13')
 
+fixed_seed = 43
+
 
 def test_find_idx_nearest_val():
 
     # Create an array of randomly sorted integers
     x = np.arange(-10, 10)
-    randomizer = np.random.random(len(x))
+    with NumpyRNGContext(fixed_seed):
+        randomizer = np.random.random(len(x))
     ransort = np.argsort(randomizer)
     x = x[ransort]
 
@@ -33,7 +38,8 @@ def test_find_idx_nearest_val():
     # Check that you never differ by more than 0.5 when
     # your inputs are within the range spanned by x
     Npts = int(1e4)
-    v = np.random.uniform(x.min()-0.5, x.max()+0.5, Npts)
+    with NumpyRNGContext(fixed_seed):
+        v = np.random.uniform(x.min()-0.5, x.max()+0.5, Npts)
     result = np.empty(Npts)
     for ii, elt in enumerate(v):
         closest_val = x[array_utils.find_idx_nearest_val(x, elt)]
@@ -42,7 +48,8 @@ def test_find_idx_nearest_val():
 
     # Check that values beyond the upper bound are handled correctly
     Npts = 10
-    v = np.random.uniform(x.max()+10, x.max()+11, Npts)
+    with NumpyRNGContext(fixed_seed):
+        v = np.random.uniform(x.max()+10, x.max()+11, Npts)
     result = np.empty(Npts)
     for ii, elt in enumerate(v):
         closest_val = x[array_utils.find_idx_nearest_val(x, elt)]
@@ -51,7 +58,8 @@ def test_find_idx_nearest_val():
     assert np.all(result <= 11)
 
     # Check that values beyond the lower bound are handled correctly
-    v = np.random.uniform(x.min()-11, x.min()-10, Npts)
+    with NumpyRNGContext(fixed_seed):
+        v = np.random.uniform(x.min()-11, x.min()-10, Npts)
     result = np.empty(Npts)
     for ii, elt in enumerate(v):
         closest_val = x[array_utils.find_idx_nearest_val(x, elt)]

--- a/halotools/utils/tests/test_crossmatch.py
+++ b/halotools/utils/tests/test_crossmatch.py
@@ -60,7 +60,8 @@ def test_crossmatch5():
         x = np.random.randint(0, xmax+1, numx)
 
     y = np.arange(-xmax, xmax)[::10]
-    np.random.shuffle(y)
+    with NumpyRNGContext(fixed_seed):
+        np.random.shuffle(y)
 
     x_idx, y_idx = crossmatch(x, y)
 

--- a/halotools/utils/tests/test_table_utils.py
+++ b/halotools/utils/tests/test_table_utils.py
@@ -4,12 +4,15 @@ import numpy as np
 from unittest import TestCase
 from functools import partial
 from astropy.table import Table
+from astropy.utils.misc import NumpyRNGContext
 
 from ..table_utils import SampleSelector, compute_conditional_percentiles
 
 from ...sim_manager import FakeSim
 
 __all__ = ('TestSampleSelector', 'TestComputeConditionalPercentiles')
+
+fixed_seed = 43
 
 
 class TestSampleSelector(TestCase):
@@ -69,7 +72,8 @@ class TestComputeConditionalPercentiles(TestCase):
 
         d = {'halo_mvir': mass, 'halo_zform': zform}
         t = Table(d)
-        randomizer = np.random.random(len(t))
+        with NumpyRNGContext(fixed_seed):
+            randomizer = np.random.random(len(t))
         random_idx = np.argsort(randomizer)
         t = t[random_idx]
         self.custom_halo_table = t


### PR DESCRIPTION
This PR exposes the `seed` keyword to mock population, so all Halotools component and composite models can have entirely deterministic behavior, resolving #551. 

In addition to the above, all appearances of calls to any function in np.random are now protected inside the namespace of the NumpyRNGContext context manager, so that Halotools never modifies the global environment variable controlling the random number seed used by Numpy. In this way, Halotools testing is purely deterministic. Thanks to @eteq for pointing out this very useful Astropy context manager. 

@nickhand - let me know if this provides the behavior you requested.
