### PR TITLE
Relative posvel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - All models now support an optional ``seed`` keyword argument, allowing for deterministic Monte Carlo realizations of models. As a result of this feature, it is now mandatory that all user-defined models obey a new constraint. Any function appearing in the ``mock_generation_calling_sequence`` must now use the kwargs Python syntax to catch any additional inputs passed to these functions by the MockFactory.
 
+- Added relative_positions_and_velocities function to mock_observables
+
 
 0.3 (2016-06-28)
 ----------------

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -9,7 +9,8 @@ from ..empirical_models import enforce_periodicity_of_box
 
 from ..custom_exceptions import HalotoolsError
 
-__all__ = ('mean_y_vs_x', 'return_xyz_formatted_array', 'cuboid_subvolume_labels')
+__all__ = ('mean_y_vs_x', 'return_xyz_formatted_array', 'cuboid_subvolume_labels',
+    'relative_positions_and_velocities')
 __author__ = ['Andrew Hearin']
 
 
@@ -346,7 +347,7 @@ def sign_pbc(x1, x2, period=None, equality_fill_val=0.):
             assert np.all(x1 < period)
             assert np.all(x2 < period)
         except AssertionError:
-            msg = "If period is not None, all values of x and y must be between [0, 1)"
+            msg = "If period is not None, all values of x and y must be between [0, period)"
             raise ValueError(msg)
 
         d = np.abs(x1-x2)
@@ -357,3 +358,80 @@ def sign_pbc(x1, x2, period=None, equality_fill_val=0.):
         result = np.where(result == 0, equality_fill_val, result)
 
     return result
+
+
+def relative_positions_and_velocities(x1, x2, period=None, **kwargs):
+    """ Return the vector pointing from x2 towards x1,
+    that is, x1 - x2, accounting for periodic boundary conditions.
+
+    If keyword arguments ``v1`` and ``v2`` are passed in,
+    additionally return the velocity ``v1`` with respect to ``v2``, with sign convention
+    such that positive (negative) values correspond to receding (approaching) points.
+
+    Parameters
+    -----------
+    x1 : array
+        1-d array of length *Npts*.
+        If period is not None, all values must be contained in [0, Lbox)
+
+    x2 : array
+        1-d array of length *Npts*.
+        If period is not None, all values must be contained in [0, Lbox)
+
+    period : float, optional
+        Size of the periodic box. Default is None for non-periodic case.
+
+    Returns
+    --------
+    xrel : array
+        1-d array of length *Npts* storing x1 - x2.
+        If *x1 > x2* and abs(*x1* - *x2*) > period/2, the sign of *d* will be negative.
+
+    Examples
+    --------
+    >>> Lbox = 250.0
+    >>> x1 = 1.
+    >>> x2 = 249.
+    >>> result = relative_positions_and_velocities(x1, x2, period=Lbox)
+    >>> assert np.isclose(result, 2)
+
+    >>> result = relative_positions_and_velocities(x1, x2, period=None)
+    >>> assert np.isclose(result, -248)
+
+    >>> npts = 100
+    >>> x1 = np.random.uniform(0, Lbox, npts)
+    >>> x2 = np.random.uniform(0, Lbox, npts)
+    >>> result = relative_positions_and_velocities(x1, x2, period=Lbox)
+
+    Now let's frame this result in terms of a physically motivated example.
+    Suppose we have a central galaxy with position *xc* and velocity *vc*,
+    and a satellite galaxy with position *xs* and velocity *vs*.
+    We can calculate the vector pointing from the central to the satellite,
+    as well as the satellites's host-centric velocity:
+
+    >>> xcen, vcen = 249.9, 100
+    >>> xsat, vsat = 0.1, -300
+    >>> xrel, vrel = relative_positions_and_velocities(xsat, xcen, v1=vsat, v2=vcen, period=Lbox)
+    >>> assert np.isclose(xrel, +0.2)
+    >>> assert np.isclose(vrel, -400)
+
+    >>> xcen, vcen = 0.1, 100
+    >>> xsat, vsat = 249.9, -300
+    >>> xrel, vrel = relative_positions_and_velocities(xsat, xcen, v1=vsat, v2=vcen, period=Lbox)
+    >>> assert np.isclose(xrel, -0.2)
+    >>> assert np.isclose(vrel, +400)
+
+    """
+    s = sign_pbc(x1, x2, period=period, equality_fill_val=1.)
+    absd = np.abs(x1 - x2)
+    if period is None:
+        xrel = s*absd
+    else:
+        xrel = s*np.where(absd > period/2., period - absd, absd)
+
+    try:
+        v1 = kwargs['v1']
+        v2 = kwargs['v2']
+        return xrel, s*(v1-v2)
+    except KeyError:
+        return xrel

--- a/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
+++ b/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
@@ -112,12 +112,125 @@ def test_sign_pbc_catches_out_of_bounds():
     x2 = np.array((2, 5, 7, 10))
     with pytest.raises(ValueError) as err:
         __ = cat_helpers.sign_pbc(x1, x2, period=10)
-    substr = "If period is not None, all values of x and y must be between [0, 1)"
+    substr = "If period is not None, all values of x and y must be between [0, period)"
     assert substr in err.value.args[0]
 
     s = cat_helpers.sign_pbc(x1, x2)
     assert np.all(s == (-1, -1, -1, -1))
 
