### PR TITLE
Improve search length error msg

### DIFF
--- a/halotools/mock_observables/pair_counters/mesh_helpers.py
+++ b/halotools/mock_observables/pair_counters/mesh_helpers.py
@@ -155,12 +155,19 @@ def _enforce_maximum_search_length(search_length, period=None):
         If a sequence is passed, the input ``search_length`` will be required
         to be less 1/3 of the smallest element of the sequence.
     """
+    search_length = np.atleast_1d(search_length)
     if period is None:
-        period = np.inf
+        period = np.zeros_like(search_length) + np.inf
     period = np.atleast_1d(period)
+
     try:
         assert np.all(search_length < period/3.)
     except AssertionError:
-        msg = ("The `~halotools.mock_observables.pair_counters.RectangularDoubleMesh` "
-            "algorithm requires that the search length cannot exceed period/3 in any dimension.")
-        raise ValueError(msg)
+        max_search_fraction = np.max(period - search_length)
+        msg = ("The search algorithm used by the function you called \n"
+            "does not permit you to look for pairs separated by values \n"
+            "exceeding a fraction of Lbox/3. in any dimension.\n"
+            "Your function call would require searching for pairs separated by a distance of {0:.2f}*Lbox.\n"
+            "Either decrease your search length or use a larger simulation."
+            )
+        raise ValueError(msg.format(max_search_fraction))

--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_mesh_helpers.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_mesh_helpers.py
@@ -45,7 +45,7 @@ def test_enforce_maximum_search_length_case3():
     search_length, period = 1, 3
     with pytest.raises(ValueError) as err:
         _enforce_maximum_search_length(search_length, period)
-    substr = "algorithm requires that the search length cannot exceed period/3 in any dimension"
+    substr = "Either decrease your search length or use a larger simulation"
     assert substr in err.value.args[0]
 
 
@@ -54,7 +54,7 @@ def test_enforce_maximum_search_length_case4():
     search_length, period = 1, (3, 4)
     with pytest.raises(ValueError) as err:
         _enforce_maximum_search_length(search_length, period)
-    substr = "algorithm requires that the search length cannot exceed period/3 in any dimension"
+    substr = "Either decrease your search length or use a larger simulation"
     assert substr in err.value.args[0]
 
 
@@ -63,7 +63,7 @@ def test_enforce_maximum_search_length_case5():
     search_length, period = (1, 1), (3, 4)
     with pytest.raises(ValueError) as err:
         _enforce_maximum_search_length(search_length, period)
-    substr = "algorithm requires that the search length cannot exceed period/3 in any dimension"
+    substr = "Either decrease your search length or use a larger simulation"
     assert substr in err.value.args[0]
 
 

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf.py
@@ -547,7 +547,7 @@ def test_tpcf_raises_exception_for_large_search_length():
 
     with pytest.raises(ValueError) as err:
         normal_result = tpcf(sample1, rbins, period=period)
-    substr = "search length cannot exceed period/3 in any dimension."
+    substr = "Either decrease your search length or use a larger simulation"
     assert substr in err.value.args[0]
 
 


### PR DESCRIPTION
Improvement to the error message issued by the double-tree on attempts to look for neighbors over distances exceeding Lbox/3, as suggested by @villarrealas. 