### PR TITLE
Change Table column creation to be compatible with new astropy syntax

### DIFF
--- a/halotools/empirical_models/component_model_templates/binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/binary_galprop_models.py
@@ -118,7 +118,7 @@ class BinaryGalpropModel(object):
             mc_generator = np.random.random(custom_len(mean_galprop_fraction))
         result = np.where(mc_generator < mean_galprop_fraction, True, False)
         if 'table' in kwargs:
-            kwargs['table'][self.galprop_name] = result
+            kwargs['table'][self.galprop_name][:] = result
         return result
 
 


### PR DESCRIPTION
Changed syntax of model galaxy property assignment so that table slice is explicitly modified in-place in accord with https://github.com/astropy/astropy/pull/5556.

This change has been made manually here but is identical to the change brought as part of #637 by
b28fe154370524d75ae625ada513272db49dad74. However, because the #637 PR has an entirely different purpose and has many other code changes that are entirely unrelated to this bugfix, #637 can instead be rebased against this commit for clarity.

Merging this PR will also resolve the test failures that occur in #638.

@bsipocz or @eteq - let me know if you know how to handle the git rewrite in a more elegant way (e.g., rolling back b28fe154370524d75ae625ada513272db49dad74), otherwise I'm fine with simply locally rebasing #637, locally resolving the conflict, and then force-pushing #637.