### PR TITLE
counts-in-cells sub-package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@
 
 - Fixed bug in mock_observables.pair_counters.npairs_per_object_3d
 
+- New counts_in_cells sub-package in mock_observables
+
 
 0.3 (2016-06-28)
 ----------------

--- a/docs/quickstart_and_tutorials/mock_observations/calculating_counts_in_cells.rst
+++ b/docs/quickstart_and_tutorials/mock_observations/calculating_counts_in_cells.rst
@@ -1,0 +1,115 @@
+:orphan:
+
+.. _calculating_counts_in_cells:
+
+**************************************************************************
+Calculating counts-in-cells on a realistic galaxy catalog
+**************************************************************************
+
+.. currentmodule:: halotools.mock_observables
+
+In this tutorial we will how to use the `counts_in_cylinders` function
+on a realistic galaxy catalog, making full use of the variable search length
+feature of this function.
+
+Calculation overview
+=====================
+
+First we'll generate a mock galaxy catalog using a fake simulation,
+and then select two populations of galaxies, the first with relatively
+high stellar mass, the second with lower stellar mass. We'll get an estimate
+on the virial radius of the high-mass galaxies using the same methods you might
+use on a real galaxy catalog in which you don't know the true halo mass of the
+galaxies. Then we'll use the `counts_in_cylinders` function
+to calculate the number of low-mass galaxies
+inside a cylinder centered at each high-mass galaxy, where each
+cylinder has a radius equal to twice the estimated virial radius,
+and length equal to three times the estimated virial velocity.
+
+
+Generate fake data
+===================
+
+>>> from halotools.sim_manager import FakeSim
+>>> halocat = FakeSim()
+>>> from halotools.empirical_models import PrebuiltSubhaloModelFactory
+>>> model = PrebuiltSubhaloModelFactory('behroozi10', redshift=0)
+>>> model.populate_mock(halocat)
+
+>>> gals = model.mock.galaxy_table
+>>> high_mass_mask = (gals['stellar_mass'] >= 1e11) & (gals['stellar_mass'] <= 2e11)
+>>> high_mass_gals = gals[high_mass_mask]
+>>> low_mass_mask = (gals['stellar_mass'] >= 1e10) & (gals['stellar_mass'] <= 5e10)
+>>> low_mass_gals = gals[low_mass_mask]
+
+Estimating the virial radius and virial velocity
+=================================================
+
+In an analysis of any real galaxy catalog, the true virial radius of mock galaxies
+is unknown. However, under the assumption that all ``sample1`` galaxies
+are centrals, we can get an estimate of the virial radius of each ``sample1`` galaxy
+using a stellar-to-halo mass relation. This assumption will not be perfect
+as any real galaxy sample will have satellite interlopers,
+but we'll stick with this assumption to get a rough estimate of the appropriate search radius.
+
+To get the estimate, we'll exploit the fact that the central galaxy
+stellar-to-halo mass relation is invertible:
+
+>>> import numpy as np
+>>> from halotools.empirical_models import Behroozi10SmHm
+>>> model = Behroozi10SmHm(redshift = 0)
+>>> log_sm_sample1 = np.log10(high_mass_gals['stellar_mass'])
+>>> approx_log_mhalo_sample1 = model.mean_log_halo_mass(log_stellar_mass=log_sm_sample1)
+
+We now have a rough estimate of the host halo mass of our high-mass galaxy sample.
+From this information, we can use the `~halotools.empirical_models.halo_mass_to_halo_radius`
+function to estimate :math:`R_{\rm vir}`:
+
+>>> from halotools.empirical_models import halo_mass_to_halo_radius
+>>> cosmology = halocat.cosmology
+>>> redshift = 0
+>>> mdef = 'vir'
+>>> approx_rvir_sample1 = halo_mass_to_halo_radius(10**approx_log_mhalo_sample1, cosmology, redshift, mdef)
+
+To estimate :math:`V_{\rm vir}` we can use the
+`~halotools.empirical_models.halo_mass_to_virial_velocity` function:
+
+>>> from halotools.empirical_models import halo_mass_to_virial_velocity
+>>> approx_vvir_sample1 = halo_mass_to_virial_velocity(10**approx_log_mhalo_sample1, cosmology, redshift, mdef)
+
+Using the variable search radius feature of counts-in-cylinders
+=================================================================
+
+From the previous section, we now have two arrays, ``approx_rvir_sample1``
+and ``approx_vvir_sample1``. We want to use these arrays in our call to the
+`counts_in_cylinders` function to place a cylinder of radius :math:`2R_{\rm vir}`
+and half-length defined by :math:`3V_{\rm vir}`.
+Both inputs must be in length units of Mpc/h.
+Our ``approx_rvir_sample1`` array already is in Mpc/h, so we have:
+
+>>> proj_search_radius = 2*approx_rvir_sample1
+
+However, our ``approx_vvir_sample1`` array is in km/s.
+Since all units in Halotools assume *h=1*, then in Halotools units we have
+:math:`H_{0} = 100h` km/s/Mpc, and our virial velocity criteria
+gets transformed into a z-dimension length criteria as:
+
+>>> H0 = 100.0
+>>> cylinder_half_length = 3*approx_vvir_sample1/H0
+
+Now we just need to place our galaxy positions into redshift-space,
+formatting the result into the
+appropriately shaped array using the `return_xyz_formatted_array` function:
+
+>>> from halotools.mock_observables import return_xyz_formatted_array
+>>> x1, y1, z1 = high_mass_gals['x'], high_mass_gals['y'], high_mass_gals['z']
+>>> x2, y2, z2 = low_mass_gals['x'], low_mass_gals['y'], low_mass_gals['z']
+>>> vz1, vz2 = high_mass_gals['vz'], low_mass_gals['vz']
+>>> sample1 = return_xyz_formatted_array(x1, y1, z1, period=halocat.Lbox, velocity=vz1, velocity_distortion_dimension='z')
+>>> sample2 = return_xyz_formatted_array(x2, y2, z2, period=halocat.Lbox, velocity=vz2, velocity_distortion_dimension='z')
+
+We now have all inputs to the `counts_in_cylinders` function put into Mpc/h units
+and in the appropriately shaped arrays, so we can call the function:
+
+>>> from halotools.mock_observables import counts_in_cylinders
+>>> result = counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_half_length, period=halocat.Lbox)

