### PR TITLE
division by zero in two-point function calculations now raises exception

### DIFF
--- a/halotools/mock_observables/two_point_clustering/tests/test_s_mu_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_s_mu_tpcf.py
@@ -21,7 +21,7 @@ def test_s_mu_tpcf_auto_nonperiodic():
         sample1 = np.random.random((Npts, 3))
         randoms = np.random.random((Nran, 3))
     s_bins = np.linspace(0.001, 0.3, 5)
-    mu_bins = np.linspace(0, 1.0, 10)
+    mu_bins = np.linspace(0, 1.0, 5)
 
     result_1 = s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None,
         randoms=randoms, period=None,

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf_estimators.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf_estimators.py
@@ -1,0 +1,37 @@
+""" Module provides unit-testing for `~halotools.mock_observables.tpcf_estimators`.
+"""
+from __future__ import absolute_import, division, print_function
+
+from astropy.tests.helper import pytest
+import numpy as np
+
+from ..tpcf_estimators import _test_for_zero_division, _list_estimators
+
+__all__ = ('test_zero_division1', )
+
+
+def test_zero_division1():
+    nbins = 10
+    DD = np.arange(nbins) + 10
+    DR = np.arange(nbins) + 10
+    RR = np.arange(nbins) + 10
+    ND1, ND2, NR1, NR2 = 100, 100, 100, 100
+
+    for estimator in _list_estimators():
+        _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator)
+
+
+def test_zero_division2():
+    nbins = 10
+    DD = np.arange(nbins) + 10
+    DR = np.arange(nbins) + 10
+    RR = np.arange(nbins) + 10
+    ND1, ND2, NR1, NR2 = 100, 100, 100, 100
+
+    RR[0] = 0.
+    DR[0] = 0.
+    for estimator in _list_estimators():
+        with pytest.raises(ValueError) as err:
+            _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator)
+        substr = "you will have at least one NaN returned value"
+        assert substr in err.value.args[0]

--- a/halotools/mock_observables/two_point_clustering/tpcf_estimators.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_estimators.py
@@ -31,6 +31,8 @@ def _TP_estimator(DD, DR, RR, ND1, ND2, NR1, NR2, estimator):
     else:
         mult = lambda x, y: x*y  # used for all else
 
+    _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator)
+
     if estimator == 'Natural':
         factor = ND1*ND2/(NR1*NR2)
         #DD/RR-1
@@ -98,3 +100,22 @@ def _TP_estimator_requirements(estimator):
             raise HalotoolsError(msg)
 
     return do_DD, do_DR, do_RR
+
+
+def _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator):
+    zero_msg = ("When calculating the two-point function, there was at least one \n"
+        "separation bin with zero {0} pairs. Since the ``{1}`` estimator you chose \n"
+        "divides by {0}, you will have at least one NaN returned value.\n"
+        "Most likely, the innermost separation bin is the problem.\n"
+        "Try increasing the number of randoms and/or using broader bins.\n"
+        "To estimate the number of required randoms, the following expression \n"
+        "for the expected number of pairs inside a sphere of radius ``r`` may be useful:\n\n"
+        "<Npairs> = (Nran_tot)*(4pi/3)*(r/Lbox)^3 \n\n")
+
+    estimators_dividing_by_rr = ('Natural', 'Davis-Peebles', 'Hewett', 'Landy-Szalay')
+    if (estimator in estimators_dividing_by_rr) & (np.any(RR == 0)):
+        raise ValueError(zero_msg.format('RR', estimator))
+
+    estimators_dividing_by_dr = ('Hamilton', )
+    if (estimator in estimators_dividing_by_dr) & (np.any(DR == 0)):
+        raise ValueError(zero_msg.format('DR', estimator))

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -183,7 +183,7 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
     within a periodic cube of box length Lbox = 250 Mpc/h.
 
     >>> Npts = 1000
-    >>> Lbox = 250.
+    >>> Lbox = 100.
 
     >>> x = np.random.uniform(0, Lbox, Npts)
     >>> y = np.random.uniform(0, Lbox, Npts)
@@ -197,7 +197,7 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
 
     Create some 'randoms' in the same way:
 
-    >>> Nran = Npts*2
+    >>> Nran = Npts*500
     >>> xran = np.random.uniform(0, Lbox, Nran)
     >>> yran = np.random.uniform(0, Lbox, Nran)
     >>> zran = np.random.uniform(0, Lbox, Nran)
@@ -206,7 +206,7 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
     Calculate the jackknife covariance matrix by dividing the simulation box
     into 4 samples per dimension (for a total of 4^3 total jackknife samples):
 
-    >>> rbins = np.logspace(-1, 1, 10)
+    >>> rbins = np.logspace(0, 1, 8)
     >>> xi, xi_cov = tpcf_jackknife(coords, randoms, rbins, Nsub=4, period=Lbox)
     """
 

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -204,10 +204,10 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
     >>> randoms = np.vstack((x,y,z)).T
 
     Calculate the jackknife covariance matrix by dividing the simulation box
-    into 4 samples per dimension (for a total of 4^3 total jackknife samples):
+    into 3 samples per dimension (for a total of 3^3 total jackknife samples):
 
-    >>> rbins = np.logspace(0, 1, 8)
-    >>> xi, xi_cov = tpcf_jackknife(coords, randoms, rbins, Nsub=4, period=Lbox)
+    >>> rbins = np.logspace(0.5, 1.5, 8)
+    >>> xi, xi_cov = tpcf_jackknife(coords, randoms, rbins, Nsub=3, period=Lbox)
     """
 
     #process input parameters


### PR DESCRIPTION
Modified all two-point functions to raise an exception before returning NaN values as a result of dividing by DR or RR with a zero in some bin.

Resolves #588. Suggestion due to @mclaughlin6464.