### PR TITLE
Fixed bugs triggering Numpy Deprecation Warnings

### DIFF
--- a/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/tests/test_user_supplied_ptcl_catalog.py
@@ -48,7 +48,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
     def setUp(self):
         """ Pre-load various arrays into memory for use by all tests.
         """
-        self.Nptcls = 1e4
+        self.Nptcls = int(1e4)
         self.Lbox = 100
         self.redshift = 0.0
         self.x = np.linspace(0, self.Lbox, self.Nptcls)
@@ -106,7 +106,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
         assert (ptclcat.Lbox == 200.).all()
         assert hasattr(ptclcat, 'particle_mass')
         assert ptclcat.particle_mass == 100
-        
+
     def test_successful_load_vector_Lbox(self):
 
         ptclcat = UserSuppliedPtclCatalog(Lbox=[100,200,300],
@@ -142,7 +142,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
             ptclcat = UserSuppliedPtclCatalog(Lbox=200,
                 particle_mass=100, redshift=self.redshift,
                 **bad_ptclcat_args)
-    
+
     def test_positions_contained_inside_anisotropic_lbox(self):
         # positions must be < Lbox
         bad_ptclcat_args = deepcopy(self.good_ptclcat_args)
@@ -157,7 +157,7 @@ class TestUserSuppliedPtclCatalog(TestCase):
             ptclcat = UserSuppliedPtclCatalog(Lbox=[100, 150, 200],
                 particle_mass=100, redshift=self.redshift,
                 **bad_ptclcat_args)
-                
+
         with pytest.raises(HalotoolsError):
             bad_ptclcat_args['z'][0] = 225
             ptclcat = UserSuppliedPtclCatalog(Lbox=[100, 150, 200],

--- a/halotools/utils/array_utils.py
+++ b/halotools/utils/array_utils.py
@@ -65,7 +65,7 @@ def find_idx_nearest_val(array, value):
 
     Examples
     --------
-    >>> x = np.linspace(0, 1000, num=1e5)
+    >>> x = np.linspace(0, 1000, num=int(1e5))
     >>> val = 45.5
     >>> idx_nearest_val = find_idx_nearest_val(x, val)
     >>> nearest_val = x[idx_nearest_val]

--- a/halotools/utils/table_utils.py
+++ b/halotools/utils/table_utils.py
@@ -130,7 +130,7 @@ def compute_conditional_percentiles(**kwargs):
             num_prim_haloprop_bins = (lg10_max_prim_haloprop-lg10_min_prim_haloprop)/dlog10_prim_haloprop
             prim_haloprop_bin_boundaries = np.logspace(
                 lg10_min_prim_haloprop, lg10_max_prim_haloprop,
-                num=ceil(num_prim_haloprop_bins))
+                num=int(ceil(num_prim_haloprop_bins)))
 
         # digitize the masses so that we can access them bin-wise
         output = np.digitize(prim_haloprop, prim_haloprop_bin_boundaries)


### PR DESCRIPTION
All related to passing a float for the number of points in Numpy functions such as np.linspace