--- a/halotools/mock_observables/__init__.py
+++ b/halotools/mock_observables/__init__.py
@@ -16,3 +16,4 @@ from .pair_counters import (npairs_3d, npairs_projected, npairs_xy_z,
 from .radial_profiles import *
 from .two_point_clustering import *
 from .large_scale_density import *
+from .counts_in_cells import *

--- a/halotools/mock_observables/counts_in_cells/__init__.py
+++ b/halotools/mock_observables/counts_in_cells/__init__.py
@@ -1,0 +1,3 @@
+"""
+"""
+from .counts_in_cylinders import counts_in_cylinders

--- a/halotools/mock_observables/counts_in_cells/counts_in_cylinders.py
+++ b/halotools/mock_observables/counts_in_cells/counts_in_cylinders.py
@@ -1,0 +1,253 @@
+""" Module containing the `~halotools.mock_observables.counts_in_cylinders` function
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+import multiprocessing
+from functools import partial
+
+from .engines import counts_in_cylinders_engine
+
+from ..mock_observables_helpers import get_num_threads, get_period
+from ..pair_counters.rectangular_mesh import RectangularDoubleMesh
+from ..pair_counters.mesh_helpers import (_set_approximate_cell_sizes,
+    _cell1_parallelization_indices, _enclose_in_box, _enforce_maximum_search_length)
+
+from ...utils.array_utils import array_is_monotonic, custom_len
+
+__author__ = ('Andrew Hearin', )
+
+__all__ = ('counts_in_cylinders', )
+
+
+def counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_half_length,
+        period=None, verbose=False, num_threads=1,
+        approx_cell1_size=None, approx_cell2_size=None):
+    """
+    Function counts the number of points in ``sample2`` separated by a xy-distance
+    *r* and z-distance *z* from each point in ``sample1``,
+    where *r* and *z* are defined by the input ``proj_search_radius``
+    and ``cylinder_half_length``, respectively.
+
+    Parameters
+    ----------
+    sample1 : array_like
+        Npts1 x 3 numpy array containing 3-D positions of points.
+        See the :ref:`mock_obs_pos_formatting` documentation page, or the
+        Examples section below, for instructions on how to transform
+        your coordinate position arrays into the
+        format accepted by the ``sample1`` and ``sample2`` arguments.
+        Length units are comoving and assumed to be in Mpc/h, here and throughout Halotools.
+
+    sample2 : array_like, optional
+        Npts2 x 3 array containing 3-D positions of points.
+
+    proj_search_radius : array_like
+        Length-Npts1 array defining the xy-distance around each point in ``sample1``
+        to search for points in ``sample2``.
+        Length units are comoving and assumed to be in Mpc/h, here and throughout Halotools.
+
+    cylinder_half_length : array_like
+        Length-Npts1 array defining the z-distance around each point in ``sample1``
+        to search for points in ``sample2``. Thus the *total* length of the cylinder
+        placed around each point in ``sample1`` will be *twice* the corresponding
+        value stored in the input ``cylinder_half_length``.
+        Length units are comoving and assumed to be in Mpc/h, here and throughout Halotools.
+
+    period : array_like, optional
+        Length-3 array defining the periodic boundary conditions.
+        If only one number is specified, the enclosing volume is assumed to
+        be a periodic cube (by far the most common case).
+        If period is set to None, the default option,
+        PBCs are set to infinity.
+
+    verbose : Boolean, optional
+        If True, print out information and progress.
+
+    num_threads : int, optional
+        Number of threads to use in calculation, where parallelization is performed
+        using the python ``multiprocessing`` module. Default is 1 for a purely serial
+        calculation, in which case a multiprocessing Pool object will
+        never be instantiated. A string 'max' may be used to indicate that
+        the pair counters should use all available cores on the machine.
+
+    approx_cell1_size : array_like, optional
+        Length-3 array serving as a guess for the optimal manner by how points
+        will be apportioned into subvolumes of the simulation box.
+        The optimum choice unavoidably depends on the specs of your machine.
+        Default choice is to use Lbox/10 in each dimension,
+        which will return reasonable result performance for most use-cases.
+        Performance can vary sensitively with this parameter, so it is highly
+        recommended that you experiment with this parameter when carrying out
+        performance-critical calculations.
+
+    approx_cell2_size : array_like, optional
+        Analogous to ``approx_cell1_size``, but for sample2.  See comments for
+        ``approx_cell1_size`` for details.
+
+    Returns
+    -------
+    num_pairs : array_like
+        Numpy array of shape (Npts1, len(rbins)) storing the numbers of points
+        in ``sample2`` inside spheres surrounding each point in ``sample1``.
+
+    Examples
+    --------
+    For illustration purposes, we'll create some fake data and call the pair counter.
+
+    >>> from halotools.sim_manager import FakeSim
+    >>> halocat = FakeSim()
+
+    In this first example, we'll demonstrate how to calculate the number of
+    low-mass host halos are in cylinders of *fixed length* surrounding high-mass halos.
+
+    >>> host_halo_mask = halocat.halo_table['halo_upid'] == -1
+    >>> host_halos = halocat.halo_table[host_halo_mask]
+    >>> high_mass_mask = host_halos['halo_mvir'] >= 5e13
+    >>> high_mass_hosts = host_halos[high_mass_mask]
+    >>> low_mass_mask = host_halos['halo_mvir'] <= 1e12
+    >>> low_mass_hosts = host_halos[low_mass_mask]
+
+    >>> x1, y1, z1 = high_mass_hosts['halo_x'], high_mass_hosts['halo_y'], high_mass_hosts['halo_z']
+    >>> x2, y2, z2 = low_mass_hosts['halo_x'], low_mass_hosts['halo_y'], low_mass_hosts['halo_z']
+
+    We transform our *x, y, z* points into the array shape used by the pair-counter by
+    taking the transpose of the result of `numpy.vstack`. This boilerplate transformation
+    is used throughout the `~halotools.mock_observables` sub-package:
+
+    >>> sample1 = np.vstack([x1, y1, z1]).T
+    >>> sample2 = np.vstack([x2, y2, z2]).T
+
+    Now let's drop a cylinder of radius 200 kpc/h and half-length 250 kpc/h around
+    each high-mass host halo, and for each high-mass host we'll count the number of
+    low-mass halos falling within that cylinder:
+
+    >>> period = halocat.Lbox
+    >>> proj_search_radius, cylinder_half_length = 0.2, 0.25
+    >>> result = counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_half_length, period=period)
+
+    For example usage of the `~halotools.mock_observables.counts_in_cylinders` function
+    on a realistic galaxy catalog that makes use of the variable search length feature,
+    see the :ref:`calculating_counts_in_cells` tutorial.
+
+
+    """
+
+    ### Process the inputs with the helper function
+    result = _counts_in_cylinders_process_args(sample1, sample2, proj_search_radius,
+            cylinder_half_length, period, verbose, num_threads, approx_cell1_size, approx_cell2_size)
+    x1in, y1in, z1in, x2in, y2in, z2in, proj_search_radius, cylinder_half_length = result[0:8]
+    period, num_threads, PBCs, approx_cell1_size, approx_cell2_size = result[8:]
+    xperiod, yperiod, zperiod = period
+
+    rp_max = np.max(proj_search_radius)
+    pi_max = np.max(cylinder_half_length)
+    search_xlength, search_ylength, search_zlength = rp_max, rp_max, pi_max
+
+    ### Compute the estimates for the cell sizes
+    approx_cell1_size, approx_cell2_size = (
+        _set_approximate_cell_sizes(approx_cell1_size, approx_cell2_size, period)
+        )
+    approx_x1cell_size, approx_y1cell_size, approx_z1cell_size = approx_cell1_size
+    approx_x2cell_size, approx_y2cell_size, approx_z2cell_size = approx_cell2_size
+
+    # Build the rectangular mesh
+    double_mesh = RectangularDoubleMesh(x1in, y1in, z1in, x2in, y2in, z2in,
+        approx_x1cell_size, approx_y1cell_size, approx_z1cell_size,
+        approx_x2cell_size, approx_y2cell_size, approx_z2cell_size,
+        search_xlength, search_ylength, search_zlength, xperiod, yperiod, zperiod, PBCs)
+
+    # Create a function object that has a single argument, for parallelization purposes
+    engine = partial(counts_in_cylinders_engine,
+        double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, proj_search_radius, cylinder_half_length)
+
+    # Calculate the cell1 indices that will be looped over by the engine
+    num_threads, cell1_tuples = _cell1_parallelization_indices(
+        double_mesh.mesh1.ncells, num_threads)
+
+    if num_threads > 1:
+        pool = multiprocessing.Pool(num_threads)
+        result = pool.map(engine, cell1_tuples)
+        counts = np.vstack(result)
+        pool.close()
+    else:
+        result = engine(cell1_tuples[0])
+        counts = np.vstack(result)
+
+    return counts.flatten()
+
+
+def _counts_in_cylinders_process_args(sample1, sample2, proj_search_radius, cylinder_half_length,
+        period, verbose, num_threads, approx_cell1_size, approx_cell2_size):
+    """
+    """
+    num_threads = get_num_threads(num_threads)
+
+    # Passively enforce that we are working with ndarrays
+    x1 = sample1[:, 0]
+    y1 = sample1[:, 1]
+    z1 = sample1[:, 2]
+    x2 = sample2[:, 0]
+    y2 = sample2[:, 1]
+    z2 = sample2[:, 2]
+
+    proj_search_radius = np.atleast_1d(proj_search_radius).astype('f8')
+    if len(proj_search_radius) == 1:
+        proj_search_radius = np.zeros_like(x1) + proj_search_radius[0]
+    elif len(proj_search_radius) == len(x1):
+        pass
+    else:
+        msg = "Input ``proj_search_radius`` must be a scalar or length-Npts1 array"
+        raise ValueError(msg)
+    max_rp_max = np.max(proj_search_radius)
+
+    cylinder_half_length = np.atleast_1d(cylinder_half_length).astype('f8')
+    if len(cylinder_half_length) == 1:
+        cylinder_half_length = np.zeros_like(x1) + cylinder_half_length[0]
+    elif len(cylinder_half_length) == len(x1):
+        pass
+    else:
+        msg = "Input ``cylinder_half_length`` must be a scalar or length-Npts1 array"
+        raise ValueError(msg)
+    max_pi_max = np.max(cylinder_half_length)
+
+    period, PBCs = get_period(period)
+    # At this point, period may still be set to None,
+    # in which case we must remap our points inside the smallest enclosing cube
+    # and set ``period`` equal to this cube size.
+    if period is None:
+        __, __, __, __, __, __, period = (
+            _enclose_in_box(
+                sample1[:, 0], sample1[:, 2], sample1[:, 2],
+                sample2[:, 0], sample2[:, 2], sample2[:, 2],
+                min_size=[max_rp_max*3.0, max_rp_max*3.0, max_pi_max*3.0]))
+        x1 = sample1[:, 0]
+        y1 = sample1[:, 1]
+        z1 = sample1[:, 2]
+        x2 = sample2[:, 0]
+        y2 = sample2[:, 1]
+        z2 = sample2[:, 2]
+    else:
+        x1 = sample1[:, 0]
+        y1 = sample1[:, 1]
+        z1 = sample1[:, 2]
+        x2 = sample2[:, 0]
+        y2 = sample2[:, 1]
+        z2 = sample2[:, 2]
+
+    _enforce_maximum_search_length(max_rp_max, period[0])
+    _enforce_maximum_search_length(max_rp_max, period[1])
+    _enforce_maximum_search_length(max_pi_max, period[2])
+
+    if approx_cell1_size is None:
+        approx_cell1_size = [max_rp_max, max_rp_max, max_pi_max]
+    elif custom_len(approx_cell1_size) == 1:
+        approx_cell1_size = [approx_cell1_size, approx_cell1_size, approx_cell1_size]
+    if approx_cell2_size is None:
+        approx_cell2_size = [max_rp_max, max_rp_max, max_pi_max]
+    elif custom_len(approx_cell2_size) == 1:
+        approx_cell2_size = [approx_cell2_size, approx_cell2_size, approx_cell2_size]
+
+    return (x1, y1, z1, x2, y2, z2,
+        proj_search_radius, cylinder_half_length, period, num_threads, PBCs,
+        approx_cell1_size, approx_cell2_size)

--- a/halotools/mock_observables/counts_in_cells/engines/__init__.py
+++ b/halotools/mock_observables/counts_in_cells/engines/__init__.py
@@ -1,0 +1,8 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .counts_in_cylinders_engine import counts_in_cylinders_engine
+
+__all__ = ('counts_in_cylinders_engine', )

--- a/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
+++ b/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
@@ -1,0 +1,227 @@
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+cimport numpy as cnp
+cimport cython
+from libc.math cimport ceil
+
+from ....utils import unsorting_indices
+
+__author__ = ('Andrew Hearin', )
+__all__ = ('counts_in_cylinders_engine', )
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nonecheck(False)
+def counts_in_cylinders_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rp_max, pi_max, cell1_tuple):
+    """
+    Cython engine for determining counting the number of points in ``sample2``
+    in a cylinder surrounding each point in ``sample1``.
+
+    Parameters
+    ----------
+    double_mesh : object
+        Instance of `~halotools.mock_observables.RectangularDoubleMesh`
+
+    x1in : numpy.array
+        Length-Npts1 array storing Cartesian x-coordinates of points of 'sample 1'
+
+    y1in : numpy.array
+        Length-Npts1 array storing Cartesian y-coordinates of points of 'sample 1'
+
+    z1in : numpy.array
+        Length-Npts1 array storing Cartesian z-coordinates of points of 'sample 1'
+
+    x2in : numpy.array
+        Length-Npts2 array storing Cartesian x-coordinates of points of 'sample 2'
+
+    y2in : numpy.array
+        Length-Npts2 array storing Cartesian y-coordinates of points of 'sample 2'
+
+    z2in : numpy.array
+        Length-Npts2 array storing Cartesian z-coordinates of points of 'sample 2'
+
+    rp_max : numpy.array
+        Length-Npts1 array storing the x-y projected radial distance,
+        i.e., the radius of cylinder, to search
+        for neighbors around each point in 'sample 1'
+
+    pi_max : numpy.array
+        Length-Npts1 array storing the z distance,
+        i.e., the half the length of a cylinder,
+        to search for neighbors around each point in 'sample 1'
+
+    cell1_tuple : tuple
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
+
+    Returns
+    -------
+    counts : numpy.array
+        Length-Npts1 integer array storing the number of ``sample2`` points
+        inside a cylinder centered at each point in ``sample1``.
+    """
+
+    rp_max_squared_tmp = rp_max*rp_max
+    cdef cnp.float64_t[:] rp_max_squared = np.ascontiguousarray(
+        rp_max_squared_tmp[double_mesh.mesh1.idx_sorted])
+    pi_max_squared_tmp = pi_max*pi_max
+    cdef cnp.float64_t[:] pi_max_squared = np.ascontiguousarray(
+        pi_max_squared_tmp[double_mesh.mesh1.idx_sorted])
+
+    cdef cnp.float64_t xperiod = double_mesh.xperiod
+    cdef cnp.float64_t yperiod = double_mesh.yperiod
+    cdef cnp.float64_t zperiod = double_mesh.zperiod
+    cdef cnp.int64_t first_cell1_element = cell1_tuple[0]
+    cdef cnp.int64_t last_cell1_element = cell1_tuple[1]
+    cdef int PBCs = double_mesh._PBCs
+
+    cdef int Ncell1 = double_mesh.mesh1.ncells
+    cdef int Npts1 = len(x1in)
+
+    cdef cnp.float64_t[:] x1_sorted = np.ascontiguousarray(
+        x1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
+    cdef cnp.float64_t[:] y1_sorted = np.ascontiguousarray(
+        y1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
+    cdef cnp.float64_t[:] z1_sorted = np.ascontiguousarray(
+        z1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
+    cdef cnp.float64_t[:] x2_sorted = np.ascontiguousarray(
+        x2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
+    cdef cnp.float64_t[:] y2_sorted = np.ascontiguousarray(
+        y2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
+    cdef cnp.float64_t[:] z2_sorted = np.ascontiguousarray(
+        z2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
+
+    cdef cnp.int64_t[:] counts = np.zeros(len(x1_sorted), dtype=np.int64)
+
+    cdef cnp.int64_t icell1, icell2
+    cdef cnp.int64_t[:] cell1_indices = np.ascontiguousarray(
+        double_mesh.mesh1.cell_id_indices, dtype=np.int64)
+    cdef cnp.int64_t[:] cell2_indices = np.ascontiguousarray(
+        double_mesh.mesh2.cell_id_indices, dtype=np.int64)
+
+    cdef cnp.int64_t ifirst1, ilast1, ifirst2, ilast2
+
+    cdef int ix2, iy2, iz2, ix1, iy1, iz1
+    cdef int nonPBC_ix2, nonPBC_iy2, nonPBC_iz2
+
+    cdef int num_x2_covering_steps = int(np.ceil(
+        double_mesh.search_xlength / double_mesh.mesh2.xcell_size))
+    cdef int num_y2_covering_steps = int(np.ceil(
+        double_mesh.search_ylength / double_mesh.mesh2.ycell_size))
+    cdef int num_z2_covering_steps = int(np.ceil(
+        double_mesh.search_zlength / double_mesh.mesh2.zcell_size))
+
+    cdef int leftmost_ix2, rightmost_ix2
+    cdef int leftmost_iy2, rightmost_iy2
+    cdef int leftmost_iz2, rightmost_iz2
+
+    cdef int num_x1divs = double_mesh.mesh1.num_xdivs
+    cdef int num_y1divs = double_mesh.mesh1.num_ydivs
+    cdef int num_z1divs = double_mesh.mesh1.num_zdivs
+    cdef int num_x2divs = double_mesh.mesh2.num_xdivs
+    cdef int num_y2divs = double_mesh.mesh2.num_ydivs
+    cdef int num_z2divs = double_mesh.mesh2.num_zdivs
+    cdef int num_x2_per_x1 = num_x2divs // num_x1divs
+    cdef int num_y2_per_y1 = num_y2divs // num_y1divs
+    cdef int num_z2_per_z1 = num_z2divs // num_z1divs
+
+    cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq, dxy_sq, dz_sq
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp, rp_max_squaredtmp, pi_max_squaredtmp
+    cdef int Ni, Nj, i, j, k, l, current_data1_index
+
+    cdef cnp.float64_t[:] x_icell1, x_icell2
+    cdef cnp.float64_t[:] y_icell1, y_icell2
+    cdef cnp.float64_t[:] z_icell1, z_icell2
+
+    for icell1 in range(first_cell1_element, last_cell1_element):
+        ifirst1 = cell1_indices[icell1]
+        ilast1 = cell1_indices[icell1+1]
+        x_icell1 = x1_sorted[ifirst1:ilast1]
+        y_icell1 = y1_sorted[ifirst1:ilast1]
+        z_icell1 = z1_sorted[ifirst1:ilast1]
+
+        Ni = ilast1 - ifirst1
+        if Ni > 0:
+
+            ix1 = icell1 // (num_y1divs*num_z1divs)
+            iy1 = (icell1 - ix1*num_y1divs*num_z1divs) // num_z1divs
+            iz1 = icell1 - (ix1*num_y1divs*num_z1divs) - (iy1*num_z1divs)
+
+            leftmost_ix2 = ix1*num_x2_per_x1 - num_x2_covering_steps
+            leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
+            leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
+
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
+
+            for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
+                if nonPBC_ix2 < 0:
+                    x2shift = -xperiod*PBCs
+                elif nonPBC_ix2 >= num_x2divs:
+                    x2shift = +xperiod*PBCs
+                else:
+                    x2shift = 0.
+                # Now apply the PBCs
+                ix2 = nonPBC_ix2 % num_x2divs
+
+                for nonPBC_iy2 in range(leftmost_iy2, rightmost_iy2):
+                    if nonPBC_iy2 < 0:
+                        y2shift = -yperiod*PBCs
+                    elif nonPBC_iy2 >= num_y2divs:
+                        y2shift = +yperiod*PBCs
+                    else:
+                        y2shift = 0.
+                    # Now apply the PBCs
+                    iy2 = nonPBC_iy2 % num_y2divs
+
+                    for nonPBC_iz2 in range(leftmost_iz2, rightmost_iz2):
+                        if nonPBC_iz2 < 0:
+                            z2shift = -zperiod*PBCs
+                        elif nonPBC_iz2 >= num_z2divs:
+                            z2shift = +zperiod*PBCs
+                        else:
+                            z2shift = 0.
+                        # Now apply the PBCs
+                        iz2 = nonPBC_iz2 % num_z2divs
+
+                        icell2 = ix2*(num_y2divs*num_z2divs) + iy2*num_z2divs + iz2
+                        ifirst2 = cell2_indices[icell2]
+                        ilast2 = cell2_indices[icell2+1]
+
+                        x_icell2 = x2_sorted[ifirst2:ilast2]
+                        y_icell2 = y2_sorted[ifirst2:ilast2]
+                        z_icell2 = z2_sorted[ifirst2:ilast2]
+
+                        Nj = ilast2 - ifirst2
+                        #loop over points in cell1
+                        if Nj > 0:
+                            for i in range(0,Ni):
+                                x1tmp = x_icell1[i] - x2shift
+                                y1tmp = y_icell1[i] - y2shift
+                                z1tmp = z_icell1[i] - z2shift
+                                rp_max_squaredtmp = rp_max_squared[ifirst1+i]
+                                pi_max_squaredtmp = pi_max_squared[ifirst1+i]
+
+                                #loop over points in cell2
+                                for j in range(0,Nj):
+                                    #calculate the square distance
+                                    dx = x1tmp - x_icell2[j]
+                                    dy = y1tmp - y_icell2[j]
+                                    dz = z1tmp - z_icell2[j]
+                                    dxy_sq = dx*dx + dy*dy
+                                    dz_sq = dz*dz
+
+                                    if (dxy_sq < rp_max_squaredtmp) & (dz_sq < pi_max_squaredtmp):
+                                        counts[ifirst1+i] += 1
+
+    # At this point, we have calculated our counts on the input arrays *after* sorting
+    # Since the order of counts matters in this calculation, we need to undo the sorting
+    sorted_counts = np.array(counts)
+    idx_unsorted = unsorting_indices(double_mesh.mesh1.idx_sorted)
+    return sorted_counts[idx_unsorted]
+

--- a/halotools/mock_observables/counts_in_cells/engines/setup_package.py
+++ b/halotools/mock_observables/counts_in_cells/engines/setup_package.py
@@ -1,0 +1,27 @@
+from distutils.extension import Extension
+import os
+
+PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
+SOURCES = ("counts_in_cylinders_engine.pyx", )
+THIS_PKG_NAME = '.'.join(__name__.split('.')[:-1])
+
+
+def get_extensions():
+
+    names = [THIS_PKG_NAME + "." + src.replace('.pyx', '') for src in SOURCES]
+    sources = [os.path.join(PATH_TO_PKG, srcfn) for srcfn in SOURCES]
+    include_dirs = ['numpy']
+    libraries = []
+    language ='c++'
+    extra_compile_args = ['-Ofast']
+
+    extensions = []
+    for name, source in zip(names, sources):
+        extensions.append(Extension(name=name,
+            sources=[source],
+            include_dirs=include_dirs,
+            libraries=libraries,
+            language=language,
+            extra_compile_args=extra_compile_args))
+
+    return extensions

--- a/halotools/mock_observables/counts_in_cells/tests/pure_python_counts_in_cells.py
+++ b/halotools/mock_observables/counts_in_cells/tests/pure_python_counts_in_cells.py
@@ -1,0 +1,59 @@
+"""
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from astropy.utils.misc import NumpyRNGContext
+
+from ...tests.cf_helpers import generate_locus_of_3d_points, generate_3d_regular_mesh
+
+__all__ = ('pure_python_counts_in_cylinders', )
+
+fixed_seed = 43
+
+
+def pure_python_counts_in_cylinders(
+        sample1, sample2, rp_max, pi_max, period=None):
+    """ Brute force pure python function calculating the distance
+    between all pairs of points and storing the result into two matrices,
+    one storing xy-distances, the other storing z-distances,
+    account for possible periodicity of the box.
+    """
+    if period is None:
+        xperiod, yperiod, zperiod = np.inf, np.inf, np.inf
+    else:
+        xperiod, yperiod, zperiod = period, period, period
+
+    npts1, npts2 = len(sample1), len(sample2)
+
+    counts = np.zeros(npts1, dtype=int)
+
+    for i in range(npts1):
+        for j in range(npts2):
+            dx = sample1[i, 0] - sample2[j, 0]
+            dy = sample1[i, 1] - sample2[j, 1]
+            dz = sample1[i, 2] - sample2[j, 2]
+
+            if dx > xperiod/2.:
+                dx = xperiod - dx
+            elif dx < -xperiod/2.:
+                dx = -(xperiod + dx)
+
+            if dy > yperiod/2.:
+                dy = yperiod - dy
+            elif dy < -yperiod/2.:
+                dy = -(yperiod + dy)
+
+            if dz > zperiod/2.:
+                dz = zperiod - dz
+            elif dz < -zperiod/2.:
+                dz = -(zperiod + dz)
+
+            rp = np.sqrt(dx*dx + dy*dy)
+            dz = abs(dz)
+            rp_cylinder = rp_max[i]
+            pi_cylinder = pi_max[i]
+            if (rp <= rp_cylinder) & (dz <= pi_cylinder):
+                counts[i] += 1
+
+    return counts

