### PR TITLE
Version updates in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - 3.5
+    - 3.6
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -32,8 +33,6 @@ env:
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
 
 matrix:
     include:
@@ -64,27 +63,25 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development
-        - python: 3.5
+        - python: 3.6
           env: ASTROPY_VERSION=development
 
         # Try older numpy version, 1.9 is tested above with py3.3
-        - python: 2.7
+        - python: 3.4
           env: NUMPY_VERSION=1.10
+        # Try older numpy version, 1.9 is tested above with py3.3
+        - python: 3.5
+          env: NUMPY_VERSION=1.11
 
         # Try numpy pre-release version, this runs only when a pre-release
         # is available on pypi.
-        - python: 3.5
+        - python: 3.6
           env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
-    allow_failures:
-        # The build with numpy v1.11.1rc1 halts in the middle without
-        # showing any obvious reason, thus allowing it to fail for now.
-        - python: 3.5
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,51 +36,8 @@ env:
 
 matrix:
     include:
-        - python: 2.7
-          env: SETUP_CMD='egg_info'
-
-        # Do a coverage test in Python 2.
-        - python: 2.7
-          env: SETUP_CMD='test --coverage'
-
-        # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
-        - python: 2.7
-          env: SETUP_CMD='build_sphinx -w'
-
-        # Python3.3 is a bit old, thus conda doesn't have all version dependencies including newer numpies
-        - python: 3.3
-          env: NUMPY_VERSION=1.9
-               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
-
-        - python: 3.4
-          env: SETUP_CMD='egg_info'
-
-        - python: 3.4
-          env: NUMPY_VERSION=1.11
-               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
-
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
         - python: 3.6
           env: ASTROPY_VERSION=development
-
-        # Try older numpy version, 1.9 is tested above with py3.3
-        - python: 3.4
-          env: NUMPY_VERSION=1.10
-        # Try older numpy version, 1.9 is tested above with py3.3
-        - python: 3.5
-          env: NUMPY_VERSION=1.11
-
-        # Try numpy pre-release version, this runs only when a pre-release
-        # is available on pypi.
-        - python: 3.6
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
-
-        # try a version *without* h5py - we need this for readthedocs
-        - python: 2.7
-          env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
 
 before_install:

--- a/halotools/empirical_models/component_model_templates/binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/binary_galprop_models.py
@@ -140,7 +140,7 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
 
     def __init__(self, galprop_abscissa, galprop_ordinates,
             logparam=True, interpol_method='spline', **kwargs):
-        """
+        r"""
         Parameters
         ----------
         galprop_name : array, keyword argument
@@ -184,8 +184,8 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
         -----------
         Suppose we wish to construct a model for whether a central galaxy is
         star-forming or quiescent. We want to set the quiescent fraction to 1/3
-        for Milky Way-type centrals (:math:`M_{\\mathrm{vir}}=10^{12}M_{\odot}`),
-        and 90% for massive cluster centrals (:math:`M_{\\mathrm{vir}}=10^{15}M_{\odot}`).
+        for Milky Way-type centrals (:math:`M_{\mathrm{vir}}=10^{12}M_{\odot}`),
+        and 90% for massive cluster centrals (:math:`M_{\mathrm{vir}}=10^{15}M_{\odot}`).
         We can use the `BinaryGalpropInterpolModel` to implement this as follows:
 
         >>> abscissa, ordinates = [12, 15], [1/3., 0.9]
@@ -206,7 +206,7 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
 
         Here is another example of how you could use `BinaryGalpropInterpolModel`
         to construct a simple model for satellite morphology, where the early- vs. late-type
-        of the satellite depends on :math:`V_{\\mathrm{peak}}` value of the host halo
+        of the satellite depends on :math:`V_{\mathrm{peak}}` value of the host halo
 
         >>> sat_morphology_model = BinaryGalpropInterpolModel(galprop_name='late_type', galprop_abscissa=abscissa, galprop_ordinates=ordinates, prim_haloprop_key='vpeak_host')
         >>> vmax_array = np.logspace(2, 3, num=100)

--- a/halotools/empirical_models/occupation_models/leauthaud11_components.py
+++ b/halotools/empirical_models/occupation_models/leauthaud11_components.py
@@ -197,7 +197,7 @@ class Leauthaud11Sats(OccupationComponent):
             redshift=sim_manager.sim_defaults.default_redshift,
             modulate_with_cenocc=True, cenocc_model=None,
             **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -219,7 +219,7 @@ class Leauthaud11Sats(OccupationComponent):
 
         cenocc_model : `OccupationComponent`, optional
             If the ``cenocc_model`` keyword argument is set to its default value
-            of None, then the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor will be
+            of None, then the :math:`\langle N_{\mathrm{cen}}\rangle_{M}` prefactor will be
             calculated according to `leauthaud11Cens.mean_occupation`.
             However, if an instance of the `OccupationComponent` class is instead
             passed in via the ``cenocc_model`` keyword,

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -74,7 +74,7 @@ class Zheng07Cens(OccupationComponent):
         self.publications = ['arXiv:0408564', 'arXiv:0703457']
 
     def mean_occupation(self, **kwargs):
-        """ Expected number of central galaxies in a halo of mass halo_mass.
+        r""" Expected number of central galaxies in a halo of mass halo_mass.
         See Equation 2 of arXiv:0703457.
 
         Parameters
@@ -117,10 +117,10 @@ class Zheng07Cens(OccupationComponent):
         -----
         The `mean_occupation` method computes the following function:
 
