### PR TITLE
Reprocess sims

### DIFF
--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -190,6 +190,8 @@ class CachedHaloCatalog(object):
 
         self.halo_table_cache = HaloTableCache()
 
+        self._disallow_catalogs_with_known_bugs(**kwargs)
+
         self.log_entry = self._determine_cache_log_entry(**kwargs)
         self.simname = self.log_entry.simname
         self.halo_finder = self.log_entry.halo_finder
@@ -208,6 +210,7 @@ class CachedHaloCatalog(object):
             del _
 
         self._set_publication_list(self.simname)
+
 
     def _set_publication_list(self, simname):
         try:
@@ -575,7 +578,7 @@ class CachedHaloCatalog(object):
                     except AssertionError:
                         msg = ("The ``" + attr + "`` metadata of the hdf5 file \n"
                             "is inconsistent with the corresponding attribute of the \n"
-                            + matching_sim.__class__.__name__ + "class in the "
+                            + matching_sim.__class__.__name__ + " class in the "
                             "sim_manager.supported_sims module.\n"
                             "Double-check the value of this attribute in the \n"
                             "NbodySimulation sub-class you added to the supported_sims module. \n"
@@ -621,6 +624,18 @@ class CachedHaloCatalog(object):
                 return self._ptcl_table
             else:
                 raise InvalidCacheLogEntry(ptcl_log_entry._cache_safety_message)
+
+    def _disallow_catalogs_with_known_bugs(self, simname=sim_defaults.default_simname,
+            version_name=sim_defaults.default_version_name, **kwargs):
+        """
+        """
+        if (simname == 'bolplanck') and ('halotools_alpha_version' in version_name):
+            msg = ("The ``{0}`` version of the ``{1}`` simulation \n"
+            "is known to be spatially incomplete and should not be used.\n"
+            "See https://github.com/astropy/halotools/issues/598.\n"
+            "You can either download the original ASCII data and process it yourself, \n"
+            "or use version_name = ``halotools_v0p4`` instead.\n")
+            raise HalotoolsError(msg.format(version_name, simname))
 
     def _enforce_halo_ptcl_catalog_consistency(self, halo_log_entry, ptcl_log_entry):
         """

--- a/halotools/sim_manager/sim_defaults.py
+++ b/halotools/sim_manager/sim_defaults.py
@@ -18,9 +18,9 @@ from astropy import cosmology
 # such as calling the `populate_mock()` method of composite models
 default_simname = 'bolshoi'
 default_halo_finder = 'rockstar'
-default_version_name = 'halotools_alpha_version2'
+default_version_name = 'halotools_v0p4'
 default_redshift = 0.0
-default_ptcl_version_name = 'halotools_alpha_version1'
+default_ptcl_version_name = 'halotools_v0p4'
 
 # The following two variables are used to define completeness cuts applied to halo catalogs
 # The Halotools default completeness cut is to throw out all halos with mpeak < mp*300,

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -99,7 +99,7 @@ class BolPlanck(NbodySimulation):
     def __init__(self):
 
         super(BolPlanck, self).__init__(simname='bolplanck', Lbox=250.,
-            particle_mass=1.35e8, num_ptcl_per_dim=2048,
+            particle_mass=1.55e8, num_ptcl_per_dim=2048,
             softening_length=1., initial_redshift=80., cosmology=cosmology.Planck13)
 
         self.orig_ascii_web_location = (

--- a/halotools/sim_manager/tests/test_cached_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_cached_halo_catalog.py
@@ -1,5 +1,6 @@
-#!/usr/bin/env python
-from __future__ import (absolute_import, division, print_function)
+"""
+"""
+from __future__ import absolute_import, division, print_function
 
 from unittest import TestCase
 import os
@@ -217,7 +218,7 @@ class TestCachedHaloCatalog(TestCase):
 
     @pytest.mark.skipif('not APH_MACHINE')
     def test_fname_optional_load(self):
-        fname = '/Users/aphearin/.astropy/cache/halotools/halo_catalogs/bolplanck/rockstar/hlist_0.33406.list.halotools_alpha_version2.hdf5'
+        fname = '/Users/aphearin/.astropy/cache/halotools/halo_catalogs/bolplanck/rockstar/hlist_0.33406.list.halotools_v0p4.hdf5'
         halocat = CachedHaloCatalog(fname=fname)
         assert halocat.simname == 'bolplanck'
 

--- a/halotools/sim_manager/tests/test_download_manager.py
+++ b/halotools/sim_manager/tests/test_download_manager.py
@@ -120,17 +120,17 @@ class TestDownloadManager(TestCase):
 
         file_list = self.downman._ptcl_tables_available_for_download(simname='bolshoi')
         assert len(file_list) == 1
-        assert 'hlist_1.00035.particles.halotools_alpha_version1.hdf5' == os.path.basename(file_list[0])
+        assert 'hlist_1.00035.particles.halotools_v0p4.hdf5' == os.path.basename(file_list[0])
 
         file_list = self.downman._ptcl_tables_available_for_download(simname='multidark')
         assert len(file_list) == 1
-        assert 'hlist_1.00109.particles.halotools_alpha_version1.hdf5' == os.path.basename(file_list[0])
+        assert 'hlist_1.00109.particles.halotools_v0p4.hdf5' == os.path.basename(file_list[0])
 
         consuelo_set = set(
-            ['hlist_0.33324.particles.halotools_alpha_version1.hdf5',
-            'hlist_0.50648.particles.halotools_alpha_version1.hdf5',
-            'hlist_0.67540.particles.halotools_alpha_version1.hdf5',
-            'hlist_1.00000.particles.halotools_alpha_version1.hdf5']
+            ['hlist_0.33324.particles.halotools_v0p4.hdf5',
+            'hlist_0.50648.particles.halotools_v0p4.hdf5',
+            'hlist_0.67540.particles.halotools_v0p4.hdf5',
+            'hlist_1.00000.particles.halotools_v0p4.hdf5']
             )
         file_list = self.downman._ptcl_tables_available_for_download(simname='consuelo')
         assert len(file_list) == 4
@@ -138,10 +138,10 @@ class TestDownloadManager(TestCase):
         assert file_set == consuelo_set
 
         bolplanck_set = set(
-            ['hlist_0.33406.particles.halotools_alpha_version1.hdf5',
-            'hlist_0.50112.particles.halotools_alpha_version1.hdf5',
-            'hlist_0.66818.particles.halotools_alpha_version1.hdf5',
-            'hlist_1.00231.particles.halotools_alpha_version1.hdf5']
+            ['hlist_0.33406.particles.halotools_v0p4.hdf5',
+            'hlist_0.50112.particles.halotools_v0p4.hdf5',
+            'hlist_0.66818.particles.halotools_v0p4.hdf5',
+            'hlist_1.00231.particles.halotools_v0p4.hdf5']
             )
         file_list = self.downman._ptcl_tables_available_for_download(simname='bolplanck')
         assert len(file_list) == 4
@@ -256,7 +256,7 @@ class TestDownloadManager(TestCase):
         """
         fname, redshift = self.downman._closest_catalog_on_web(simname='bolshoi',
             halo_finder='rockstar', desired_redshift=0., catalog_type='halos')
-        assert 'hlist_1.00035.list.halotools_alpha_version2.hdf5' in fname
+        assert 'hlist_1.00035.list.halotools_v0p4.hdf5' in fname
 
     @remote_data
     def test_closest_halo_catalog_on_web2(self):
@@ -264,7 +264,7 @@ class TestDownloadManager(TestCase):
         """
         fname, redshift = self.downman._closest_catalog_on_web(simname='bolshoi',
             halo_finder='bdm', desired_redshift=0., catalog_type='halos')
-        assert 'bolshoi/bdm/hlist_1.00030.list.halotools_alpha_version2.hdf5' in fname
+        assert 'bolshoi/bdm/hlist_1.00030.list.halotools_v0p4.hdf5' in fname
 
     @remote_data
     def test_closest_halo_catalog_on_web3(self):
@@ -282,7 +282,7 @@ class TestDownloadManager(TestCase):
         """
         fname, redshift = self.downman._closest_catalog_on_web(simname='bolplanck',
             desired_redshift=2, catalog_type='particles')
-        assert 'bolplanck/hlist_0.33406.particles.halotools_alpha_version1.hdf5' in fname
+        assert 'bolplanck/hlist_0.33406.particles.halotools_v0p4.hdf5' in fname
 
     @classmethod
     def clear_APH_MACHINE_of_highz_file(self,
@@ -370,7 +370,7 @@ class TestDownloadManager(TestCase):
             self.downman.download_processed_halo_table(
                 simname='bolshoi',
                 halo_finder='rockstar',
-                version_name=sim_defaults.default_version_name,
+                version_name='halotools_alpha_version2',
                 redshift=11.7, dz_tol=200,
                 overwrite=True, download_dirname='std_cache_loc')
         substr = "the ``ignore_nearby_redshifts`` to True, or decrease ``dz_tol``"

--- a/halotools/sim_manager/tests/test_supported_sims.py
+++ b/halotools/sim_manager/tests/test_supported_sims.py
@@ -8,6 +8,8 @@ from astropy.tests.helper import pytest
 
 from ..cached_halo_catalog import CachedHaloCatalog
 
+from ...custom_exceptions import HalotoolsError
+
 slow = pytest.mark.slow
 
 aph_home = '/Users/aphearin'
@@ -17,45 +19,62 @@ if aph_home == detected_home:
 else:
     APH_MACHINE = False
 
-__all__ = ('TestSupportedSims', )
+__all__ = ('test_load_halo_catalogs', 'test_halo_rvir_in_correct_units')
+
+adict = {'bolshoi': [0.33035, 0.54435, 0.67035, 1], 'bolplanck': [0.33406, 0.50112, 0.67, 1],
+    'consuelo': [0.333, 0.506, 0.6754, 1], 'multidark': [0.318, 0.5, 0.68, 1]}
 
 
-class TestSupportedSims(TestCase):
-    """ Class providing unit testing for `~halotools.sim_manager.HaloTableCacheLogEntry`.
+@pytest.mark.slow
+@pytest.mark.skipif('not APH_MACHINE')
+def test_load_halo_catalogs():
     """
-    adict = {'bolshoi': [0.33035, 0.54435, 0.67035, 1], 'bolplanck': [0.33406, 0.50112, 0.67, 1],
-        'consuelo': [0.333, 0.506, 0.6754, 1], 'multidark': [0.318, 0.5, 0.68, 1]}
+    """
 
-    @pytest.mark.slow
-    @pytest.mark.skipif('not APH_MACHINE')
-    def test_load_halo_catalogs(self):
-        """
-        """
-
-        for simname in list(self.adict.keys()):
-            alist = self.adict[simname]
-            for a in alist:
-                z = 1/a - 1
-                halocat = CachedHaloCatalog(simname=simname, redshift=z)
-                assert np.allclose(halocat.redshift, z, atol=0.01)
-
-                if simname not in ['bolshoi', 'multidark']:
-                    particles = halocat.ptcl_table
-                else:
-                    if a == 1:
-                        particles = halocat.ptcl_table
-
-    @pytest.mark.slow
-    @pytest.mark.skipif('not APH_MACHINE')
-    def test_halo_rvir_in_correct_units(self):
-        """ Loop over all halo catalogs in cache and verify that the
-        ``halo_rvir`` column never exeeds the number 50. This is a crude way of
-        ensuring that units are in Mpc/h, not kpc/h.
-        """
-        for simname in list(self.adict.keys()):
-            alist = self.adict[simname]
-            a = alist[0]
+    for simname in list(adict.keys()):
+        alist = adict[simname]
+        for a in alist:
             z = 1/a - 1
             halocat = CachedHaloCatalog(simname=simname, redshift=z)
-            r = halocat.halo_table['halo_rvir']
-            assert np.all(r < 50.)
+            assert np.allclose(halocat.redshift, z, atol=0.01)
+
+            if simname not in ['bolshoi', 'multidark']:
+                particles = halocat.ptcl_table
+            else:
+                if a == 1:
+                    particles = halocat.ptcl_table
+
+
+@pytest.mark.slow
+@pytest.mark.skipif('not APH_MACHINE')
+def test_halo_rvir_in_correct_units():
+    """ Loop over all halo catalogs in cache and verify that the
+    ``halo_rvir`` column never exeeds the number 50. This is a crude way of
+    ensuring that units are in Mpc/h, not kpc/h.
+    """
+    for simname in list(adict.keys()):
+        alist = adict[simname]
+        a = alist[0]
+        z = 1/a - 1
+        halocat = CachedHaloCatalog(simname=simname, redshift=z)
+        r = halocat.halo_table['halo_rvir']
+        assert np.all(r < 50.)
+
+
+def test_bolplanck_particle_mass():
+    from ..supported_sims import BolPlanck
+    bp = BolPlanck()
+    assert np.allclose(bp.particle_mass, 1.55e8, rtol=0.01)
+
+
+def test_forbidden_sims():
+    """
+    """
+    with pytest.raises(HalotoolsError) as err:
+        __ = CachedHaloCatalog(simname='bolplanck', version_name='halotools_alpha_version2')
+    substr = "See https://github.com/astropy/halotools/issues/598"
+    assert substr in err.value.args[0]
+
+
+
+


### PR DESCRIPTION
This PR updates Halotools behavior to be based on newly processed and uploaded `version_name = halotools_v0p4` halo and particle catalogs, resolving #598 and #576. 