--- a/halotools/mock_observables/counts_in_cells/tests/test_counts_in_cylinders.py
+++ b/halotools/mock_observables/counts_in_cells/tests/test_counts_in_cylinders.py
@@ -1,0 +1,195 @@
+""" Module providing testing for the `~halotools.mock_observables.counts_in_cylinders` function.
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from astropy.utils.misc import NumpyRNGContext
+from astropy.tests.helper import pytest
+
+from .pure_python_counts_in_cells import pure_python_counts_in_cylinders
+
+from ..counts_in_cylinders import counts_in_cylinders
+
+from ...tests.cf_helpers import generate_locus_of_3d_points, generate_3d_regular_mesh
+
+__all__ = ('test_counts_in_cylinders0', 'test_counts_in_cylinders1', 'test_counts_in_cylinders2')
+
+fixed_seed = 43
+seed_list = np.arange(5).astype(int)
+
+
+def test_counts_in_cylinders0():
+    """ For ``sample1`` a regular grid and ``sample2`` a tightly locus of points
+    in the immediate vicinity of a grid node, verify that the returned counts
+    are correct with scalar inputs for proj_search_radius and cylinder_half_length
+    """
+    period = 1
+    # set(sample1) = 0.1, 0.3, 0.5, 0.7, 0.9, with mesh[0,:] = (0.1, 0.1, 0.1)
+    sample1 = generate_3d_regular_mesh(5)
+
+    npts2 = 100
+    sample2 = generate_locus_of_3d_points(npts2, xc=0.101, yc=0.101, zc=0.101, seed=fixed_seed)
+
+    proj_search_radius, cylinder_half_length = 0.02, 0.02
+
+    result = counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_half_length, period=period)
+    assert np.shape(result) == (len(sample1), )
+    assert np.sum(result) == npts2
+
+
+def test_counts_in_cylinders1():
+    """ For ``sample1`` a regular grid and ``sample2`` a tightly locus of points
+    in the immediate vicinity of a grid node, verify that the returned counts
+    are correct with scalar inputs for proj_search_radius and cylinder_half_length
+    """
+    period = 1
+    # set(sample1) = 0.1, 0.3, 0.5, 0.7, 0.9, with mesh[0,:] = (0.1, 0.1, 0.1)
+    sample1 = generate_3d_regular_mesh(5)
+
+    npts2 = 100
+    sample2 = generate_locus_of_3d_points(npts2, xc=0.101, yc=0.101, zc=0.101, seed=fixed_seed)
+
+    proj_search_radius, cylinder_half_length = 0.02, 0.02
+
+    result = counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_half_length, period=period)
+    assert result[0] == npts2
+    assert np.all(result[1:] == 0)
+
+
+def test_counts_in_cylinders2():
+    """ For ``sample1`` a regular grid and ``sample2`` a tightly locus of points
+    in the immediate vicinity of a grid node, verify that the returned counts
+    are correct with scalar inputs for proj_search_radius and cylinder_half_length
+    """
+    period = 1
+    # set(sample1) = 0.1, 0.3, 0.5, 0.7, 0.9, with mesh[55,:] = (0.3,  0.5,  0.1)
+    sample1 = generate_3d_regular_mesh(5)
+
+    npts2 = 100
+    idx_to_test = 55
+    sample2 = generate_locus_of_3d_points(npts2,
+        xc=sample1[idx_to_test, 0] + 0.001,
+        yc=sample1[idx_to_test, 1] + 0.001,
+        zc=sample1[idx_to_test, 2] + 0.001,
+        seed=fixed_seed)
+
+    print("Sample2 (xmin, xmax) = ({0:.3F}, {1:.3F})".format(np.min(sample2[:, 0]), np.max(sample2[:, 0])))
+    print("Sample2 (ymin, ymax) = ({0:.3F}, {1:.3F})".format(np.min(sample2[:, 1]), np.max(sample2[:, 1])))
+    print("Sample2 (zmin, zmax) = ({0:.3F}, {1:.3F})".format(np.min(sample2[:, 2]), np.max(sample2[:, 2])))
+
+    proj_search_radius, cylinder_half_length = 0.02, 0.02
+
+    result = counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_half_length, period=period)
+    assert np.sum(result == npts2)
+
+    idx_result = np.where(result != 0)[0]
+    print("Index where the counts_in_cylinders function identifies points = {0}".format(idx_result))
+    print("Correct index should be {0}".format(idx_to_test))
+    print("\n")
+    print("Point in sample1 corresponding to the incorrect index = {0}".format(sample1[idx_result[0]]))
+    print("Point in sample1 corresponding to the correct index   = {0}".format(sample1[idx_to_test]))
+    assert result[idx_to_test] == npts2
+    assert np.all(result[0:idx_to_test] == 0)
+    assert np.all(result[idx_to_test+1:] == 0)
+
+
+def test_counts_in_cylinders_brute_force1():
+    """
+    """
+    npts1 = 100
+    npts2 = 90
+
+    for seed in seed_list:
+        with NumpyRNGContext(seed):
+            sample1 = np.random.random((npts1, 3))
+            sample2 = np.random.random((npts2, 3))
+
+        rp_max = np.zeros(npts1) + 0.2
+        pi_max = np.zeros(npts1) + 0.2
+        brute_force_result = pure_python_counts_in_cylinders(sample1, sample2, rp_max, pi_max)
+        result = counts_in_cylinders(sample1, sample2, rp_max, pi_max)
+        assert brute_force_result.shape == result.shape
+        assert np.all(result == brute_force_result)
+
+
+def test_counts_in_cylinders_brute_force2():
+    """
+    """
+    npts1 = 100
+    npts2 = 90
+
+    for seed in seed_list:
+        with NumpyRNGContext(seed):
+            sample1 = np.random.random((npts1, 3))
+            sample2 = np.random.random((npts2, 3))
+
+        rp_max = np.zeros(npts1) + 0.2
+        pi_max = np.zeros(npts1) + 0.2
+        brute_force_result = pure_python_counts_in_cylinders(sample1, sample2, rp_max, pi_max, period=1)
+        result = counts_in_cylinders(sample1, sample2, rp_max, pi_max, period=1)
+        assert brute_force_result.shape == result.shape
+        assert np.all(result == brute_force_result)
+
+
+def test_counts_in_cylinders_brute_force3():
+    """
+    """
+    npts1 = 100
+    npts2 = 90
+
+    for seed in seed_list:
+        with NumpyRNGContext(seed):
+            sample1 = np.random.random((npts1, 3))
+            sample2 = np.random.random((npts2, 3))
+            rp_max = np.random.uniform(0, 0.2, npts1)
+            pi_max = np.random.uniform(0, 0.2, npts1)
+
+        brute_force_result = pure_python_counts_in_cylinders(sample1, sample2, rp_max, pi_max)
+        result = counts_in_cylinders(sample1, sample2, rp_max, pi_max)
+        assert brute_force_result.shape == result.shape
+        assert np.all(result == brute_force_result)
+
+
+def test_counts_in_cylinders_brute_force4():
+    """
+    """
+    npts1 = 100
+    npts2 = 90
+
+    for seed in seed_list:
+        with NumpyRNGContext(seed):
+            sample1 = np.random.random((npts1, 3))
+            sample2 = np.random.random((npts2, 3))
+            rp_max = np.random.uniform(0, 0.2, npts1)
+            pi_max = np.random.uniform(0, 0.2, npts1)
+
+        brute_force_result = pure_python_counts_in_cylinders(sample1, sample2, rp_max, pi_max, period=1)
+        result = counts_in_cylinders(sample1, sample2, rp_max, pi_max, period=1)
+        assert brute_force_result.shape == result.shape
+        assert np.all(result == brute_force_result)
+
+
+def test_counts_in_cylinders_error_handling():
+    """
+    """
+    npts1 = 100
+    npts2 = 90
+
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
+        rp_max = np.random.uniform(0, 0.2, npts1)
+        pi_max = np.random.uniform(0, 0.2, npts1)
+
+    with pytest.raises(ValueError) as err:
+        __ = counts_in_cylinders(sample1, sample2, rp_max[1:], pi_max, period=1)
+    substr = "Input ``proj_search_radius`` must be a scalar or length-Npts1 array"
+    assert substr in err.value.args[0]
+
+    with pytest.raises(ValueError) as err:
+        __ = counts_in_cylinders(sample1, sample2, rp_max, pi_max[1:], period=1)
+    substr = "Input ``cylinder_half_length`` must be a scalar or length-Npts1 array"
+    assert substr in err.value.args[0]
+
+    __ = counts_in_cylinders(sample1, sample2, rp_max, pi_max, period=1,
+        approx_cell1_size=0.2, approx_cell2_size=0.2)

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_per_object_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_per_object_3d_engine.pyx
@@ -201,7 +201,7 @@ def npairs_per_object_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     # Since the order of counts matters in this calculation, we need to undo the sorting
     sorted_counts = np.array(outer_counts)
     idx_unsorted = unsorting_indices(double_mesh.mesh1.idx_sorted)
-    return sorted_counts[idx_unsorted]
+    return sorted_counts[idx_unsorted, :]
 
 
 


### PR DESCRIPTION
This PR introduces a new `mock_observables` function: counts_in_cylinders. The API is:

```
counts_in_cylinders(sample1, sample2, proj_search_radius, cylinder_length)
```
The function returns a length-Npts1 integer array storing the number of `sample2` points inside a cylinder around each point in `sample1`. 

**Optional feature.** The search radii and cylinder lengths are permitted to be vary from point-to-point in `sample1`, permitting the user, for example, to define a search radius according to a virial radius estimate of the `sample1` points (such as one based on stellar mass from abundance matching). 