### PR TITLE
Subhalo-based phase space model for satellites

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -607,6 +607,16 @@ class HodModelFactory(ModelFactory):
                 docstring = getattr(component_model, methodname).__doc__
                 getattr(self, new_method_name).__doc__ = docstring
 
+                if hasattr(component_model, '_additional_kwargs_dict'):
+                    additional_kwargs_dict = component_model._additional_kwargs_dict
+                    self._test_additional_kwargs_dict(additional_kwargs_dict)
+                    try:
+                        additional_kwargs = additional_kwargs_dict[methodname]
+                        setattr(getattr(self, new_method_name),
+                            'additional_kwargs', additional_kwargs)
+                    except KeyError:
+                        pass
+
             attrs_to_inherit = list(set(
                 component_model._attrs_to_inherit))
             for attrname in attrs_to_inherit:
@@ -1044,6 +1054,12 @@ class HodModelFactory(ModelFactory):
                         "composite model with a self-consistent population of centrals.\n".format(
                             component_model.gal_type, component_model.__class__.__name__))
                     raise HalotoolsError(msg)
+
+    def _test_additional_kwargs_dict(self, _additional_kwargs_dict):
+        """
+        """
+        assert 'table' not in list(_additional_kwargs_dict.keys())
+        assert 'seed' not in list(_additional_kwargs_dict.keys())
 
     def populate_mock(self, halocat, **kwargs):
         """

--- a/halotools/empirical_models/model_defaults.py
+++ b/halotools/empirical_models/model_defaults.py
@@ -37,18 +37,6 @@ sec_haloprop_key = 'halo_nfw_conc'
 
 halo_mass_definition = 'vir'
 
-#
-default_inherited_subhalo_props_dict = (
-    {'halo_id': ('halo_id', 'i8'),
-    'halo_x': ('x', 'f8'),
-    'halo_y': ('y', 'f8'),
-    'halo_z': ('z', 'f8'),
-    'halo_vx': ('vx', 'f8'),
-    'halo_vy': ('vy', 'f8'),
-    'halo_vz': ('vz', 'f8'),
-    'halo_mpeak': ('halo_mpeak', 'f8')
-    })
-
 
 def get_halo_boundary_key(mdef):
     """ For the input mass definition,