-        :math:`\\langle N_{\\mathrm{cen}} \\rangle_{M} =
-        \\frac{1}{2}\\left( 1 +
-        \\mathrm{erf}\\left( \\frac{\\log_{10}M -
-        \\log_{10}M_{min}}{\\sigma_{\\log_{10}M}} \\right) \\right)`
+        :math:`\langle N_{\mathrm{cen}} \rangle_{M} =
+        \frac{1}{2}\left( 1 +
+        \mathrm{erf}\left( \frac{\log_{10}M -
+        \log_{10}M_{min}}{\sigma_{\log_{10}M}} \right) \right)`
 
         """
         # Retrieve the array storing the mass-like variable
@@ -206,11 +206,11 @@ class Zheng07Cens(OccupationComponent):
 
 
 class Zheng07Sats(OccupationComponent):
-    """ Power law model for the occupation statistics of satellite galaxies,
+    r""" Power law model for the occupation statistics of satellite galaxies,
     introduced in Kravtsov et al. 2004, arXiv:0308519. This implementation uses
     Zheng et al. 2007, arXiv:0703457, to assign fiducial parameter values.
 
-    :math:`\\langle N_{sat} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha}`.
+    :math:`\langle N_{sat} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha}`.
 
     .. note::
 
@@ -224,7 +224,7 @@ class Zheng07Sats(OccupationComponent):
             threshold=model_defaults.default_luminosity_threshold,
             prim_haloprop_key=model_defaults.prim_haloprop_key,
             modulate_with_cenocc=False, cenocc_model=None, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -242,15 +242,15 @@ class Zheng07Sats(OccupationComponent):
             If set to True, the `Zheng07Sats.mean_occupation` method will
             be multiplied by the the first moment of the centrals:
 
-            :math:`\\langle N_{\mathrm{sat}}\\rangle_{M}\\Rightarrow\\langle N_{\mathrm{sat}}\\rangle_{M}\\times\\langle N_{\mathrm{cen}}\\rangle_{M}`
+            :math:`\langle N_{\mathrm{sat}}\rangle_{M}\Rightarrow\langle N_{\mathrm{sat}}\rangle_{M}\times\langle N_{\mathrm{cen}}\rangle_{M}`
 
             The ``cenocc_model`` keyword argument works together with
             the ``modulate_with_cenocc`` keyword argument to determine how
-            the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor is calculated.
+            the :math:`\langle N_{\mathrm{cen}}\rangle_{M}` prefactor is calculated.
 
         cenocc_model : `OccupationComponent`, optional
             If the ``cenocc_model`` keyword argument is set to its default value
-            of None, then the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor will be
+            of None, then the :math:`\langle N_{\mathrm{cen}}\rangle_{M}` prefactor will be
             calculated according to `Zheng07Cens.mean_occupation`.
             However, if an instance of the `OccupationComponent` class is instead
             passed in via the ``cenocc_model`` keyword,
@@ -289,7 +289,7 @@ class Zheng07Sats(OccupationComponent):
         Now ``sat_model1`` and ``sat_model2`` are identical in every respect,
         excepting only the following difference:
 
-        :math:`\\langle N_{\mathrm{sat}}\\rangle^{\mathrm{model 2}} = \\langle N_{\mathrm{cen}}\\rangle\\times\\langle N_{\mathrm{sat}}\\rangle^{\mathrm{model 1}}`
+        :math:`\langle N_{\mathrm{sat}}\rangle^{\mathrm{model 2}} = \langle N_{\mathrm{cen}}\rangle\times\langle N_{\mathrm{sat}}\rangle^{\mathrm{model 1}}`
 
         See also
         ----------
@@ -338,7 +338,7 @@ class Zheng07Sats(OccupationComponent):
         self.publications = ['arXiv:0308519', 'arXiv:0703457']
 
     def mean_occupation(self, **kwargs):
-        """Expected number of satellite galaxies in a halo of mass logM.
+        r"""Expected number of satellite galaxies in a halo of mass logM.
         See Equation 5 of arXiv:0703457.
 
         Parameters
@@ -358,11 +358,11 @@ class Zheng07Sats(OccupationComponent):
         mean_nsat : float or array
             Mean number of satellite galaxies in a host halo of the specified mass.
 
-        :math:`\\langle N_{\\mathrm{sat}} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha} \\langle N_{\\mathrm{cen}} \\rangle_{M}`
+        :math:`\langle N_{\mathrm{sat}} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha} \langle N_{\mathrm{cen}} \rangle_{M}`
 
         or
 
-        :math:`\\langle N_{\\mathrm{sat}} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha}`,
+        :math:`\langle N_{\mathrm{sat}} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha}`,
 
         depending on whether a central model was passed to the constructor.
 

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/nfw_profile.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/nfw_profile.py
@@ -298,6 +298,7 @@ class NFWProfile(AnalyticDensityProf):
 
         See :ref:`nfw_cumulative_mass_pdf_derivation` for a derivation of this expression.
 
+
         Parameters
         -------------
         scaled_radius : array_like

--- a/halotools/mock_observables/surface_density/surface_density_helpers.py
+++ b/halotools/mock_observables/surface_density/surface_density_helpers.py
@@ -64,7 +64,7 @@ def log_interpolation_with_inner_zero_masking(onep_sig_in, rp_bins, rp_mids):
 
 
 def rho_matter_comoving_in_halotools_units(cosmology):
-    """ Calculate the comoving matter density in units of
+    r""" Calculate the comoving matter density in units of
     :math:`M_{\odot}/{\rm Mpc}^3` assuming :math:`h = 1`.
 
     Parameters


### PR DESCRIPTION
We've recently found the probably reason of the halting numpy prerelease builds and made a fix in ci-helpers. So I'm removing it from the allowed failures with the note that since there is no prerelease available at the moment it will pass anyway. I'm almost certain that it should work (the fix worked for e.g. photutils). 

But while I was already editing the file, also added the new py 3.6 version to the matrix as well as numpy 1.11.