### PR TITLE
Compile args centralization

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -82,9 +82,9 @@ This will install the master branch of the code that is currently under developm
 	functions by 10-40% (with zero impact on the performance
 	of the mock-making algorithm implemented in `~halotools.empirical_models`).
 	To compile Halotools with these flags thrown,
-	simply add two new elements to the
-	``extra_compiler_args`` list in every source code file
-	named ``setup_package.py``: the string ``'-Ofast'`` and
+	simply change the strings stored in the ``mock_observables_extra_compile_args``
+	list defined in cython_config.py so that this list contains two strings:
+	the string ``'-Ofast'`` and
 	the string ``'-march=native'``.
 	When you've made these modifications to the code,
 	install Halotools by following the *Building fom source* instructions above

--- a/halotools/cython_config.py
+++ b/halotools/cython_config.py
@@ -1,0 +1,5 @@
+"""
+"""
+# The following global variable defines how the mock_observables
+# cython sub-packages will compile
+mock_observables_extra_compile_args = ['-Ofast']

--- a/halotools/mock_observables/counts_in_cells/engines/setup_package.py
+++ b/halotools/mock_observables/counts_in_cells/engines/setup_package.py
@@ -1,5 +1,6 @@
 from distutils.extension import Extension
 import os
+from ....cython_config import mock_observables_extra_compile_args as mo_args
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
 SOURCES = ("counts_in_cylinders_engine.pyx", )
@@ -13,7 +14,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = mo_args
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/isolation_functions/engines/setup_package.py
+++ b/halotools/mock_observables/isolation_functions/engines/setup_package.py
@@ -1,5 +1,6 @@
 from distutils.extension import Extension
 import os
+from ....cython_config import mock_observables_extra_compile_args as mo_args
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
 SOURCES = ("spherical_isolation_engine.pyx", "cylindrical_isolation_engine.pyx",
@@ -15,7 +16,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = mo_args
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pair_counters/cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/cpairs/setup_package.py
@@ -1,5 +1,6 @@
 from distutils.extension import Extension
 import os
+from ....cython_config import mock_observables_extra_compile_args as mo_args
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
 SOURCES = ("distances.pyx", "pairwise_distances.pyx",
@@ -16,7 +17,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = mo_args
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/setup_package.py
@@ -1,5 +1,6 @@
 from distutils.extension import Extension
 import os
+from ....cython_config import mock_observables_extra_compile_args as mo_args
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
 SOURCES = ("custom_weighting_func.pyx",
@@ -16,7 +17,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = mo_args
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/pairwise_velocities/engines/setup_package.py
+++ b/halotools/mock_observables/pairwise_velocities/engines/setup_package.py
@@ -1,5 +1,6 @@
 from distutils.extension import Extension
 import os
+from ....cython_config import mock_observables_extra_compile_args as mo_args
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
 SOURCES = ("velocity_marked_npairs_3d_engine.pyx",
@@ -16,7 +17,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = mo_args
 
     extensions = []
     for name, source in zip(names, sources):

--- a/halotools/mock_observables/radial_profiles/engines/setup_package.py
+++ b/halotools/mock_observables/radial_profiles/engines/setup_package.py
@@ -1,5 +1,6 @@
 from distutils.extension import Extension
 import os
+from ....cython_config import mock_observables_extra_compile_args as mo_args
 
 PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
 SOURCES = ("radial_profile_3d_engine.pyx", )
@@ -13,7 +14,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
     language ='c++'
-    extra_compile_args = ['-Ofast']
+    extra_compile_args = mo_args
 
     extensions = []
     for name, source in zip(names, sources):


### PR DESCRIPTION
This PR moves the definition of the cython `extra_compile_args` argument into a single place used package-wide, making it easier for users to painlessly configure their cython compilation according to the version of gcc they have available to them. 