### PR TITLE
Cleaned up the test suite for halo and particle table cache logs.

### DIFF
--- a/halotools/sim_manager/tests/test_halo_table_cache.py
+++ b/halotools/sim_manager/tests/test_halo_table_cache.py
@@ -110,7 +110,8 @@ class TestHaloTableCache(TestCase):
                 'bad_table.hdf5')
             self.bad_table.write(bad_table_fname, path='data')
 
-            self.bad_log_entry = HaloTableCacheLogEntry('1', '2', '3', '4', '5')
+            tmp_dummy_fname = os.path.join(self.dummy_cache_baseloc, 'tmp_dummy_fname')
+            self.bad_log_entry = HaloTableCacheLogEntry('1', '2', '3', '4', tmp_dummy_fname)
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_determine_log_entry_from_fname(self):

--- a/halotools/sim_manager/tests/test_ptcl_table_cache.py
+++ b/halotools/sim_manager/tests/test_ptcl_table_cache.py
@@ -113,7 +113,8 @@ class TestPtclTableCache(TestCase):
                                            'bad_table.hdf5')
             self.bad_table.write(bad_table_fname, path='data')
 
-            self.bad_log_entry = PtclTableCacheLogEntry('1', '2', '3', '4')
+            tmp_dummy_fname = os.path.join(self.dummy_cache_baseloc, 'tmp_dummy_fname')
+            self.bad_log_entry = PtclTableCacheLogEntry('1', '2', '3', tmp_dummy_fname)
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_determine_log_entry_from_fname1(self):


### PR DESCRIPTION
The `test_halo_table_cache.py` and `test_ptcl_table_cache.py` modules run unit-tests of the cache management system by creating temporary files in a (hidden) temporary sub-directory of $HOME that is then deleted after all the tests have been executed. Prior to this PR, some of the temporary files were accidentally created in the current working directory, rather than the temporary
directory, causing the testing files (e.g., fake halo catalogs and cache logs) to persist on disk after running the suite. The way the tests are written, the persistence of these files will lead failures if the test suite is called twice in succession from the same working directory for cases where the suite is executed via the method recommended in the docs:

```
>>> import halotools
>>> halotools.test()
```

This PR resolves the issue.