### PR TITLE
adds support for 3-vector Lbox

### DIFF
--- a/halotools/empirical_models/factories/hod_mock_factory.py
+++ b/halotools/empirical_models/factories/hod_mock_factory.py
@@ -312,21 +312,21 @@ class HodMockFactory(MockFactory):
         if self.enforce_PBC is True:
             self.galaxy_table['x'], self.galaxy_table['vx'] = (
                 model_helpers.enforce_periodicity_of_box(
-                    self.galaxy_table['x'], self.Lbox,
+                    self.galaxy_table['x'], self.Lbox[0],
                     velocity=self.galaxy_table['vx'],
                     check_multiple_box_lengths=self._testing_mode)
                 )
 
             self.galaxy_table['y'], self.galaxy_table['vy'] = (
                 model_helpers.enforce_periodicity_of_box(
-                    self.galaxy_table['y'], self.Lbox,
+                    self.galaxy_table['y'], self.Lbox[1],
                     velocity=self.galaxy_table['vy'],
                     check_multiple_box_lengths=self._testing_mode)
                 )
 
             self.galaxy_table['z'], self.galaxy_table['vz'] = (
                 model_helpers.enforce_periodicity_of_box(
-                    self.galaxy_table['z'], self.Lbox,
+                    self.galaxy_table['z'], self.Lbox[2],
                     velocity=self.galaxy_table['vz'],
                     check_multiple_box_lengths=self._testing_mode)
                 )

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -145,7 +145,7 @@ class MockFactory(object):
 
         """
         ngals = len(self.galaxy_table)
-        comoving_volume = self.Lbox**3
+        comoving_volume = np.prod(self.Lbox)
         return ngals/float(comoving_volume)
 
     def compute_galaxy_clustering(self, include_crosscorr=False, **kwargs):
@@ -494,7 +494,7 @@ class MockFactory(object):
         z = self.galaxy_table['z']
         if zspace is True:
             z += self.galaxy_table['vz']/100.
-            z = model_helpers.enforce_periodicity_of_box(z, self.Lbox)
+            z = model_helpers.enforce_periodicity_of_box(z, self.Lbox[2])
         pos = np.vstack((x, y, z)).T
 
         group_finder = mock_observables.FoFGroups(positions=pos,

--- a/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
+++ b/halotools/empirical_models/factories/tests/test_hod_mock_factory.py
@@ -158,15 +158,15 @@ class TestHodMockFactory(TestCase):
         sats = model.mock.galaxy_table[~cenmask]
 
         sats_outside_boundary_mask = (
-            (sats['x'] < 0) | (sats['x'] > halocat.Lbox) |
-            (sats['y'] < 0) | (sats['y'] > halocat.Lbox) |
-            (sats['z'] < 0) | (sats['z'] > halocat.Lbox))
+            (sats['x'] < 0) | (sats['x'] > halocat.Lbox[0]) |
+            (sats['y'] < 0) | (sats['y'] > halocat.Lbox[1]) |
+            (sats['z'] < 0) | (sats['z'] > halocat.Lbox[2]))
         assert np.any(sats_outside_boundary_mask == True)
 
         cens_outside_boundary_mask = (
-            (cens['x'] < 0) | (cens['x'] > halocat.Lbox) |
-            (cens['y'] < 0) | (cens['y'] > halocat.Lbox) |
-            (cens['z'] < 0) | (cens['z'] > halocat.Lbox))
+            (cens['x'] < 0) | (cens['x'] > halocat.Lbox[0]) |
+            (cens['y'] < 0) | (cens['y'] > halocat.Lbox[1]) |
+            (cens['z'] < 0) | (cens['z'] > halocat.Lbox[2]))
         assert np.all(cens_outside_boundary_mask == False)
 
     @pytest.mark.slow
@@ -183,15 +183,15 @@ class TestHodMockFactory(TestCase):
         sats = model.mock.galaxy_table[~cenmask]
 
         sats_outside_boundary_mask = (
-            (sats['x'] < 0) | (sats['x'] > halocat.Lbox) |
-            (sats['y'] < 0) | (sats['y'] > halocat.Lbox) |
-            (sats['z'] < 0) | (sats['z'] > halocat.Lbox))
+            (sats['x'] < 0) | (sats['x'] > halocat.Lbox[0]) |
+            (sats['y'] < 0) | (sats['y'] > halocat.Lbox[1]) |
+            (sats['z'] < 0) | (sats['z'] > halocat.Lbox[2]))
         assert np.all(sats_outside_boundary_mask == False)
 
         cens_outside_boundary_mask = (
-            (cens['x'] < 0) | (cens['x'] > halocat.Lbox) |
-            (cens['y'] < 0) | (cens['y'] > halocat.Lbox) |
-            (cens['z'] < 0) | (cens['z'] > halocat.Lbox))
+            (cens['x'] < 0) | (cens['x'] > halocat.Lbox[0]) |
+            (cens['y'] < 0) | (cens['y'] > halocat.Lbox[1]) |
+            (cens['z'] < 0) | (cens['z'] > halocat.Lbox[2]))
         assert np.all(cens_outside_boundary_mask == False)
 
     def test_zero_satellite_edge_case(self):
@@ -224,11 +224,11 @@ class TestHodMockFactory(TestCase):
         y2 = gals['halo_y']
         z2 = gals['halo_z']
         dx = np.fabs(x1 - x2)
-        dx = np.fmin(dx, self.model.mock.Lbox - dx)
+        dx = np.fmin(dx, self.model.mock.Lbox[0] - dx)
         dy = np.fabs(y1 - y2)
-        dy = np.fmin(dy, self.model.mock.Lbox - dy)
+        dy = np.fmin(dy, self.model.mock.Lbox[1] - dy)
         dz = np.fabs(z1 - z2)
-        dz = np.fmin(dz, self.model.mock.Lbox - dz)
+        dz = np.fmin(dz, self.model.mock.Lbox[2] - dz)
         d = np.sqrt(dx*dx+dy*dy+dz*dz)
         assert np.all(d <= gals['halo_rvir'])
 

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_phase_space.py
@@ -186,7 +186,7 @@ class SubhaloPhaseSpace(object):
         """
         """
         poskeys = ('x', 'y', 'z')
-        for poskey in poskeys:
+        for axis,poskey in enumerate(poskeys):
             subhalo_hostpos_key = 'halo_' + poskey + '_host_halo'
             subhalo_poskey = 'halo_' + poskey
             subhalo_hostpos = subhalo_table[subhalo_hostpos_key][satellite_selection_idx][missing_subhalo_mask]
@@ -198,9 +198,9 @@ class SubhaloPhaseSpace(object):
             subhalo_vel = subhalo_table[subhalo_velkey][satellite_selection_idx][missing_subhalo_mask]
 
             s, pbc_correction = _sign_pbc(subhalo_pos, subhalo_hostpos,
-                period=Lbox, return_pbc_correction=True)
+                period=Lbox[axis], return_pbc_correction=True)
             absd = np.abs(subhalo_pos - subhalo_hostpos)
-            relpos = s*np.where(absd > Lbox/2., Lbox - absd, absd)
+            relpos = s*np.where(absd > Lbox[axis]/2., Lbox[axis] - absd, absd)
             relvel = pbc_correction*(subhalo_vel-subhalo_hostvel)
             galaxy_table[poskey][missing_subhalo_mask] += relpos
             galaxy_table['v'+poskey][missing_subhalo_mask] += relvel

--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_composite_model.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_composite_model.py
@@ -43,11 +43,11 @@ def test_composite_model():
     sats = model.mock.galaxy_table[satmask]
 
     assert np.all(sats['x'] >= 0.)
-    assert np.all(sats['x'] <= halocat.Lbox)
+    assert np.all(sats['x'] <= halocat.Lbox[0])
     assert np.all(sats['x'] >= 0.)
-    assert np.all(sats['y'] <= halocat.Lbox)
+    assert np.all(sats['y'] <= halocat.Lbox[1])
     assert np.all(sats['z'] >= 0.)
-    assert np.all(sats['z'] <= halocat.Lbox)
+    assert np.all(sats['z'] <= halocat.Lbox[2])
 
     hostrvir = np.zeros(len(sats))
     hostx = np.zeros(len(sats))
@@ -63,9 +63,9 @@ def test_composite_model():
     hostrvir[idxA] = model.mock.halo_table['halo_rvir'][idxB]
     x, y, z = sats['x'], sats['y'], sats['z']
 
-    dx = rel_posvel(hostx, x, period=halocat.Lbox)
-    dy = rel_posvel(hosty, y, period=halocat.Lbox)
-    dz = rel_posvel(hostz, z, period=halocat.Lbox)
+    dx = rel_posvel(hostx, x, period=halocat.Lbox[0])
+    dy = rel_posvel(hosty, y, period=halocat.Lbox[1])
+    dz = rel_posvel(hostz, z, period=halocat.Lbox[2])
 
     d = np.sqrt(dx**2 + dy**2 + dz**2)
     assert np.all(d < 2*hostrvir)

--- a/halotools/sim_manager/ptcl_table_cache_log_entry.py
+++ b/halotools/sim_manager/ptcl_table_cache_log_entry.py
@@ -260,7 +260,9 @@ class PtclTableCacheLogEntry(object):
         try:
             data = Table.read(self.fname, path='data')
             f = self.h5py.File(self.fname)
-            Lbox = f.attrs['Lbox']
+            Lbox = np.empty(3)
+            Lbox[:] = f.attrs['Lbox']
+
             f.close()
             try:
                 x = data['x']
@@ -268,11 +270,11 @@ class PtclTableCacheLogEntry(object):
                 z = data['z']
 
                 assert np.all(x >= 0)
-                assert np.all(x <= Lbox)
+                assert np.all(x <= Lbox[0])
                 assert np.all(y >= 0)
-                assert np.all(y <= Lbox)
+                assert np.all(y <= Lbox[1])
                 assert np.all(z >= 0)
-                assert np.all(z <= Lbox)
+                assert np.all(z <= Lbox[2])
 
             except AssertionError:
                 num_failures += 1

--- a/halotools/sim_manager/tests/test_fake_sim.py
+++ b/halotools/sim_manager/tests/test_fake_sim.py
@@ -65,7 +65,7 @@ def test_attrs2():
 def test_positions2():
     fake_sim = FakeSimHalosNearBoundaries()
     assert not np.any((fake_sim.halo_table['halo_x'] > 1) &
-        (fake_sim.halo_table['halo_x'] < fake_sim.Lbox - 1))
+        (fake_sim.halo_table['halo_x'] < fake_sim.Lbox[0] - 1))
 
 
 def test_stochasticity2():

--- a/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_halo_catalog.py
@@ -111,9 +111,17 @@ class TestUserSuppliedHaloCatalog(TestCase):
             particle_mass=100, redshift=self.redshift,
             **self.good_halocat_args)
         assert hasattr(halocat, 'Lbox')
-        assert halocat.Lbox == 200
+        assert (halocat.Lbox == 200).all()
         assert hasattr(halocat, 'particle_mass')
         assert halocat.particle_mass == 100
+        
+    def test_successful_load_vector_Lbox(self):
+
+        halocat = UserSuppliedHaloCatalog(Lbox=[100,200,300],
+            particle_mass=100, redshift=self.redshift,
+            **self.good_halocat_args)
+        assert hasattr(halocat, 'Lbox')
+        assert (halocat.Lbox == [100,200,300]).all()
 
     def test_additional_metadata(self):
 
@@ -142,6 +150,28 @@ class TestUserSuppliedHaloCatalog(TestCase):
             halocat = UserSuppliedHaloCatalog(Lbox=200,
                 particle_mass=100, redshift=self.redshift,
                 **bad_halocat_args)
+                
+    def test_positions_contained_inside_anisotropic_lbox(self):
+        # positions must be < Lbox
+        bad_halocat_args = deepcopy(self.good_halocat_args)
+        with pytest.raises(HalotoolsError):
+            bad_halocat_args['halo_x'][0] = 125
+            halocat = UserSuppliedHaloCatalog(Lbox=[100, 150, 200],
+                particle_mass=100, redshift=self.redshift,
+                **bad_halocat_args)
+
+        with pytest.raises(HalotoolsError):
+            bad_halocat_args['halo_y'][0] = 175
+            halocat = UserSuppliedHaloCatalog(Lbox=[100, 150, 200],
+                particle_mass=100, redshift=self.redshift,
+                **bad_halocat_args)
+                
+        with pytest.raises(HalotoolsError):
+            bad_halocat_args['halo_z'][0] = 225
+            halocat = UserSuppliedHaloCatalog(Lbox=[100, 150, 200],
+                particle_mass=100, redshift=self.redshift,
+                **bad_halocat_args)
+        
 
     def test_has_halo_x_column(self):
         # must have halo_x column

--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -103,9 +103,17 @@ class TestUserSuppliedPtclCatalog(TestCase):
             particle_mass=100, redshift=self.redshift,
             **self.good_ptclcat_args)
         assert hasattr(ptclcat, 'Lbox')
-        assert ptclcat.Lbox == 200
+        assert (ptclcat.Lbox == 200.).all()
         assert hasattr(ptclcat, 'particle_mass')
         assert ptclcat.particle_mass == 100
+        
+    def test_successful_load_vector_Lbox(self):
+
+        ptclcat = UserSuppliedPtclCatalog(Lbox=[100,200,300],
+            particle_mass=100, redshift=self.redshift,
+            **self.good_ptclcat_args)
+        assert hasattr(ptclcat, 'Lbox')
+        assert (ptclcat.Lbox == [100,200,300]).all()
 
     def test_additional_metadata(self):
 
@@ -132,6 +140,27 @@ class TestUserSuppliedPtclCatalog(TestCase):
         with pytest.raises(HalotoolsError):
             bad_ptclcat_args['x'][0] = 10000
             ptclcat = UserSuppliedPtclCatalog(Lbox=200,
+                particle_mass=100, redshift=self.redshift,
+                **bad_ptclcat_args)
+    
+    def test_positions_contained_inside_anisotropic_lbox(self):
+        # positions must be < Lbox
+        bad_ptclcat_args = deepcopy(self.good_ptclcat_args)
+        with pytest.raises(HalotoolsError):
+            bad_ptclcat_args['x'][0] = 125
+            ptclcat = UserSuppliedPtclCatalog(Lbox=[100, 150, 200],
+                particle_mass=100, redshift=self.redshift,
+                **bad_ptclcat_args)
+
+        with pytest.raises(HalotoolsError):
+            bad_ptclcat_args['y'][0] = 175
+            ptclcat = UserSuppliedPtclCatalog(Lbox=[100, 150, 200],
+                particle_mass=100, redshift=self.redshift,
+                **bad_ptclcat_args)
+                
+        with pytest.raises(HalotoolsError):
+            bad_ptclcat_args['z'][0] = 225
+            ptclcat = UserSuppliedPtclCatalog(Lbox=[100, 150, 200],
                 particle_mass=100, redshift=self.redshift,
                 **bad_ptclcat_args)
 

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -145,6 +145,12 @@ class UserSuppliedPtclCatalog(object):
         self.ptcl_table = Table(ptcl_table_dict)
 
         self._test_metadata_dict(**metadata_dict)
+        
+        # make Lbox a 3-vector
+        _Lbox = metadata_dict.pop('Lbox')
+        metadata_dict['Lbox'] = np.empty(3)
+        metadata_dict['Lbox'][:] = _Lbox
+        
         for key, value in metadata_dict.items():
             setattr(self, key, value)
 
@@ -181,22 +187,30 @@ class UserSuppliedPtclCatalog(object):
         return ptcl_table_dict, metadata_dict
 
     def _test_metadata_dict(self, **metadata_dict):
+        
         try:
             assert 'Lbox' in metadata_dict
-            assert custom_len(metadata_dict['Lbox']) == 1
+            assert custom_len(metadata_dict['Lbox']) in [1,3]
+        except AssertionError:
+            msg = ("\nThe UserSuppliedPtclCatalog requires keyword argument "
+                   "``Lbox``, storing either a scalar or 3-vector.\n")
+            raise HalotoolsError(msg)
+                
+        try:
             assert 'particle_mass' in metadata_dict
             assert custom_len(metadata_dict['particle_mass']) == 1
             assert 'redshift' in metadata_dict
         except AssertionError:
             msg = ("\nThe UserSuppliedPtclCatalog requires keyword arguments "
-                   "``Lbox``, ``particle_mass`` and ``redshift``\n"
+                   "``particle_mass`` and ``redshift``\n"
                    "storing scalars that will be interpreted as metadata "
                    "about the particle catalog.\n")
             raise HalotoolsError(msg)
 
-        Lbox = metadata_dict['Lbox']
-        assert Lbox > 0, "``Lbox`` must be a positive number"
-
+        Lbox = np.empty(3)
+        Lbox[:] = metadata_dict['Lbox']
+        assert (Lbox > 0).all(), "``Lbox`` must be positive"
+    
         try:
             x, y, z = (
                 self.ptcl_table['x'],
@@ -204,11 +218,11 @@ class UserSuppliedPtclCatalog(object):
                 self.ptcl_table['z'])
 
             assert np.all(x >= 0)
-            assert np.all(x <= Lbox)
+            assert np.all(x <= Lbox[0])
             assert np.all(y >= 0)
-            assert np.all(y <= Lbox)
+            assert np.all(y <= Lbox[1])
             assert np.all(z >= 0)
-            assert np.all(z <= Lbox)
+            assert np.all(z <= Lbox[2])
         except AssertionError:
             msg = ("The ``x``, ``y`` and ``z`` columns must only store "
                    "arrays\n that are bound by 0 and the input ``Lbox``. \n")


### PR DESCRIPTION
This PR addresses the feature request #641 

* the `Lbox` attribute of particle and halo catalogs is now stored as a 3-vector
* user can pass in a 3-vector or float