+
+def test_relative_positions_and_velocities_catches_out_of_bounds():
+    x1 = np.array((1, 4, 6, 10.))
+    x2 = x1
+    with pytest.raises(ValueError) as err:
+        __ = cat_helpers.relative_positions_and_velocities(x1, x2, period=10)
+    substr = "If period is not None, all values of x and y must be between [0, period)"
+    assert substr in err.value.args[0]
+
+
+def test_relative_positions_and_velocities1():
+    """ In this test, x1 > x2 and PBCs are irrelevant
+    """
+    period = 10
+    x1 = np.array((1, 4, 6, 9.))
+    x2 = x1 - 1
+    result = cat_helpers.relative_positions_and_velocities(x1, x2, period=period)
+    assert np.all(result == np.ones(len(x1)))
+    result = cat_helpers.relative_positions_and_velocities(x1, x2)
+    assert np.all(result == np.ones(len(x1)))
+
+
+def test_relative_positions_and_velocities2():
+    """ In this test, x1 > x2 and PBCs impact the results
+    """
+    period = 10
+    x1 = np.array((1, 4, 6, 9.))
+    x2 = np.mod(x1 - 1 + period, period)
+    result = cat_helpers.relative_positions_and_velocities(x1, x2, period=period)
+    assert np.all(result == np.ones(len(x1)))
+
+
+def test_relative_positions_and_velocities3():
+    """ In this test, x1 < x2 and PBCs are irrelevant
+    """
+    period = 100
+    x1 = np.array((1, 4, 6, 9.))
+    x2 = x1 + 1
+    result = cat_helpers.relative_positions_and_velocities(x1, x2, period=period)
+    assert np.all(result == -np.ones(len(x1)))
+    result = cat_helpers.relative_positions_and_velocities(x1, x2)
+    assert np.all(result == -np.ones(len(x1)))
+
+
+def test_relative_positions_and_velocities4():
+    """ In this test, x1 < x2 and PBCs impact the results
+    """
+    period = 10
+    x1 = np.array((1, 4, 6, 9.))
+    x2 = np.zeros(len(x1))
+    result = cat_helpers.relative_positions_and_velocities(x1, x2, period=period)
+    assert np.all(result == np.array((1, 4, -4, -1)))
+    result = cat_helpers.relative_positions_and_velocities(x1, x2)
+    assert np.all(result == x1)
+
+
+def test_relative_velocities1():
+    """ In this test, x1 > x2 and PBCs are irrelevant
+    """
+    period = 100
+    x1 = np.array((9, 9, 9, 9))
+    x2 = x1 - 1
+    v1 = np.array((100, 100, 100, 100))
+    v2 = np.array((-100, -10, 90, 110))
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, period=period, v1=v1, v2=v2)
+    assert np.all(vrel == (200, 110, 10, -10))
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, v1=v1, v2=v2)
+    assert np.all(vrel == (200, 110, 10, -10))
+
+
+def test_relative_velocities2():
+    """ In this test, x1 > x2 and PBCs impact the results
+    """
+    period = 10
+    x1 = np.array((9, 9, 9, 9))
+    x2 = np.zeros(len(x1))
+    v1 = np.array((100, 100, 100, 100))
+    v2 = np.array((-100, -10, 90, 110))
+    correct_result = np.array((-200, -110, -10, 10))
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, period=period, v1=v1, v2=v2)
+    assert np.all(vrel == correct_result)
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, v1=v1, v2=v2)
+    assert np.all(vrel == -correct_result)
+
+
+def test_relative_velocities3():
+    """ In this test, x1 < x2 and PBCs are irrelevant
+    """
+    period = 100
+    x1 = np.array((9, 9, 9, 9))
+    x2 = x1 + 1
+    v1 = np.array((100, 100, 100, 100))
+    v2 = np.array((-100, -10, 90, 110))
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, period=period, v1=v1, v2=v2)
+    correct_result = np.array((-200, -110, -10, 10))
+    assert np.all(vrel == correct_result)
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, v1=v1, v2=v2)
+    assert np.all(vrel == correct_result)
+
+
+def test_relative_velocities4():
+    """ In this test, x1 < x2 and PBCs are irrelevant
+    """
+    period = 10
+    x1 = np.zeros(4)
+    x2 = np.zeros(4) + 9.
+    v1 = np.array((100, 100, 100, 100))
+    v2 = np.array((-100, -10, 90, 110))
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, period=period, v1=v1, v2=v2)
+    correct_result = np.array((200, 110, 10, -10))
+    assert np.all(vrel == correct_result)
+    xrel, vrel = cat_helpers.relative_positions_and_velocities(x1, x2, v1=v1, v2=v2)
+    assert np.all(vrel == -correct_result)
 
 
 class TestCatalogAnalysisHelpers(TestCase):


### PR DESCRIPTION
New function in catalog_analysis_helpers can be used, for example, to calculate host-centric distances and host-relative velocities of satellites for equal-length arrays. 

CC @duncandc - I'm considering including the following new columns to all Halotools-provided catalogs: `halo_x_host_halo, halo_y_host_halo, halo_z_host_halo, halo_vx_host_halo, halo_vy_host_halo, halo_vz_host_halo, halo_distance_to_host`. These quantities would not actually stored on disk, but calculated from scratch using `crossmatch` the first time the `halo_table` is accessed. Does this seem like overkill? Or do you agree that these are common enough to consider basic subhalo properties that should be loaded into the catalogs by default?

Input welcome from anyone else who wants to weigh in. 