--- a/halotools/empirical_models/model_defaults.py
+++ b/halotools/empirical_models/model_defaults.py
@@ -27,7 +27,7 @@ default_binary_galprop_haloprop = default_smhm_haloprop
 host_haloprop_prefix = 'halo_'
 
 default_haloprop_list_inherited_by_mock = (
-    ['halo_id', 'halo_x', 'halo_y', 'halo_z',
+    ['halo_id', 'halo_hostid', 'halo_x', 'halo_y', 'halo_z',
     'halo_vx', 'halo_vy', 'halo_vz',
     'halo_mvir', 'halo_rvir', 'halo_upid']
     )
@@ -36,6 +36,18 @@ prim_haloprop_key = 'halo_mvir'
 sec_haloprop_key = 'halo_nfw_conc'
 
 halo_mass_definition = 'vir'
+
+#
+default_inherited_subhalo_props_dict = (
+    {'halo_id': ('halo_id', 'i8'),
+    'halo_x': ('x', 'f8'),
+    'halo_y': ('y', 'f8'),
+    'halo_z': ('z', 'f8'),
+    'halo_vx': ('vx', 'f8'),
+    'halo_vy': ('vy', 'f8'),
+    'halo_vz': ('vz', 'f8'),
+    'halo_mpeak': ('halo_mpeak', 'f8')
+    })
 
 
 def get_halo_boundary_key(mdef):

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/__init__.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/__init__.py
@@ -1,3 +1,4 @@
 """
 """
 from .subhalo_selection_kernel import *
+from .subhalo_phase_space import SubhaloPhaseSpace

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_phase_space.py
@@ -1,0 +1,351 @@
+"""
+"""
+from __future__ import division, print_function, absolute_import, unicode_literals
+
+import numpy as np
+
+from .subhalo_selection_kernel import calculate_satellite_selection_mask
+
+from ....utils import array_is_monotonic, crossmatch
+from ....custom_exceptions import HalotoolsError
+
+__author__ = ('Andrew Hearin', )
+__all__ = ('SubhaloPhaseSpace', )
+
+
+sorting_error_msg = ("\nIn order for the SubhaloPhaseSpace class to behave properly, \n"
+    "the chosen ``subhalo_table_sorting_keys`` list should result in a subhalo_table with a \n"
+    "``halo_hostid`` column that is monotonically increasing\n"
+    "(although repeated entries in the ``halo_hostid`` column are permissible)\n")
+
+default_inherited_subhalo_props_dict = (
+    {'halo_id': ('halo_id', 'i8'),
+    'halo_x': ('x', 'f8'),
+    'halo_y': ('y', 'f8'),
+    'halo_z': ('z', 'f8'),
+    'halo_vx': ('vx', 'f8'),
+    'halo_vy': ('vy', 'f8'),
+    'halo_vz': ('vz', 'f8'),
+    'halo_mpeak': ('halo_mpeak', 'f8')
+    })
+
+
+class SubhaloPhaseSpace(object):
+    """ Class using subhalo information to model the phase space of satellite galaxies.
+    """
+
+    def __init__(self, gal_type, host_haloprop_bins,
+            inherited_subhalo_props_dict=default_inherited_subhalo_props_dict,
+            binning_key='halo_mvir_host_halo', intra_halo_sorting_key='halo_mpeak', **kwargs):
+        """
+        Parameters
+        ----------
+        gal_type : string
+            Name of the modeled galaxy population, e.g, 'satellites'.
+
+        host_haloprop_bins : array_like
+            Array used to bin subhalos into groups of a similar property.
+            The first element of ``subhalo_table_sorting_keys`` determines
+            which property will be binned, and so ``host_haloprop_bins`` must
+            be consistent with that property. For example, if the first element
+            of ``host_haloprop_bins`` is ``halo_mvir_host_halo``,
+            then ``host_haloprop_bins`` could be np.logspace(10, 15, 15).
+
+            The purpose of ``host_haloprop_bins`` is to address the
+            possibility that the desired number of satellites in a halo may
+            exceed the number of subhalos in the halo. In such a case,
+            randomly selected subhalos from the same bin are chosen.
+
+        binning_key : string, optional
+            Column name defining how the input subhalos will be grouped together
+            by some host halo property such as virial mass.
+            Default is ``halo_mvir_host_halo``.
+
+        intra_halo_sorting_key : string, optional
+            Column name defining how the subhalos will be sorted within each host halo.
+            Subhalos appearing first are preferentially selected as satellites.
+            Default is ``halo_mpeak``.
+
+        inherited_subhalo_props_dict : dict, optional
+            Python dictionary determining which properties
+            the modeled galaxies will inherit from their corresponding subhalo.
+            Each key of the ``inherited_subhalo_props_dict`` dictionary
+            gives the name of a column in the ``subhalo_table``
+            that you wish to inherit.
+            The value bound to each key is a tuple of two strings.
+            The first string specifies the name you would like to give
+            the inherited property in the ``galaxy_table``.
+            The second string specifies the data type of the column, e.g., 'f4' or 'i8'.
+            For example, suppose you wish to treat the x-position of the subhalo
+            as the x-position of your satellite galaxy. Then you would have
+            a ``halo_x`` key in the ``inherited_subhalo_props_dict`` dictionary,
+            and the two-element tuple bound to it would be ('x', 'f4').
+
+            Default value is set by the ``default_inherited_subhalo_props_dict``
+            variable in the `~halotools.empirical_models.model_defaults` module.
+
+        """
+        self._mock_generation_calling_sequence = ['inherit_subhalo_properties']
+        self._methods_to_inherit = ['inherit_subhalo_properties', 'preprocess_subhalo_table']
+
+        self.list_of_haloprops_needed = list((intra_halo_sorting_key,
+            binning_key, binning_key+'_bin_number', '_subhalo_inheritance_id', 'halo_hostid'))
+
+        self.gal_type = gal_type
+        self.host_haloprop_bins = host_haloprop_bins
+        self.inherited_subhalo_props_dict = inherited_subhalo_props_dict
+        self.binning_key = binning_key
+        self.intra_halo_sorting_key = intra_halo_sorting_key
+        self.subhalo_table_sorting_keys = list((self.binning_key,
+            '_subhalo_inheritance_id', self.intra_halo_sorting_key))
+
+        self._additional_kwargs_dict = dict(
+            inherit_subhalo_properties=['halo_table', 'subhalo_table', '_occupation', 'Lbox'])
+
+        dt_arg = [(str(a[0]), str(a[1])) for a in inherited_subhalo_props_dict.values()]
+        dt_arg.append((str('real_subhalo'), bool))
+        self._galprop_dtypes_to_allocate = np.dtype(dt_arg)
+
+        self.param_dict = {}
+
+    def _retrieve_satellite_selection_idx(self, host_halo_table, subhalo_table, occupations,
+            seed=None):
+        """
+        """
+        try:
+            assert len(occupations) == len(host_halo_table)
+        except AssertionError:
+            msg = ("The input `occupations`` array and ``host_halo_table`` \n"
+                "must have equal length. This indicates bookkeeping bug.\n")
+            raise HalotoolsError(msg)
+
+        try:
+            host_halo_bin_numbers = host_halo_table[self.host_halo_binning_key].data
+        except KeyError:
+            msg = ("The input ``halo_table`` is missing the ``{0}`` key.\n"
+                "This indicates that the ``preprocess_subhalo_table`` method \n"
+                "was not called prior to calling the ``inherit_subhalo_properties`` method.\n")
+            raise HalotoolsError(msg.format(self.host_halo_binning_key))
+
+        satellite_selection_idx, missing_subhalo_mask = calculate_satellite_selection_mask(
+            subhalo_table['_subhalo_inheritance_id'].data, occupations,
+            host_halo_table['_subhalo_inheritance_id'].data, host_halo_bin_numbers,
+            fill_remaining_satellites=True, seed=seed)
+
+        return satellite_selection_idx, missing_subhalo_mask
+
+    def inherit_subhalo_properties(self, seed=None, **kwargs):
+        """
+        """
+        subhalo_table = kwargs['subhalo_table']
+        host_halo_table = kwargs['halo_table']
+        occupations = kwargs['_occupation'][self.gal_type]
+        Lbox = kwargs['Lbox']
+
+        satellite_selection_idx, missing_subhalo_mask = self._retrieve_satellite_selection_idx(
+            host_halo_table, subhalo_table, occupations, seed=seed)
+
+        galaxy_table = kwargs['table']
+        try:
+            assert len(galaxy_table) == occupations.sum()
+        except AssertionError:
+            msg = ("The input `occupations`` array has an inconsistent total sum\n"
+                "with the length of the input ``galaxy_table`` slice.\n"
+                "This indicates a bookkeeping bug.\n")
+            raise HalotoolsError(msg)
+
+        galaxy_table['real_subhalo'][~missing_subhalo_mask] = True
+
+        self._inherit_props_from_true_subhalos(galaxy_table, subhalo_table,
+            satellite_selection_idx, missing_subhalo_mask)
+
+        self._inherit_props_for_remaining_satellites(galaxy_table, subhalo_table,
+            satellite_selection_idx, missing_subhalo_mask, Lbox)
+
+    def _inherit_props_from_true_subhalos(self, galaxy_table, subhalo_table,
+            satellite_selection_idx, missing_subhalo_mask):
+        """
+        """
+        for subhalo_table_key, value in self.inherited_subhalo_props_dict.items():
+            galaxy_table_key = value[0]
+            galaxy_table[galaxy_table_key][~missing_subhalo_mask] = (
+                subhalo_table[subhalo_table_key][satellite_selection_idx][~missing_subhalo_mask])
+
+    def _inherit_props_for_remaining_satellites(self, galaxy_table, subhalo_table,
+            satellite_selection_idx, missing_subhalo_mask, Lbox):
+        """
+        """
+        poskeys = ('x', 'y', 'z')
+        for poskey in poskeys:
+            subhalo_hostpos_key = 'halo_' + poskey + '_host_halo'
+            subhalo_poskey = 'halo_' + poskey
+            subhalo_hostpos = subhalo_table[subhalo_hostpos_key][satellite_selection_idx][missing_subhalo_mask]
+            subhalo_pos = subhalo_table[subhalo_poskey][satellite_selection_idx][missing_subhalo_mask]
+
+            subhalo_hostvel_key = 'halo_v' + poskey + '_host_halo'
+            subhalo_velkey = 'halo_v' + poskey
+            subhalo_hostvel = subhalo_table[subhalo_hostvel_key][satellite_selection_idx][missing_subhalo_mask]
+            subhalo_vel = subhalo_table[subhalo_velkey][satellite_selection_idx][missing_subhalo_mask]
+
+            s, pbc_correction = _sign_pbc(subhalo_pos, subhalo_hostpos,
+                period=Lbox, return_pbc_correction=True)
+            absd = np.abs(subhalo_pos - subhalo_hostpos)
+            relpos = s*np.where(absd > Lbox/2., Lbox - absd, absd)
+            relvel = pbc_correction*(subhalo_vel-subhalo_hostvel)
+            galaxy_table[poskey][missing_subhalo_mask] += relpos
+            galaxy_table['v'+poskey][missing_subhalo_mask] += relvel
+
+        for subhalo_table_key, value in self.inherited_subhalo_props_dict.items():
+            galaxy_table_key = value[0]
+            if galaxy_table_key not in ('x', 'y', 'z', 'vx', 'vy', 'vz'):
+                galaxy_table[galaxy_table_key][missing_subhalo_mask] = (
+                    subhalo_table[subhalo_table_key][satellite_selection_idx][missing_subhalo_mask])
+
+    def preprocess_subhalo_table(self, host_halo_table, subhalo_table):
+        """ Method makes cuts and organizes the memory layout of the input
+        ``subhalo_table`` and ``host_halo_table``.
+
+        The only subhalos that will be kept are those with a value
+        in their ``halo_hostid`` column that matches an
+        entry of the ``halo_id`` column of the input ``host_halo_table``.
+        The returned subhalo table will be sorted according to
+        ``self.subhalo_table_sorting_keys``.
+        The returned ``host_halo_table`` will be sorted by the first two
+        entries of ``subhalo_table_sorting_keys``.
+
+        Parameters
+        ----------
+        host_halo_table = table
+
+        subhalo_table = table
+
+        Returns
+        --------
+        processed_subhalo_table : table
+            Astropy Table of subhalos with a matching host_halo,
+            sorted according to ``self.subhalo_table_sorting_keys``.
+
+
+        Notes
+        -----
+        The requirement of having a matching host halo is the basis of the algorithm,
+        and this is implemented by requiring that each subhalo's ``halo_hostid``
+        column has a matching value in the ``halo_id`` column of the input.
+        The reason that such subhalos could exist at all is if they are part of a
+        larger system that is just merging into a still larger host halo.
+        In such a case, the ``halo_upid`` of a sub-subhalo may point to
+        the ``halo_id`` of a subhalo that has *just* fallen into a larger host,
+        so that the center of the sub-subhalo has not quite passed within the
+        virial radius of its ultimate host. These subhalos are very rare,
+        and are thrown out to make bookkeeping simpler.
+        """
+        host_halo_table.sort(self.binning_key)
+        host_halo_table['_subhalo_inheritance_id'] = np.arange(len(host_halo_table))
+
+        idxA, idxB = crossmatch(subhalo_table['halo_hostid'].data,
+            host_halo_table['halo_id'].data)
+        subs_with_matching_hosts = subhalo_table[idxA]
+
+        subs_with_matching_hosts['_subhalo_inheritance_id'] = (
+            host_halo_table['_subhalo_inheritance_id'][idxB])
+        self.subhalo_table_sorting_keys = ['halo_mvir_host_halo', '_subhalo_inheritance_id']
+        subs_with_matching_hosts.sort(self.subhalo_table_sorting_keys)
+
+        if not array_is_monotonic(subs_with_matching_hosts['_subhalo_inheritance_id'].data,
+                strict=False):
+            raise HalotoolsError(sorting_error_msg)
+
+        host_halo_prop = host_halo_table[self.binning_key].data
+        bins = self.host_haloprop_bins
+        host_halo_bin_numbers = np.digitize(host_halo_prop, bins).astype(int)
+        self.host_halo_binning_key = self.binning_key + '_bin_number'
+        host_halo_table[self.host_halo_binning_key] = host_halo_bin_numbers
+
+        phase_space_keys = ('halo_x', 'halo_y', 'halo_z',
+            'halo_vx', 'halo_vy', 'halo_vz')
+        subs_with_matching_hosts[self.host_halo_binning_key] = 0
+        for key in phase_space_keys:
+            subs_with_matching_hosts[key+'_host_halo'] = 0.
+        idxA, idxB = crossmatch(subs_with_matching_hosts['halo_hostid'].data,
+            host_halo_table['halo_id'].data)
+        subs_with_matching_hosts[self.host_halo_binning_key][idxA] = (
+            host_halo_table[self.host_halo_binning_key][idxB])
+        for key in phase_space_keys:
+            subs_with_matching_hosts[key+'_host_halo'][idxA] = host_halo_table[key][idxB]
+
+        self._check_bins_satisfy_requirements(
+            host_halo_table[self.binning_key].data,
+            subs_with_matching_hosts[self.binning_key].data,
+            subs_with_matching_hosts[self.host_halo_binning_key].data,
+            self.host_haloprop_bins)
+
+        return host_halo_table, subs_with_matching_hosts
+
+    def _check_bins_satisfy_requirements(self, host_halo_prop, subhalo_prop,
+            subhalo_bin_numbers, bins):
+        """
+        """
+        binning_key = self.subhalo_table_sorting_keys[0]
+        try:
+            assert host_halo_prop[0] > bins[0]
+            assert host_halo_prop[-1] < bins[-1]
+        except AssertionError:
+            msg = ("The model ``host_haloprop_bins`` spans the range "
+                "({0}, {1}).\n But the range required by "
+                "the halo_table is ({2}, {3}).\n")
+            raise ValueError(msg.format(bins[0], bins[1], host_halo_prop[0], host_halo_prop[-1]))
+
+        try:
+            assert host_halo_prop[0] <= subhalo_prop[0]
+            assert host_halo_prop[-1] >= subhalo_prop[-1]
+        except AssertionError:
+            msg = ("The ``{0}`` column of the input ``subhalo_table`` "
+                "has not been calculated properly.\n"
+                "For the ``host_halo_table``, this property spans the range ({1}, {2}).\n"
+                "For the ``subhalo_table``, this property spans the range ({3}, {4}).\n"
+                "Since the ``subhalo_table`` has already been culled of subs without a matching host\n"
+                "the fact that the ``subhalo_table`` spans a broader range can only mean\n"
+                "that one or more values of the {5} key in the ``subhalo_table``\n"
+                "has not been calculated correctly.\n".format(
+                    binning_key, host_halo_prop[0], host_halo_prop[-1],
+                    subhalo_prop[0], subhalo_prop[-1], binning_key))
+            raise ValueError(msg)
+
+        subhalo_counts = np.histogram(subhalo_bin_numbers, np.arange(1, len(bins)))[0]
+        try:
+            assert np.all(subhalo_counts > 1)
+        except AssertionError:
+            msg = "There must be at least 1 subhalo in each bin of {0}".format(binning_key)
+            raise ValueError(msg)
+
+
+def _sign_pbc(x1, x2, period=None, equality_fill_val=0., return_pbc_correction=False):
+    """ Exact copy-and-paste of the mock.observables.catalog_analysis_helpers.sign_pbc
+    function, reimplemented here to circumvent a mysterious namespace collision that only
+    occurs during particular modes of unit-testing. Strictly for internal use.
+    """
+    x1 = np.atleast_1d(x1)
+    x2 = np.atleast_1d(x2)
+    result = np.sign(x1 - x2)
+
+    if period is not None:
+        try:
+            assert np.all(x1 >= 0)
+            assert np.all(x2 >= 0)
+            assert np.all(x1 < period)
+            assert np.all(x2 < period)
+        except AssertionError:
+            msg = "If period is not None, all values of x and y must be between [0, period)"
+            raise ValueError(msg)
+
+        d = np.abs(x1-x2)
+        pbc_correction = np.sign(period/2. - d)
+        result = pbc_correction*result
+
+    if equality_fill_val != 0:
+        result = np.where(result == 0, equality_fill_val, result)
+
+    if return_pbc_correction:
+        return result, pbc_correction
+    else:
+        return result

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_selection_kernel.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_selection_kernel.py
@@ -8,16 +8,16 @@ import numpy as np
 from ....utils import (calculate_first_idx_unique_array_vals, sum_in_bins,
     random_indices_within_bin, calculate_entry_multiplicity)
 
-__all__ = ('subhalo_indexing_array', )
+__all__ = ('calculate_satellite_selection_mask', )
 
 
-def subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids,
+def calculate_satellite_selection_mask(subhalo_hostids, satellite_occupations, host_halo_ids,
         host_halo_bin_numbers, fill_remaining_satellites=True,
         seed=None, testing_mode=False, min_required_entries_per_bin=None):
     """ Function driving the selection of subhalos during HOD mock population.
     Given a catalog of subhalos, host halos and a desired number of satellites
-    in each host, the `subhalo_indexing_array` function can be used to return the
-    indices used to select subhalos to serve as satellites.
+    in each host, the `calculate_satellite_selection_mask` function can be used
+    to calculate the indices used to select subhalos to serve as satellites.
 
     In the situation in which a host halo does not have as many subhalos
     as the desired number of satellites, a subhalo within the same bin
@@ -29,7 +29,7 @@ def subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids
 
     The returned array is a length-*Nsats* array storing the indices of the
     ``subhalo_hostids`` that were selected. In case special treatment of the
-    orphan satellites is desired, the ``subhalo_indexing_array`` function
+    orphan satellites is desired, the `calculate_satellite_selection_mask` function
     also returns a boolean array that can be used as a mask to identify the
     orphans.
 
@@ -76,7 +76,7 @@ def subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids
     Returns
     -------
     satellite_selection_indices : array
-        Integer array storing the indices of the selected subhalos.
+        Integer array of indices that can act as a mask to select subhalos.
 
         If ``fill_remaining_satellites`` is set to False,
         then some values of ``satellite_selection_indices`` may be -1.
@@ -106,14 +106,14 @@ def subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids
     We'll demonstrate basic usage here using a halo catalog taken from a
     `~halotools.sim_manager.FakeSim` object, which means we'll have to do a fair
     amount of work to arrange the memory layout into the required form.
-    When ``subhalo_indexing_array`` is used as part of a Halotools model,
+    When `calculate_satellite_selection_mask` is used as part of a Halotools model,
     this organization is typically accomplished in an automated fashion during a
     pre-processing phase of mock population.
 
     >>> from halotools.sim_manager import FakeSim
     >>> halocat = FakeSim()
 
-    The `subhalo_indexing_array` algorithm requires that
+    The `calculate_satellite_selection_mask` algorithm requires that
     every entry of the input ``subhalo_hostids`` has a matching entry in
     the input ``host_halo_ids`` array. To address this, we will mask out
     those rare subhalos with no matching host halo
@@ -139,7 +139,7 @@ def subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids
     large ``halo_vpeak`` will be preferentially selected to serve as satellites.
 
     Now we separate host halos from subhalos (preserving the above memory layout),
-    and define the arrays we'll use as inputs to the `subhalo_indexing_array` function.
+    and define the arrays we'll use as inputs to the `calculate_satellite_selection_mask` function.
 
     >>> host_halo_mask = halos['halo_upid'] == -1
     >>> hosts = halos[host_halo_mask]
@@ -150,11 +150,11 @@ def subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids
     >>> satellite_occupations = np.random.randint(0, 5, len(hosts))
     >>> host_halo_ids = hosts['halo_id'].data
 
-    With our arrays so defined, we call the ``subhalo_indexing_array`` function
+    With our arrays so defined, we call the `calculate_satellite_selection_mask` function
     and demonstrate that it does indeed return a result that can serve as an indexing
     array providing us with the correct total number of satellites.
 
-    >>> result = subhalo_indexing_array(subhalo_hostids, satellite_occupations, host_halo_ids, host_halo_bin_numbers, testing_mode=True)
+    >>> result = calculate_satellite_selection_mask(subhalo_hostids, satellite_occupations, host_halo_ids, host_halo_bin_numbers, testing_mode=True)
     >>> satellite_selection_indices, missing_subhalo_mask = result
     >>> selected_subhalos = subhalos[satellite_selection_indices]
     >>> assert len(selected_subhalos) == satellite_occupations.sum()
@@ -284,7 +284,7 @@ def calculate_selection_of_remaining_satellites(remaining_occupations,
         Integer array of length *num_remaining_satellites* that may be used
         as indices of any length *Nsubs* array to select subhalo properties.
         Here *Nsubs* is the total number of subhalos in the original catalog
-        passed to the `~halotools.empirical_models.subhalo_indexing_array` function,
+        passed to the `~halotools.empirical_models.calculate_satellite_selection_mask` function,
         and *num_remaining_satellites* is the sum of the entries of ``remaining_occupations``.
     """
 

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_composite_model.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_composite_model.py
@@ -1,0 +1,74 @@
+"""
+"""
+from __future__ import division, print_function, absolute_import, unicode_literals
+
+import numpy as np
+from astropy.tests.helper import pytest
+from copy import deepcopy
+
+from ..subhalo_phase_space import SubhaloPhaseSpace
+
+from .....sim_manager import CachedHaloCatalog
+from .....empirical_models import PrebuiltHodModelFactory, HodModelFactory
+from .....utils import crossmatch
+from .....mock_observables import relative_positions_and_velocities as rel_posvel
+
+__all__ = ('test_composite_model', )
+
+try:
+    halocat = CachedHaloCatalog()
+    HAS_DEFAULT_CATALOG = True
+except:
+    HAS_DEFAULT_CATALOG = False
+
+fixed_seed = 43
+
+
+@pytest.mark.skipif('not HAS_DEFAULT_CATALOG')
+def test_composite_model():
+    orig_model = PrebuiltHodModelFactory('leauthaud11')
+    halocat = CachedHaloCatalog()
+
+    model_dictionary = deepcopy(orig_model.model_dictionary)
+    model_dictionary['satellites_profile'] = SubhaloPhaseSpace(
+        'satellites', np.logspace(10.5, 15.1, 15))
+    model = HodModelFactory(**model_dictionary)
+
+    f = getattr(model, 'inherit_subhalo_properties_satellites')
+    d = getattr(f, 'additional_kwargs')
+    assert 'halo_table' in d
+    model.populate_mock(halocat, seed=fixed_seed)
+
+    satmask = model.mock.galaxy_table['gal_type'] == 'satellites'
+    sats = model.mock.galaxy_table[satmask]
+
+    assert np.all(sats['x'] >= 0.)
+    assert np.all(sats['x'] <= halocat.Lbox)
+    assert np.all(sats['x'] >= 0.)
+    assert np.all(sats['y'] <= halocat.Lbox)
+    assert np.all(sats['z'] >= 0.)
+    assert np.all(sats['z'] <= halocat.Lbox)
+
+    hostrvir = np.zeros(len(sats))
+    hostx = np.zeros(len(sats))
+    hosty = np.zeros(len(sats))
+    hostz = np.zeros(len(sats))
+    x = np.zeros(len(sats))
+    y = np.zeros(len(sats))
+    z = np.zeros(len(sats))
+    idxA, idxB = crossmatch(sats['halo_hostid'], model.mock.halo_table['halo_id'])
+    hostx[idxA] = model.mock.halo_table['halo_x'][idxB]
+    hosty[idxA] = model.mock.halo_table['halo_y'][idxB]
+    hostz[idxA] = model.mock.halo_table['halo_z'][idxB]
+    hostrvir[idxA] = model.mock.halo_table['halo_rvir'][idxB]
+    x, y, z = sats['x'], sats['y'], sats['z']
+
+    dx = rel_posvel(hostx, x, period=halocat.Lbox)
+    dy = rel_posvel(hosty, y, period=halocat.Lbox)
+    dz = rel_posvel(hostz, z, period=halocat.Lbox)
+
+    d = np.sqrt(dx**2 + dy**2 + dz**2)
+    assert np.all(d < 2*hostrvir)
+
+
+

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_subhalo_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_subhalo_phase_space.py
@@ -1,0 +1,196 @@
+"""
+"""
+from __future__ import division, print_function, absolute_import, unicode_literals
+
+import numpy as np
+from astropy.tests.helper import pytest
+from astropy.utils.misc import NumpyRNGContext
+from astropy.table import Table
+
+from ..subhalo_phase_space import SubhaloPhaseSpace
+
+from .....sim_manager import FakeSim, CachedHaloCatalog
+from .....utils import crossmatch
+
+__all__ = ('test_preprocess_subhalo_table1', )
+
+try:
+    halocat = CachedHaloCatalog()
+    HAS_DEFAULT_CATALOG = True
+except:
+    HAS_DEFAULT_CATALOG = False
+
+fixed_seed = 43
+
+
+def test_init():
+    model = SubhaloPhaseSpace('satellites', np.logspace(10, 15, 25))
+    assert list(model._additional_kwargs_dict.keys()) == ['inherit_subhalo_properties']
+    assert model._mock_generation_calling_sequence == ['inherit_subhalo_properties']
+
+
+def test_preprocess_subhalo_table1():
+    halocat = FakeSim(seed=fixed_seed)
+
+    subhalo_mask = halocat.halo_table['halo_upid'] != -1
+    subhalo_table = halocat.halo_table[subhalo_mask]
+    host_halo_table = halocat.halo_table[~subhalo_mask]
+
+    model = SubhaloPhaseSpace('satellites', np.logspace(10.1, 16.1, 25))
+    with pytest.raises(ValueError) as err:
+        hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+    substr = "The model ``host_haloprop_bins`` spans the range"
+    assert substr in err.value.args[0]
+
+
+def test_preprocess_subhalo_table2():
+    halocat = FakeSim(seed=fixed_seed)
+
+    subhalo_mask = halocat.halo_table['halo_upid'] != -1
+    subhalo_table = halocat.halo_table[subhalo_mask]
+    host_halo_table = halocat.halo_table[~subhalo_mask]
+
+    subhalo_table['halo_mvir_host_halo'] = 0.5
+
+    model = SubhaloPhaseSpace('satellites', np.logspace(9.9, 16.1, 25))
+
+    with pytest.raises(ValueError) as err:
+        hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+    substr = "The ``halo_mvir_host_halo`` column of the input ``subhalo_table``"
+    assert substr in err.value.args[0]
+
+
+def test_preprocess_subhalo_table3():
+    halocat = FakeSim(seed=fixed_seed)
+
+    subhalo_mask = halocat.halo_table['halo_upid'] != -1
+    subhalo_table = halocat.halo_table[subhalo_mask][0:4]
+    host_halo_table = halocat.halo_table[~subhalo_mask]
+
+    model = SubhaloPhaseSpace('satellites', np.logspace(9.9, 16.1, 25))
+
+    with pytest.raises(ValueError) as err:
+        hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+    substr = "There must be at least 1 subhalo in each bin of"
+    assert substr in err.value.args[0]
+
+
+def test_preprocess_subhalo_table4():
+    halocat = FakeSim(seed=fixed_seed)
+
+    subhalo_mask = halocat.halo_table['halo_upid'] != -1
+    subhalo_table = halocat.halo_table[subhalo_mask]
+    host_halo_table = halocat.halo_table[~subhalo_mask]
+
+    model = SubhaloPhaseSpace('satellites', np.logspace(9.9, 16.1, 10))
+    hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+
+
+def test_retrieve_subhalo_indices1():
+    halocat = FakeSim(seed=fixed_seed)
+
+    subhalo_mask = halocat.halo_table['halo_upid'] != -1
+    subhalo_table = halocat.halo_table[subhalo_mask]
+    host_halo_table = halocat.halo_table[~subhalo_mask]
+
+    model = SubhaloPhaseSpace('satellites', np.logspace(9.9, 16.1, 10))
+    hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+
+    with NumpyRNGContext(fixed_seed):
+        occupations = np.random.randint(0, 3, len(hosts))
+
+    idx, missing_subhalo_mask = model._retrieve_satellite_selection_idx(
+        hosts, subs, occupations, seed=fixed_seed)
+
+    try:
+        selected_subs = subs[idx]
+    except IndexError:
+        msg = ("Output of ``_retrieve_satellite_selection_idx`` function fails to \n"
+            "serve as an indexing array into the pre-processed ``subhalo_table``.\n")
+        raise ValueError(msg)
+
+    assert len(selected_subs) == occupations.sum()
+
+
+@pytest.mark.skipif('not HAS_DEFAULT_CATALOG')
+def test_retrieve_subhalo_indices2():
+    halocat = CachedHaloCatalog()
+
+    mass_cut = 3000*halocat.particle_mass
+    initial_cut = halocat.halo_table['halo_mvir'] > mass_cut
+    halos = halocat.halo_table[initial_cut]
+
+    subhalo_mask = halos['halo_upid'] != -1
+    subhalo_table = halos[subhalo_mask]
+    host_halo_table = halos[~subhalo_mask]
+
+    log10_mmin = np.log10(mass_cut)-0.1
+    log10_mmax = np.log10(halos['halo_mpeak'].max())+0.1
+    num_mass_bins = 10
+    mass_bins = np.logspace(log10_mmin, log10_mmax, num_mass_bins)
+    model = SubhaloPhaseSpace('satellites', mass_bins)
+
+    hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+
+    with NumpyRNGContext(fixed_seed):
+        occupations = np.random.randint(0, 3, len(hosts))
+
+    idx, missing_subhalo_mask = model._retrieve_satellite_selection_idx(
+        hosts, subs, occupations, seed=fixed_seed)
+
+    try:
+        selected_subs = subs[idx]
+    except IndexError:
+        msg = ("Output of ``_retrieve_satellite_selection_idx`` function fails to \n"
+            "serve as an indexing array into the pre-processed ``subhalo_table``.\n")
+        raise ValueError(msg)
+
+    assert len(selected_subs) == occupations.sum()
+
+    idx2, missing_subhalo_mask = model._retrieve_satellite_selection_idx(
+        hosts, subs, occupations, seed=fixed_seed)
+    assert np.all(idx == idx2)
+
+    idx3, missing_subhalo_mask = model._retrieve_satellite_selection_idx(
+        hosts, subs, occupations, seed=fixed_seed+1)
+
+    assert np.any(missing_subhalo_mask == True)
+    assert not np.all(idx == idx3)
+    assert np.all(idx[~missing_subhalo_mask] == idx3[~missing_subhalo_mask])
+
+
+def test_inherit_subhalo_properties():
+    halocat = FakeSim(seed=fixed_seed, num_halos_per_massbin=1000)
+
+    subhalo_mask = halocat.halo_table['halo_upid'] != -1
+    subhalo_table = halocat.halo_table[subhalo_mask]
+    host_halo_table = halocat.halo_table[~subhalo_mask]
+
+    model = SubhaloPhaseSpace('satellites', np.logspace(9.9, 16.1, 10))
+    hosts, subs = model.preprocess_subhalo_table(host_halo_table, subhalo_table)
+
+    with NumpyRNGContext(fixed_seed):
+        occupations = np.random.randint(0, 2, len(hosts))
+
+    galaxy_table = Table()
+    galaxy_table['real_subhalo'] = np.zeros(occupations.sum(), dtype=np.dtype(bool))
+    for item in model.inherited_subhalo_props_dict.values():
+        key, dt = item[0], np.dtype(item[1])
+        galaxy_table[key] = np.zeros(occupations.sum(), dtype=dt)
+
+    assert np.all(galaxy_table['x'] == 0)
+
+    _occupations = {'satellites': occupations}
+    model.inherit_subhalo_properties(table=galaxy_table,
+        halo_table=hosts, subhalo_table=subs, _occupation=_occupations,
+        seed=fixed_seed, Lbox=halocat.Lbox)
+
+    msg = "This fails because _inherit_props_for_remaining_satellites is still unfinished"
+    zero_mask = galaxy_table['x'] == 0
+    fake_mask = galaxy_table['real_subhalo'] == True
+    print(len(galaxy_table), len(galaxy_table[zero_mask]), len(galaxy_table[fake_mask]),
+        set(galaxy_table['real_subhalo'][zero_mask]))
+    assert not np.any(galaxy_table['x'] == 0), msg
+
+    idxA, idxB = crossmatch(galaxy_table['halo_id'].data, subs['halo_id'].data)
+    assert len(galaxy_table['halo_id'][idxA]) == len(galaxy_table['halo_id'])

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_subhalo_selection_kernel.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_subhalo_selection_kernel.py
@@ -8,13 +8,13 @@ from astropy.utils.misc import NumpyRNGContext
 
 from .. import subhalo_selection_kernel as ssk
 
-__all__ = ('test_subhalo_indexing_array1', )
+__all__ = ('test_calculate_satellite_selection_mask1', )
 
 fixed_seed = 43
 seed_array = np.arange(0, 10)
 
 
-def test_subhalo_indexing_array1():
+def test_calculate_satellite_selection_mask1():
     """ Create a hard-coded specific example for which the indices can be
     determined by hand, and explicitly enforce that the returned values agree.
     """
@@ -23,15 +23,16 @@ def test_subhalo_indexing_array1():
     host_halo_bins = np.array([0, 0, 1, 1, 2, 2, 3, 3, 3])
     occupations = np.array([2, 1, 1, 0, 3, 3, 0, 2, 1])
     correct_result = np.array([-1, -1, 0, -1, 3, 4, 5, 6, 7, -1, 8, -1, -1])
-    result, mask = ssk.subhalo_indexing_array(objID, occupations, hostIDs, host_halo_bins,
+    result, mask = ssk.calculate_satellite_selection_mask(objID, occupations, hostIDs, host_halo_bins,
         testing_mode=True, fill_remaining_satellites=False)
-    msg = "subhalo_indexing_array function is incorrect with testing_mode=True"
+    msg = "calculate_satellite_selection_mask function is incorrect with testing_mode=True"
     assert np.all(result == correct_result), msg
+    assert np.all(result[mask] == -1)
 
-    result2, mask = ssk.subhalo_indexing_array(objID, occupations, hostIDs, host_halo_bins,
+    result2, mask2 = ssk.calculate_satellite_selection_mask(objID, occupations, hostIDs, host_halo_bins,
         fill_remaining_satellites=True)
-    assert np.all(result[result != -1] == result2[result != -1])
-    assert np.all(result[result == -1] != result2[result == -1])
+    assert np.all(result[~mask] == result2[~mask])
+    assert np.all(result[mask] != result2[mask])
 
     try:
         selected_objects = objID[result2]
@@ -47,9 +48,9 @@ def test_subhalo_indexing_array1():
     assert set(fake_satellite_objids[4:]) <= set((12, 15, 16))
 
 
-def test_subhalo_indexing_array2():
+def test_calculate_satellite_selection_mask2():
     """ Create a sequence of randomly selected inputs and verify that
-    the subhalo_indexing_array function returns sensible results
+    the calculate_satellite_selection_mask function returns sensible results
     """
     nhosts = 1000
     for seed in seed_array:
@@ -73,7 +74,7 @@ def test_subhalo_indexing_array2():
             __[0:nbins] = np.arange(nbins)
             host_halo_bin_numbers = np.sort(__)
 
-            satellite_selection_indices, missing_subhalo_mask = ssk.subhalo_indexing_array(
+            satellite_selection_indices, missing_subhalo_mask = ssk.calculate_satellite_selection_mask(
                 subhalo_hostids, satellite_occupations, host_halo_ids, host_halo_bin_numbers,
                 testing_mode=True, fill_remaining_satellites=False, seed=seed)
 
@@ -85,7 +86,7 @@ def test_subhalo_indexing_array2():
             assert np.all(satellite_selection_indices[missing_subhalo_mask] == -1)
             assert not np.any(satellite_selection_indices[~missing_subhalo_mask] == -1)
 
-            satellite_selection_indices2, missing_subhalo_mask2 = ssk.subhalo_indexing_array(
+            satellite_selection_indices2, missing_subhalo_mask2 = ssk.calculate_satellite_selection_mask(
                 subhalo_hostids, satellite_occupations, host_halo_ids, host_halo_bin_numbers,
                 testing_mode=True, fill_remaining_satellites=True, seed=None)
 

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -306,7 +306,7 @@ def cuboid_subvolume_labels(sample, Nsub, Lbox):
     return index, int(N_sub_vol)
 
 
-def sign_pbc(x1, x2, period=None, equality_fill_val=0.):
+def sign_pbc(x1, x2, period=None, equality_fill_val=0., return_pbc_correction=False):
     """ Return the sign of the unit vector pointing from x2 towards x1,
     that is, the sign of (x1 - x2), accounting for periodic boundary conditions.
 
@@ -327,6 +327,11 @@ def sign_pbc(x1, x2, period=None, equality_fill_val=0.):
 
     equality_fill_val : float, optional
         Value to return for cases where x1 == x2. Default is 0.
+
+    return_pbc_correction : bool, optional
+        If True, the `sign_pbc` function will additionally return a
+        length *Npts* boolean array storing whether or not the input
+        points had a PBC correction applied. Default is False.
 
     Returns
     -------
@@ -370,7 +375,10 @@ def sign_pbc(x1, x2, period=None, equality_fill_val=0.):
     if equality_fill_val != 0:
         result = np.where(result == 0, equality_fill_val, result)
 
-    return result
+    if return_pbc_correction:
+        return result, pbc_correction
+    else:
+        return result
 
 
 def relative_positions_and_velocities(x1, x2, period=None, **kwargs):
@@ -399,6 +407,10 @@ def relative_positions_and_velocities(x1, x2, period=None, **kwargs):
     xrel : array
         1-d array of length *Npts* storing x1 - x2.
         If *x1 > x2* and abs(*x1* - *x2*) > period/2, the sign of *d* will be negative.
+
+    vrel : array, optional
+        1-d array of length *Npts* storing v1 relative to v2.
+        Only returned if ``v1`` and ``v2`` are passed in.
 
     Examples
     --------

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -10,7 +10,7 @@ from ..empirical_models import enforce_periodicity_of_box
 from ..custom_exceptions import HalotoolsError
 
 __all__ = ('mean_y_vs_x', 'return_xyz_formatted_array', 'cuboid_subvolume_labels',
-    'relative_positions_and_velocities')
+    'relative_positions_and_velocities', 'sign_pbc')
 __author__ = ['Andrew Hearin']
 
 


### PR DESCRIPTION
This PR introduces the SubhaloPhaseSpace class to HOD profile modeling. Briefly, using this class subhalo positions and velocities can be chosen for HOD/CLF satellites, as opposed to analytical relations. 

This initial PR is currently just for testing and is unfinished as the `reverse_order` option still needs to be implemented, as discussed with @johannesulf. 