### PR TITLE
Modified table-writing syntax in TrivialPhaseSpace class

### DIFF
--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_composite_model.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/tests/test_composite_model.py
@@ -69,6 +69,3 @@ def test_composite_model():
 
     d = np.sqrt(dx**2 + dy**2 + dz**2)
     assert np.all(d < 2*hostrvir)
-
-
-

--- a/halotools/empirical_models/phase_space_models/trivial_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/trivial_phase_space.py
@@ -58,4 +58,4 @@ class TrivialPhaseSpace(object):
         """
         phase_space_keys = ['x', 'y', 'z', 'vx', 'vy', 'vz']
         for key in phase_space_keys:
-            table[key] = table['halo_'+key]
+            table[key][:] = table['halo_'+key][:]


### PR DESCRIPTION
This PR is intended to resolve #659, a forgotten fix needed to finish addressing #639. 