### PR TITLE
Python 3.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
+        # Significant docstring formatting changes in 3.6, so we check both
         - python: 3.6
           env: SETUP_CMD='build_sphinx -w'
 
@@ -83,14 +84,11 @@ matrix:
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
-        - python: 3.5
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
-
     allow_failures:
         # Python 3.6 currently has a DeprecationWarning related to pytest
         # that we don't understand at the moment.
         - python: 3.6
-          env: NUMPY_VERSION=1.12 SETUP_CMD='test'
+          env: SETUP_CMD='test'
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='egg_info'
 
-        # # Do a coverage test in Python 2.
-        # - python: 2.7
-        #   env: SETUP_CMD='test --coverage'
+        # Do a coverage test in Python 2.
+        - python: 2.7
+          env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
@@ -52,45 +52,45 @@ matrix:
         - python: 3.6
           env: SETUP_CMD='build_sphinx -w'
 
-        # # Python3.3 is a bit old, thus conda doesn't have all version dependencies including newer numpies
-        # - python: 3.3
-        #   env: NUMPY_VERSION=1.9
-        #        CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
+        # Python3.3 is a bit old, thus conda doesn't have all version dependencies including newer numpies
+        - python: 3.3
+          env: NUMPY_VERSION=1.9
+               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
-        # - python: 3.4
-        #   env: SETUP_CMD='egg_info'
+        - python: 3.4
+          env: SETUP_CMD='egg_info'
 
-        # - python: 3.4
-        #   env: NUMPY_VERSION=1.11
-        #        CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
+        - python: 3.4
+          env: NUMPY_VERSION=1.11
+               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
-        # # Try Astropy development version
-        # - python: 2.7
-        #   env: ASTROPY_VERSION=development
-        # - python: 3.5
-        #   env: ASTROPY_VERSION=development
+        # Try Astropy development version
+        - python: 2.7
+          env: ASTROPY_VERSION=development
+        - python: 3.5
+          env: ASTROPY_VERSION=development
 
-        # # Try older numpy version, 1.9 is tested above with py3.3
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.10
+        # Try older numpy version, 1.9 is tested above with py3.3
+        - python: 2.7
+          env: NUMPY_VERSION=1.10
 
-        # # Try numpy pre-release version, this runs only when a pre-release
-        # # is available on pypi.
-        # - python: 3.5
-        #   env: NUMPY_VERSION=prerelease SETUP_CMD='test'
-
-        - python: 3.6
-          env: NUMPY_VERSION=1.12 SETUP_CMD='test'
+        # Try numpy pre-release version, this runs only when a pre-release
+        # is available on pypi.
+        - python: 3.5
+          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
-    allow_failures:
-        # The build with numpy v1.11.1rc1 halts in the middle without
-        # showing any obvious reason, thus allowing it to fail for now.
         - python: 3.5
           env: NUMPY_VERSION=prerelease SETUP_CMD='test'
+
+    allow_failures:
+        # Python 3.6 currently has a DeprecationWarning related to pytest
+        # that we don't understand at the moment.
+        - python: 3.6
+          env: NUMPY_VERSION=1.12 SETUP_CMD='test'
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,41 +40,47 @@ matrix:
         - python: 2.7
           env: SETUP_CMD='egg_info'
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
-          env: SETUP_CMD='test --coverage'
+        # # Do a coverage test in Python 2.
+        # - python: 2.7
+        #   env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
         - python: 2.7
           env: SETUP_CMD='build_sphinx -w'
 
-        # Python3.3 is a bit old, thus conda doesn't have all version dependencies including newer numpies
-        - python: 3.3
-          env: NUMPY_VERSION=1.9
-               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
+        - python: 3.6
+          env: SETUP_CMD='build_sphinx -w'
 
-        - python: 3.4
-          env: SETUP_CMD='egg_info'
+        # # Python3.3 is a bit old, thus conda doesn't have all version dependencies including newer numpies
+        # - python: 3.3
+        #   env: NUMPY_VERSION=1.9
+        #        CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
-        - python: 3.4
-          env: NUMPY_VERSION=1.11
-               CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
+        # - python: 3.4
+        #   env: SETUP_CMD='egg_info'
 
-        # Try Astropy development version
-        - python: 2.7
-          env: ASTROPY_VERSION=development
-        - python: 3.5
-          env: ASTROPY_VERSION=development
+        # - python: 3.4
+        #   env: NUMPY_VERSION=1.11
+        #        CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
-        # Try older numpy version, 1.9 is tested above with py3.3
-        - python: 2.7
-          env: NUMPY_VERSION=1.10
+        # # Try Astropy development version
+        # - python: 2.7
+        #   env: ASTROPY_VERSION=development
+        # - python: 3.5
+        #   env: ASTROPY_VERSION=development
 
-        # Try numpy pre-release version, this runs only when a pre-release
-        # is available on pypi.
-        - python: 3.5
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
+        # # Try older numpy version, 1.9 is tested above with py3.3
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.10
+
+        # # Try numpy pre-release version, this runs only when a pre-release
+        # # is available on pypi.
+        # - python: 3.5
+        #   env: NUMPY_VERSION=prerelease SETUP_CMD='test'
+
+        - python: 3.6
+          env: NUMPY_VERSION=1.12 SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ matrix:
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
 
+        - python: 3.6
+          env: SETUP_CMD='test'
+
     allow_failures:
         # Python 3.6 currently has a DeprecationWarning related to pytest
         # that we don't understand at the moment.

--- a/halotools/empirical_models/component_model_templates/binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/binary_galprop_models.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.empirical_models.BinaryGalpropModel` class
 used to map a binary-valued galaxy property to a halo catalog.
 """
@@ -21,7 +21,7 @@ __author__ = ('Andrew Hearin', )
 
 @six.add_metaclass(ABCMeta)
 class BinaryGalpropModel(object):
-    """
+    r"""
     Container class for any component model of a binary-valued galaxy property.
 
     """
@@ -29,7 +29,7 @@ class BinaryGalpropModel(object):
     def __init__(self,
             prim_haloprop_key=model_defaults.default_binary_galprop_haloprop,
             **kwargs):
-        """
+        r"""
         Parameters
         ----------
         galprop_name : string, keyword argument
@@ -81,7 +81,7 @@ class BinaryGalpropModel(object):
         self._galprop_dtypes_to_allocate = np.dtype([(self.galprop_name, bool)])
 
     def _mc_galprop(self, seed=None, **kwargs):
-        """ Return a Monte Carlo realization of the galaxy property
+        r""" Return a Monte Carlo realization of the galaxy property
         based on draws from a nearest-integer distribution.
 
         Parameters
@@ -123,7 +123,7 @@ class BinaryGalpropModel(object):
 
 
 class BinaryGalpropInterpolModel(BinaryGalpropModel):
-    """
+    r"""
     Component model for any binary-valued galaxy property
     whose assignment is determined by interpolating between points on a grid.
 
@@ -140,7 +140,7 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
 
     def __init__(self, galprop_abscissa, galprop_ordinates,
             logparam=True, interpol_method='spline', **kwargs):
-        """
+        r"""
         Parameters
         ----------
         galprop_name : array, keyword argument
@@ -184,8 +184,8 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
         -----------
         Suppose we wish to construct a model for whether a central galaxy is
         star-forming or quiescent. We want to set the quiescent fraction to 1/3
-        for Milky Way-type centrals (:math:`M_{\\mathrm{vir}}=10^{12}M_{\odot}`),
-        and 90% for massive cluster centrals (:math:`M_{\\mathrm{vir}}=10^{15}M_{\odot}`).
+        for Milky Way-type centrals (:math:`M_{\mathrm{vir}}=10^{12}M_{\odot}`),
+        and 90% for massive cluster centrals (:math:`M_{\mathrm{vir}}=10^{15}M_{\odot}`).
         We can use the `BinaryGalpropInterpolModel` to implement this as follows:
 
         >>> abscissa, ordinates = [12, 15], [1/3., 0.9]
@@ -206,7 +206,7 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
 
         Here is another example of how you could use `BinaryGalpropInterpolModel`
         to construct a simple model for satellite morphology, where the early- vs. late-type
-        of the satellite depends on :math:`V_{\\mathrm{peak}}` value of the host halo
+        of the satellite depends on :math:`V_{\mathrm{peak}}` value of the host halo
 
         >>> sat_morphology_model = BinaryGalpropInterpolModel(galprop_name='late_type', galprop_abscissa=abscissa, galprop_ordinates=ordinates, prim_haloprop_key='vpeak_host')
         >>> vmax_array = np.logspace(2, 3, num=100)
@@ -282,7 +282,7 @@ class BinaryGalpropInterpolModel(BinaryGalpropModel):
         self.param_dict = {key: value for key, value in zip(self._ordinates_keys, self._ordinates)}
 
     def _mean_galprop_fraction(self, **kwargs):
-        """
+        r"""
         Expectation value of the galprop for galaxies living in the input halos.
 
         Parameters

--- a/halotools/empirical_models/composite_models/hod_models/zheng07.py
+++ b/halotools/empirical_models/composite_models/hod_models/zheng07.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the HOD-style composite model
 published in Zheng et al. (2007), arXiv:0703457.
 """
@@ -17,7 +17,7 @@ __all__ = ['zheng07_model_dictionary']
 def zheng07_model_dictionary(
         threshold=model_defaults.default_luminosity_threshold,
         redshift=sim_defaults.default_redshift, modulate_with_cenocc=False, **kwargs):
-    """ Dictionary for an HOD-style based on Zheng et al. (2007), arXiv:0703457.
+    r""" Dictionary for an HOD-style based on Zheng et al. (2007), arXiv:0703457.
 
     See :ref:`zheng07_composite_model` for a tutorial on this model.
 
@@ -52,9 +52,9 @@ def zheng07_model_dictionary(
         If set to True, the `Zheng07Sats.mean_occupation` method will
         be multiplied by the the first moment of the centrals:
 
-        :math:`\\langle N_{\mathrm{sat}}\\rangle_{M}\\Rightarrow\\langle N_{\\mathrm{sat}}\\rangle_{M}\\times\\langle N_{\\mathrm{cen}}\\rangle_{M}`
+        :math:`\langle N_{\mathrm{sat}}\rangle_{M}\Rightarrow\langle N_{\mathrm{sat}}\rangle_{M}\times\langle N_{\mathrm{cen}}\rangle_{M}`
 
-        The :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` function is calculated
+        The :math:`\langle N_{\mathrm{cen}}\rangle_{M}` function is calculated
         according to `Zheng07Cens.mean_occupation`.
 
     Returns

--- a/halotools/empirical_models/model_helpers.py
+++ b/halotools/empirical_models/model_helpers.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module contains general purpose helper functions
 used by many of the Halotools models.
 """
@@ -21,7 +21,7 @@ __author__ = ['Andrew Hearin', 'Surhud More', 'Johannes Ulf Lange']
 
 
 def solve_for_polynomial_coefficients(abscissa, ordinates):
-    """ Solves for coefficients of the unique,
+    r""" Solves for coefficients of the unique,
     minimum-degree polynomial that passes through
     the input abscissa and attains values equal the input ordinates.
 
@@ -52,7 +52,7 @@ def solve_for_polynomial_coefficients(abscissa, ordinates):
     The coefficients of that unique polynomial are the output of the function.
 
     As an example, suppose that a model in which the quenched fraction is
-    :math:`F_{q}(logM_{\\mathrm{halo}} = 12) = 0.25` and :math:`F_{q}(logM_{\\mathrm{halo}} = 15) = 0.9`.
+    :math:`F_{q}(logM_{\mathrm{halo}} = 12) = 0.25` and :math:`F_{q}(logM_{\mathrm{halo}} = 15) = 0.9`.
     Then this function takes [12, 15] as the input abscissa,
     [0.25, 0.9] as the input ordinates,
     and returns the array :math:`[c_{0}, c_{1}]`.
@@ -83,7 +83,7 @@ def solve_for_polynomial_coefficients(abscissa, ordinates):
 
 
 def polynomial_from_table(table_abscissa, table_ordinates, input_abscissa):
-    """ Method to evaluate an input polynomial at the input_abscissa.
+    r""" Method to evaluate an input polynomial at the input_abscissa.
     The input polynomial is determined by `solve_for_polynomial_coefficients`
     from table_abscissa and table_ordinates.
 
@@ -126,7 +126,7 @@ def polynomial_from_table(table_abscissa, table_ordinates, input_abscissa):
 
 def enforce_periodicity_of_box(coords, box_length,
         check_multiple_box_lengths=False, **kwargs):
-    """ Function used to apply periodic boundary conditions
+    r""" Function used to apply periodic boundary conditions
     of the simulation, so that mock galaxies all lie in the range [0, Lbox].
 
     Parameters
@@ -176,7 +176,7 @@ def enforce_periodicity_of_box(coords, box_length,
 
 
 def custom_spline(table_abscissa, table_ordinates, **kwargs):
-    """ Convenience wrapper around `~scipy.interpolate.InterpolatedUnivariateSpline`,
+    r""" Convenience wrapper around `~scipy.interpolate.InterpolatedUnivariateSpline`,
     written specifically to handle the edge case of a spline table being
     built from a single point.
 
@@ -235,7 +235,7 @@ def custom_spline(table_abscissa, table_ordinates, **kwargs):
 
 
 def call_func_table(func_table, abscissa, func_indices):
-    """ Returns the output of an array of functions evaluated at a set of input points
+    r""" Returns the output of an array of functions evaluated at a set of input points
     if the indices of required functions is known.
 
     Parameters
@@ -275,7 +275,7 @@ def call_func_table(func_table, abscissa, func_indices):
 
 
 def bind_required_kwargs(required_kwargs, obj, **kwargs):
-    """ Method binds each element of ``required_kwargs`` to
+    r""" Method binds each element of ``required_kwargs`` to
     the input object ``obj``, or raises and exception for cases
     where a mandatory keyword argument was not passed to the
     ``obj`` constructor.
@@ -311,7 +311,7 @@ def bind_required_kwargs(required_kwargs, obj, **kwargs):
 
 
 def create_composite_dtype(dtype_list):
-    """ Find the union of the dtypes in the input list, and return a composite
+    r""" Find the union of the dtypes in the input list, and return a composite
     dtype after verifying consistency of typing of possibly repeated fields.
 
     Parameters
@@ -351,7 +351,7 @@ def create_composite_dtype(dtype_list):
 
 
 def bind_default_kwarg_mixin_safe(obj, keyword_argument, constructor_kwargs, default_value):
-    """ Function used to ensure that a keyword argument passed to the constructor
+    r""" Function used to ensure that a keyword argument passed to the constructor
     of an orthogonal mix-in class is not already an attribute bound to self.
     If it is safe to bind the keyword_argument to the object,
     `bind_default_kwarg_mixin_safe` will do so.
@@ -389,7 +389,7 @@ def bind_default_kwarg_mixin_safe(obj, keyword_argument, constructor_kwargs, def
 
 
 def custom_incomplete_gamma(a, x):
-    """ Incomplete gamma function.
+    r""" Incomplete gamma function.
 
     For the case covered by scipy, a > 0, scipy is called. Otherwise the gamma function
     recurrence relations are called, extending the scipy behavior.
@@ -452,7 +452,7 @@ custom_incomplete_gamma.__author__ = ['Surhud More', 'Johannes Ulf Lange']
 
 
 def bounds_enforcing_decorator_factory(lower_bound, upper_bound, warning=True):
-    """
+    r"""
     Function returns a decorator that can be used to clip the values
     of an original function to produce a modified function whose
     values are replaced by the input ``lower_bound`` and ``upper_bound`` whenever

--- a/halotools/empirical_models/occupation_models/cacciato09_components.py
+++ b/halotools/empirical_models/occupation_models/cacciato09_components.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module contains occupation components used by the cacciato09 composite
 model.
 """
@@ -12,14 +12,13 @@ from .engines import cacciato09_sats_mc_prim_galprop_engine
 
 from .. import custom_incomplete_gamma
 
-from ... import sim_manager
 from ...custom_exceptions import HalotoolsError
 
 __all__ = ('Cacciato09Cens', 'Cacciato09Sats')
 
 
 class Cacciato09Cens(OccupationComponent):
-    """ CLF-style model for the central galaxy occupation. Since it is a CLF
+    r""" CLF-style model for the central galaxy occupation. Since it is a CLF
     model, it also assigns a primary galaxy property to galaxies in addition to
     effectively being an HOD model. The primary galaxy property can for example
     be luminosity or stellar mass.
@@ -30,7 +29,7 @@ class Cacciato09Cens(OccupationComponent):
 
     def __init__(self, threshold=10.0, prim_haloprop_key='halo_m200b',
                  prim_galprop_key='luminosity', **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -71,7 +70,7 @@ class Cacciato09Cens(OccupationComponent):
         self.publications = ['arXiv:0807.4932']
 
     def get_published_parameters(self):
-        """ Return the values of ``self.param_dict`` according to
+        r""" Return the values of ``self.param_dict`` according to
         the best-fit values of the WMAP3 model in Table 3 of arXiv:0807.4932.
         """
         param_dict = (
@@ -85,7 +84,7 @@ class Cacciato09Cens(OccupationComponent):
         return param_dict
 
     def median_prim_galprop(self, **kwargs):
-        """ Return the median primary galaxy property of a central galaxy as a
+        r""" Return the median primary galaxy property of a central galaxy as a
         function of the input table.
 
         Parameters
@@ -128,7 +127,7 @@ class Cacciato09Cens(OccupationComponent):
         return prim_galprop_c * (r / (1 + r))**gamma_1 * (1 + r)**gamma_2
 
     def clf(self, prim_galprop=1e10, prim_haloprop=1e12):
-        """ Return the CLF in units of dn/dlogL for the primary halo property
+        r""" Return the CLF in units of dn/dlogL for the primary halo property
         and galaxy property L.
 
         Parameters
@@ -165,7 +164,7 @@ class Cacciato09Cens(OccupationComponent):
                        self.param_dict['sigma']**2)))
 
     def mean_occupation(self, prim_galprop_min=None, **kwargs):
-        """ Expected number of central galaxies in a halo. Derived from
+        r""" Expected number of central galaxies in a halo. Derived from
         integrating the CLF from the primary galaxy property threshold to
         infinity.
 
@@ -204,7 +203,7 @@ class Cacciato09Cens(OccupationComponent):
                            (np.sqrt(2.0) * self.param_dict['sigma'])))
 
     def mc_prim_galprop(self, **kwargs):
-        """ Method to generate Monte Carlo realizations of the primary galaxy
+        r""" Method to generate Monte Carlo realizations of the primary galaxy
         property of galaxies under the constraint that the primary galaxy
         property is above the primary galaxy property threshold.
 
@@ -288,7 +287,7 @@ class Cacciato09Cens(OccupationComponent):
 
 
 class Cacciato09Sats(OccupationComponent):
-    """ CLF-style model for the satellite galaxy occupation. Since it is a CLF
+    r""" CLF-style model for the satellite galaxy occupation. Since it is a CLF
     model, it also assigns a primary galaxy property to galaxies in addition to
     effectively being an HOD model. The primary galaxy property can for example
     be luminosity or stellar mass.
@@ -298,7 +297,7 @@ class Cacciato09Sats(OccupationComponent):
 
     def __init__(self, threshold=10.0, prim_haloprop_key='halo_m200b',
                  prim_galprop_key='luminosity', **kwargs):
-        """
+        r"""
         Parameters
         ----------
             Logarithm of the primary galaxy property threshold. If the primary
@@ -341,7 +340,7 @@ class Cacciato09Sats(OccupationComponent):
         self.publications = ['arXiv:0807.4932']
 
     def get_default_parameters(self):
-        """ Return the values of ``self.param_dict`` according to
+        r""" Return the values of ``self.param_dict`` according to
         the best-fit values of the WMAP3 model in Table 3 of arXiv:0807.4932.
         """
 
@@ -363,7 +362,7 @@ class Cacciato09Sats(OccupationComponent):
         return param_dict
 
     def _update_central_params(self):
-        """
+        r"""
         Private method to update the model parameters.
         """
 
@@ -372,7 +371,7 @@ class Cacciato09Sats(OccupationComponent):
                 self.central_occupation_model.param_dict[key] = value
 
     def phi_sat(self, **kwargs):
-        """ Return the normalization for the CLF as a function of the input
+        r""" Return the normalization for the CLF as a function of the input
         table. See equation (36) in Cacciato et al. (2009) for details.
         The normalization refers to $\phi_s^\star$.
 
@@ -415,7 +414,7 @@ class Cacciato09Sats(OccupationComponent):
                     (log_prim_haloprop - 12.0)**2)
 
     def alpha_sat(self, **kwargs):
-        """ Return the power-law slope of the CLF as a function of the input
+        r""" Return the power-law slope of the CLF as a function of the input
         table.
 
         Parameters
@@ -455,7 +454,7 @@ class Cacciato09Sats(OccupationComponent):
             mass) - log_m_2)))
 
     def prim_galprop_cut(self, **kwargs):
-        """ Return the cut-off primary galaxy properties of the CLF as a
+        r""" Return the cut-off primary galaxy properties of the CLF as a
         function of the input table. See equation (38) in Cacciato et al. (2009)
         for details. The cut-off primary galaxy property refers to $\L_s^\star$.
 
@@ -494,7 +493,7 @@ class Cacciato09Sats(OccupationComponent):
 
     def mean_occupation(self, prim_galprop_min=None, prim_galprop_max=None,
                         **kwargs):
-        """ Expected number of satellite galaxies in a halo. Derived from
+        r""" Expected number of satellite galaxies in a halo. Derived from
         integrating the CLF from the luminosity threshold to infinity.
 
         Parameters
@@ -568,7 +567,7 @@ class Cacciato09Sats(OccupationComponent):
         return result
 
     def clf(self, prim_galprop=1e10, prim_haloprop=1e12):
-        """ Return the CLF in units of dn/dlogL for the primary halo property
+        r""" Return the CLF in units of dn/dlogL for the primary halo property
         and galaxy property L.
 
         Parameters
@@ -612,7 +611,7 @@ class Cacciato09Sats(OccupationComponent):
                 np.log(10))
 
     def mc_prim_galprop(self, **kwargs):
-        """ Method to generate Monte Carlo realizations of the primary galaxy
+        r""" Method to generate Monte Carlo realizations of the primary galaxy
         property of galaxies under the constraint that the primary galaxy
         property is above the primary galaxy property threshold.
 

--- a/halotools/empirical_models/occupation_models/leauthaud11_components.py
+++ b/halotools/empirical_models/occupation_models/leauthaud11_components.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module contains occupation components used by the Leauthaud11 composite model.
 """
 
@@ -21,7 +21,7 @@ __all__ = ('Leauthaud11Cens', 'Leauthaud11Sats',
 
 
 class Leauthaud11Cens(OccupationComponent):
-    """ HOD-style model for any central galaxy occupation that derives from
+    r""" HOD-style model for any central galaxy occupation that derives from
     a stellar-to-halo-mass relation.
 
     .. note::
@@ -35,7 +35,7 @@ class Leauthaud11Cens(OccupationComponent):
     def __init__(self, threshold=model_defaults.default_stellar_mass_threshold,
             prim_haloprop_key=model_defaults.prim_haloprop_key,
             redshift=sim_manager.sim_defaults.default_redshift, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -85,7 +85,7 @@ class Leauthaud11Cens(OccupationComponent):
         self.publications = list(set(self.publications))
 
     def get_published_parameters(self):
-        """ Return the values of ``self.param_dict`` according to
+        r""" Return the values of ``self.param_dict`` according to
         the SIG_MOD1 values of Table 5 of arXiv:1104.0928 for the
         lowest redshift bin.
 
@@ -100,7 +100,7 @@ class Leauthaud11Cens(OccupationComponent):
         return d
 
     def mean_occupation(self, **kwargs):
-        """ Expected number of central galaxies in a halo.
+        r""" Expected number of central galaxies in a halo.
         See Equation 8 of arXiv:1103.2077.
 
         Parameters
@@ -136,7 +136,7 @@ class Leauthaud11Cens(OccupationComponent):
         return mean_ncen
 
     def mean_stellar_mass(self, **kwargs):
-        """ Return the stellar mass of a central galaxy as a function
+        r""" Return the stellar mass of a central galaxy as a function
         of the input table.
 
         Parameters
@@ -161,7 +161,7 @@ class Leauthaud11Cens(OccupationComponent):
         return self.smhm_model.mean_stellar_mass(redshift=self.redshift, **kwargs)
 
     def mean_log_halo_mass(self, log_stellar_mass):
-        """ Return the base-10 logarithm of the halo mass of a central galaxy as a function
+        r""" Return the base-10 logarithm of the halo mass of a central galaxy as a function
         of the base-10 logarithm of the input stellar mass.
 
         Parameters
@@ -182,7 +182,7 @@ class Leauthaud11Cens(OccupationComponent):
 
 
 class Leauthaud11Sats(OccupationComponent):
-    """ HOD-style model for any satellite galaxy occupation that derives from
+    r""" HOD-style model for any satellite galaxy occupation that derives from
     a stellar-to-halo-mass relation.
 
     .. note::
@@ -197,7 +197,7 @@ class Leauthaud11Sats(OccupationComponent):
             redshift=sim_manager.sim_defaults.default_redshift,
             modulate_with_cenocc=True, cenocc_model=None,
             **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -219,7 +219,7 @@ class Leauthaud11Sats(OccupationComponent):
 
         cenocc_model : `OccupationComponent`, optional
             If the ``cenocc_model`` keyword argument is set to its default value
-            of None, then the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor will be
+            of None, then the :math:`\langle N_{\mathrm{cen}}\rangle_{M}` prefactor will be
             calculated according to `leauthaud11Cens.mean_occupation`.
             However, if an instance of the `OccupationComponent` class is instead
             passed in via the ``cenocc_model`` keyword,
@@ -276,7 +276,7 @@ class Leauthaud11Sats(OccupationComponent):
         self.publications = self.central_occupation_model.publications
 
     def mean_occupation(self, **kwargs):
-        """ Expected number of satellite galaxies in a halo of mass halo_mass.
+        r""" Expected number of satellite galaxies in a halo of mass halo_mass.
         See Equation 12-14 of arXiv:1103.2077.
 
         Parameters
@@ -368,7 +368,7 @@ class AssembiasLeauthaud11Cens(Leauthaud11Cens, HeavisideAssembias):
     """
 
     def __init__(self, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -426,7 +426,7 @@ class AssembiasLeauthaud11Sats(Leauthaud11Sats, HeavisideAssembias):
     """
 
     def __init__(self, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module contains occupation components used by the Zheng07 composite model.
 """
 
@@ -18,7 +18,7 @@ __all__ = ('Zheng07Cens', 'Zheng07Sats',
 
 
 class Zheng07Cens(OccupationComponent):
-    """ ``Erf`` function model for the occupation statistics of central galaxies,
+    r""" ``Erf`` function model for the occupation statistics of central galaxies,
     introduced in Zheng et al. 2005, arXiv:0408564. This implementation uses
     Zheng et al. 2007, arXiv:0703457, to assign fiducial parameter values.
 
@@ -34,7 +34,7 @@ class Zheng07Cens(OccupationComponent):
             threshold=model_defaults.default_luminosity_threshold,
             prim_haloprop_key=model_defaults.prim_haloprop_key,
             **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -74,7 +74,7 @@ class Zheng07Cens(OccupationComponent):
         self.publications = ['arXiv:0408564', 'arXiv:0703457']
 
     def mean_occupation(self, **kwargs):
-        """ Expected number of central galaxies in a halo of mass halo_mass.
+        r""" Expected number of central galaxies in a halo of mass halo_mass.
         See Equation 2 of arXiv:0703457.
 
         Parameters
@@ -117,10 +117,10 @@ class Zheng07Cens(OccupationComponent):
         -----
         The `mean_occupation` method computes the following function:
 
-        :math:`\\langle N_{\\mathrm{cen}} \\rangle_{M} =
-        \\frac{1}{2}\\left( 1 +
-        \\mathrm{erf}\\left( \\frac{\\log_{10}M -
-        \\log_{10}M_{min}}{\\sigma_{\\log_{10}M}} \\right) \\right)`
+        :math:`\langle N_{\mathrm{cen}} \rangle_{M} =
+        \frac{1}{2}\left( 1 +
+        \mathrm{erf}\left( \frac{\log_{10}M -
+        \log_{10}M_{min}}{\sigma_{\log_{10}M}} \right) \right)`
 
         """
         # Retrieve the array storing the mass-like variable
@@ -140,7 +140,7 @@ class Zheng07Cens(OccupationComponent):
         return mean_ncen
 
     def get_published_parameters(self, threshold, publication='Zheng07'):
-        """
+        r"""
         Best-fit HOD parameters from Table 1 of Zheng et al. 2007.
 
         Parameters
@@ -206,11 +206,11 @@ class Zheng07Cens(OccupationComponent):
 
 
 class Zheng07Sats(OccupationComponent):
-    """ Power law model for the occupation statistics of satellite galaxies,
+    r""" Power law model for the occupation statistics of satellite galaxies,
     introduced in Kravtsov et al. 2004, arXiv:0308519. This implementation uses
     Zheng et al. 2007, arXiv:0703457, to assign fiducial parameter values.
 
-    :math:`\\langle N_{sat} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha}`.
+    :math:`\langle N_{sat} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha}`.
 
     .. note::
 
@@ -224,7 +224,7 @@ class Zheng07Sats(OccupationComponent):
             threshold=model_defaults.default_luminosity_threshold,
             prim_haloprop_key=model_defaults.prim_haloprop_key,
             modulate_with_cenocc=False, cenocc_model=None, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -242,15 +242,15 @@ class Zheng07Sats(OccupationComponent):
             If set to True, the `Zheng07Sats.mean_occupation` method will
             be multiplied by the the first moment of the centrals:
 
-            :math:`\\langle N_{\mathrm{sat}}\\rangle_{M}\\Rightarrow\\langle N_{\mathrm{sat}}\\rangle_{M}\\times\\langle N_{\mathrm{cen}}\\rangle_{M}`
+            :math:`\langle N_{\mathrm{sat}}\rangle_{M}\Rightarrow\langle N_{\mathrm{sat}}\rangle_{M}\times\langle N_{\mathrm{cen}}\rangle_{M}`
 
             The ``cenocc_model`` keyword argument works together with
             the ``modulate_with_cenocc`` keyword argument to determine how
-            the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor is calculated.
+            the :math:`\langle N_{\mathrm{cen}}\rangle_{M}` prefactor is calculated.
 
         cenocc_model : `OccupationComponent`, optional
             If the ``cenocc_model`` keyword argument is set to its default value
-            of None, then the :math:`\\langle N_{\mathrm{cen}}\\rangle_{M}` prefactor will be
+            of None, then the :math:`\langle N_{\mathrm{cen}}\rangle_{M}` prefactor will be
             calculated according to `Zheng07Cens.mean_occupation`.
             However, if an instance of the `OccupationComponent` class is instead
             passed in via the ``cenocc_model`` keyword,
@@ -289,7 +289,7 @@ class Zheng07Sats(OccupationComponent):
         Now ``sat_model1`` and ``sat_model2`` are identical in every respect,
         excepting only the following difference:
 
-        :math:`\\langle N_{\mathrm{sat}}\\rangle^{\mathrm{model 2}} = \\langle N_{\mathrm{cen}}\\rangle\\times\\langle N_{\mathrm{sat}}\\rangle^{\mathrm{model 1}}`
+        :math:`\langle N_{\mathrm{sat}}\rangle^{\mathrm{model 2}} = \langle N_{\mathrm{cen}}\rangle\times\langle N_{\mathrm{sat}}\rangle^{\mathrm{model 1}}`
 
         See also
         ----------
@@ -338,7 +338,7 @@ class Zheng07Sats(OccupationComponent):
         self.publications = ['arXiv:0308519', 'arXiv:0703457']
 
     def mean_occupation(self, **kwargs):
-        """Expected number of satellite galaxies in a halo of mass logM.
+        r"""Expected number of satellite galaxies in a halo of mass logM.
         See Equation 5 of arXiv:0703457.
 
         Parameters
@@ -358,11 +358,11 @@ class Zheng07Sats(OccupationComponent):
         mean_nsat : float or array
             Mean number of satellite galaxies in a host halo of the specified mass.
 
-        :math:`\\langle N_{\\mathrm{sat}} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha} \\langle N_{\\mathrm{cen}} \\rangle_{M}`
+        :math:`\langle N_{\mathrm{sat}} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha} \langle N_{\mathrm{cen}} \rangle_{M}`
 
         or
 
-        :math:`\\langle N_{\\mathrm{sat}} \\rangle_{M} = \left( \\frac{M - M_{0}}{M_{1}} \\right)^{\\alpha}`,
+        :math:`\langle N_{\mathrm{sat}} \rangle_{M} = \left( \frac{M - M_{0}}{M_{1}} \right)^{\alpha}`,
 
         depending on whether a central model was passed to the constructor.
 
@@ -430,7 +430,7 @@ class Zheng07Sats(OccupationComponent):
         return mean_nsat
 
     def get_published_parameters(self, threshold, publication='Zheng07'):
-        """
+        r"""
         Best-fit HOD parameters from Table 1 of Zheng et al. 2007.
 
         Parameters
@@ -495,11 +495,11 @@ class Zheng07Sats(OccupationComponent):
 
 
 class AssembiasZheng07Sats(Zheng07Sats, HeavisideAssembias):
-    """ Assembly-biased modulation of `Zheng07Sats`.
+    r""" Assembly-biased modulation of `Zheng07Sats`.
     """
 
     def __init__(self, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional
@@ -552,11 +552,11 @@ class AssembiasZheng07Sats(Zheng07Sats, HeavisideAssembias):
 
 
 class AssembiasZheng07Cens(Zheng07Cens, HeavisideAssembias):
-    """ Assembly-biased modulation of `Zheng07Cens`.
+    r""" Assembly-biased modulation of `Zheng07Cens`.
     """
 
     def __init__(self, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         threshold : float, optional

--- a/halotools/empirical_models/phase_space_models/analytic_models/profile_model_template.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/profile_model_template.py
@@ -26,7 +26,7 @@ __all__ = ['AnalyticDensityProf']
 
 @six.add_metaclass(ABCMeta)
 class AnalyticDensityProf(object):
-    """ Container class for any analytical radial profile model.
+    r""" Container class for any analytical radial profile model.
 
     See :ref:`profile_template_tutorial` for a review of the mathematics of
     halo profiles, and a thorough description of how the relevant equations
@@ -43,7 +43,7 @@ class AnalyticDensityProf(object):
     """
 
     def __init__(self, cosmology, redshift, mdef, **kwargs):
-        """
+        r"""
         Parameters
         -----------
         cosmology : object
@@ -411,7 +411,7 @@ class AnalyticDensityProf(object):
         return self.circular_velocity(result.x[0]*halo_radius, total_mass, *prof_params)
 
     def halo_mass_to_halo_radius(self, total_mass):
-        """
+        r"""
         Spherical overdensity radius as a function of the input mass.
 
         Note that this function is independent of the form of the density profile.
@@ -438,7 +438,7 @@ class AnalyticDensityProf(object):
             redshift=self.redshift, mdef=self.mdef)
 
     def halo_radius_to_halo_mass(self, radius):
-        """
+        r"""
         Spherical overdensity mass as a function of the input radius.
 
         Note that this function is independent of the form of the density profile.

--- a/halotools/empirical_models/sfr_models/halo_mass_quenching.py
+++ b/halotools/empirical_models/sfr_models/halo_mass_quenching.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.empirical_models.HaloMassInterpolQuenching` class
 responsible for providing a mapping between halo mass and galaxy quenching designation.
 """
@@ -12,7 +12,7 @@ __all__ = ['HaloMassInterpolQuenching']
 
 
 class HaloMassInterpolQuenching(BinaryGalpropInterpolModel):
-    """ Model for the quiescent fraction as a function of halo mass
+    r""" Model for the quiescent fraction as a function of halo mass
     defined by interpolating between a set of input control points.
 
     Notes
@@ -26,7 +26,7 @@ class HaloMassInterpolQuenching(BinaryGalpropInterpolModel):
 
     def __init__(self, halo_mass_key,
             halo_mass_abscissa, quiescent_fraction_control_values, **kwargs):
-        """
+        r"""
         Parameters
         -----------
         halo_mass_key : string
@@ -72,7 +72,7 @@ class HaloMassInterpolQuenching(BinaryGalpropInterpolModel):
         >>> model_instance.param_dict['quiescent_ordinates_param1'] = 0.35
 
         The above line of code changed the quiescent fraction to 0.35 at the first control value
-        of :math:`M_{\\rm vir} = 10^{12}M_{\\odot}`. You will have one parameter for every
+        of :math:`M_{\rm vir} = 10^{12}M_{\odot}`. You will have one parameter for every
         control value you used to instantiate the model. While you can always change the
         quiescent fraction of your model instance at any given control value, you cannot
         change the halo masses at which the control values are evaluated. To do that,

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -1,4 +1,4 @@
-""" Common functions used when analyzing catalogs of galaxies/halos.
+r""" Common functions used when analyzing catalogs of galaxies/halos.
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
@@ -15,7 +15,7 @@ __author__ = ['Andrew Hearin']
 
 
 def mean_y_vs_x(x, y, error_estimator='error_on_mean', **kwargs):
-    """
+    r"""
     Estimate the mean value of the property *y* as a function of *x*
     for an input sample of galaxies/halos,
     optionally returning an error estimate.
@@ -39,12 +39,12 @@ def mean_y_vs_x(x, y, error_estimator='error_on_mean', **kwargs):
 
     error_estimator : string, optional
         If set to ``error_on_mean``, function will also return an array storing
-        :math:`\\sigma_{y}/\\sqrt{N}`, where :math:`\\sigma_{y}` is the
+        :math:`\sigma_{y}/\sqrt{N}`, where :math:`\sigma_{y}` is the
         standard deviation of *y* in the bin
-        and :math:`\\sqrt{N}` is the counts in each bin.
+        and :math:`\sqrt{N}` is the counts in each bin.
 
         If set to ``variance``, function will also return an array storing
-        :math:`\\sigma_{y}`.
+        :math:`\sigma_{y}`.
 
         Default is ``error_on_mean``
 
@@ -98,7 +98,7 @@ def mean_y_vs_x(x, y, error_estimator='error_on_mean', **kwargs):
 
 
 def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
-    """ Returns a Numpy array of shape *(Npts, 3)* storing the
+    r""" Returns a Numpy array of shape *(Npts, 3)* storing the
     xyz-positions in the format used throughout
     the `~halotools.mock_observables` package.
 
@@ -112,7 +112,7 @@ def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
     velocity : array, optional
         Length-Npts array of velocities in units of km/s
         used to apply peculiar velocity distortions, e.g.,
-        :math:`z_{\\rm dist} = z + v/H_{0}`.
+        :math:`z_{\rm dist} = z + v/H_{0}`.
         Since Halotools workes exclusively in h=1 units,
         in the above formula :math:`H_{0} = 100 km/s/Mpc`.
 
@@ -214,7 +214,7 @@ def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
 
 
 def cuboid_subvolume_labels(sample, Nsub, Lbox):
-    """
+    r"""
     Return integer labels indicating which cubical subvolume of a larger cubical volume a
     set of points occupy.
 
@@ -307,7 +307,7 @@ def cuboid_subvolume_labels(sample, Nsub, Lbox):
 
 
 def sign_pbc(x1, x2, period=None, equality_fill_val=0., return_pbc_correction=False):
-    """ Return the sign of the unit vector pointing from x2 towards x1,
+    r""" Return the sign of the unit vector pointing from x2 towards x1,
     that is, the sign of (x1 - x2), accounting for periodic boundary conditions.
 
     If x1 > x2, returns 1. If x1 < x2, returns -1. If x1 == x2, returns equality_fill_val.
@@ -382,7 +382,7 @@ def sign_pbc(x1, x2, period=None, equality_fill_val=0., return_pbc_correction=Fa
 
 
 def relative_positions_and_velocities(x1, x2, period=None, **kwargs):
-    """ Return the vector pointing from x2 towards x1,
+    r""" Return the vector pointing from x2 towards x1,
     that is, x1 - x2, accounting for periodic boundary conditions.
 
     If keyword arguments ``v1`` and ``v2`` are passed in,

--- a/halotools/mock_observables/group_identification/fof_groups.py
+++ b/halotools/mock_observables/group_identification/fof_groups.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.FoFGroups` class used to
 identify friends-of-friends groups of points.
 """
@@ -27,12 +27,12 @@ __author__ = ['Duncan Campbell']
 
 
 class FoFGroups(object):
-    """
+    r"""
     Friends-of-friends (FoF) groups class.
     """
 
     def __init__(self, positions, b_perp, b_para, period=None, Lbox=None, num_threads=1):
-        """
+        r"""
         Build FoF groups in redshift space assuming the distant observer approximation.
 
         The first two dimensions (x, y) define the plane for perpendicular distances.
@@ -171,7 +171,7 @@ class FoFGroups(object):
 
     @property
     def group_ids(self):
-        """
+        r"""
         Determine integer IDs for groups.
 
         Each member of a group is assigned a unique integer ID that it shares with all
@@ -190,7 +190,7 @@ class FoFGroups(object):
 
     @property
     def n_groups(self):
-        """
+        r"""
         Calculate the total number of groups, including 1-member groups
 
         Returns
@@ -269,7 +269,7 @@ class FoFGroups(object):
             raise HalotoolsError(no_igraph_msg)
 
     def get_edges(self):
-        """
+        r"""
         Return all edges of the graph (requires igraph package).
 
         Returns
@@ -290,7 +290,7 @@ class FoFGroups(object):
             raise HalotoolsError(no_igraph_msg)
 
     def get_edge_lengths(self):
-        """
+        r"""
         Return the length of all edges (requires igraph package).
 
         Returns
@@ -303,9 +303,9 @@ class FoFGroups(object):
         The length is caclulated as:
 
         .. math::
-            L_{\\rm edge} = \\sqrt{r_{\\perp}^2 + r_{\\parallel}^2},
+            L_{\rm edge} = \sqrt{r_{\perp}^2 + r_{\parallel}^2},
 
-        where :math:`r_{\\perp}` and :math:`r_{\\parallel}` are the perendicular and
+        where :math:`r_{\perp}` and :math:`r_{\parallel}` are the perendicular and
         parallel distance between galaixes.
 
         """
@@ -323,7 +323,7 @@ class FoFGroups(object):
 
 
 def _scipy_to_igraph(matrix, coords, directed=False):
-    """
+    r"""
     Convert a scipy sparse matrix to an igraph graph object (requires igraph package).
 
     Paramaters

--- a/halotools/mock_observables/isolation_functions/conditional_cylindrical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/conditional_cylindrical_isolation.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.conditional_spherical_isolation` function
 used to apply a a variety of 3d isolation criteria to a set of points in a periodic box.
 """
@@ -25,7 +25,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 def conditional_cylindrical_isolation(sample1, sample2, rp_max, pi_max,
                           marks1=None, marks2=None, cond_func=0, period=None, num_threads=1,
                           approx_cell1_size=None, approx_cell2_size=None):
-    """
+    r"""
     Determine whether a set of points, ``sample1``, is isolated, i.e. does not have a
     neighbor in ``sample2`` within an user specified cylindrical volume centered at each
     point in ``sample1``, where various additional conditions may be applied to judge
@@ -148,62 +148,62 @@ def conditional_cylindrical_isolation(sample1, sample2, rp_max, pi_max,
     1. greater than (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] > w_2[0] \\\\
-                    False & : w_1[0] \\leq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] > w_2[0] \\
+                    False & : w_1[0] \leq w_2[0] \\
+                \end{array}
+                \right.
 
     2. less than (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] < w_2[0] \\\\
-                    False & : w_1[0] \\geq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] < w_2[0] \\
+                    False & : w_1[0] \geq w_2[0] \\
+                \end{array}
+                \right.
 
     3. equality (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] = w_2[0] \\\\
-                    False & : w_1[0] \\neq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] = w_2[0] \\
+                    False & : w_1[0] \neq w_2[0] \\
+                \end{array}
+                \right.
 
     4. inequality (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] \\neq w_2[0] \\\\
-                    False & : w_1[0] = w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] \neq w_2[0] \\
+                    False & : w_1[0] = w_2[0] \\
+                \end{array}
+                \right.
 
     5. tolerance greater than (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] > (w_2[0]+w_1[1]) \\\\
-                    False & : w_1[0] \\leq (w_2[0]+w_1[1]) \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] > (w_2[0]+w_1[1]) \\
+                    False & : w_1[0] \leq (w_2[0]+w_1[1]) \\
+                \end{array}
+                \right.
 
     6. tolerance less than (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] < (w_2[0]+w_1[1]) \\\\
-                    False & : w_1[0] \\geq (w_2[0]+w_1[1]) \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] < (w_2[0]+w_1[1]) \\
+                    False & : w_1[0] \geq (w_2[0]+w_1[1]) \\
+                \end{array}
+                \right.
 
     Examples
     --------

--- a/halotools/mock_observables/isolation_functions/conditional_spherical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/conditional_spherical_isolation.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.conditional_spherical_isolation` function
 used to apply a a variety of 3d isolation criteria to a set of points in a periodic box.
 """
@@ -25,7 +25,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 def conditional_spherical_isolation(sample1, sample2, r_max,
         marks1=None, marks2=None, cond_func=0, period=None,
         num_threads=1, approx_cell1_size=None, approx_cell2_size=None):
-    """
+    r"""
     Determine whether a set of points, ``sample1``, is isolated, i.e. does not have a
     neighbor in ``sample2`` within an user specified spherical volume centered at each
     point in ``sample1``, where various additional conditions may be applied to judge
@@ -145,62 +145,62 @@ def conditional_spherical_isolation(sample1, sample2, r_max,
     1. greater than (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] > w_2[0] \\\\
-                    False & : w_1[0] \\leq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] > w_2[0] \\
+                    False & : w_1[0] \leq w_2[0] \\
+                \end{array}
+                \right.
 
     2. less than (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] < w_2[0] \\\\
-                    False & : w_1[0] \\geq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] < w_2[0] \\
+                    False & : w_1[0] \geq w_2[0] \\
+                \end{array}
+                \right.
 
     3. equality (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] = w_2[0] \\\\
-                    False & : w_1[0] \\neq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] = w_2[0] \\
+                    False & : w_1[0] \neq w_2[0] \\
+                \end{array}
+                \right.
 
     4. inequality (N_marks = 1)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] \\neq w_2[0] \\\\
-                    False & : w_1[0] = w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] \neq w_2[0] \\
+                    False & : w_1[0] = w_2[0] \\
+                \end{array}
+                \right.
 
     5. tolerance greater than (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] > (w_2[0]+w_1[1]) \\\\
-                    False & : w_1[0] \\leq (w_2[0]+w_1[1]) \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] > (w_2[0]+w_1[1]) \\
+                    False & : w_1[0] \leq (w_2[0]+w_1[1]) \\
+                \end{array}
+                \right.
 
     6. tolerance less than (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    True & : w_1[0] < (w_2[0]+w_1[1]) \\\\
-                    False & : w_1[0] \\geq (w_2[0]+w_1[1]) \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    True & : w_1[0] < (w_2[0]+w_1[1]) \\
+                    False & : w_1[0] \geq (w_2[0]+w_1[1]) \\
+                \end{array}
+                \right.
 
     Examples
     --------

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_projected_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_projected_engine.pyx
@@ -4,8 +4,8 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
-from libc.math cimport ceil 
+cimport cython
+from libc.math cimport ceil
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
 __all__ = ('npairs_projected_engine', )
@@ -13,40 +13,40 @@ __all__ = ('npairs_projected_engine', )
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def npairs_projected_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def npairs_projected_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     rp_bins, pi_max, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of projected separation. 
+    r""" Cython engine for counting pairs of points as a function of projected separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
     rp_bins : array_like
-        numpy array of boundaries defining the bins of separation in the xy-plane 
-        :math:`r_{\\rm p}` in which pairs are counted.
+        numpy array of boundaries defining the bins of separation in the xy-plane
+        :math:`r_{\rm p}` in which pairs are counted.
 
-    pi_max : float 
-        Maximum value in the z-dimension over which pairs will be counted. 
+    pi_max : float
+        Maximum value in the z-dimension over which pairs will be counted.
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rp_bins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rp_bins``. 
+    counts : array
+        Integer array of length len(rp_bins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rp_bins``.
 
-    """    
+    """
     cdef cnp.float64_t[:] rp_bins_squared = rp_bins*rp_bins
     cdef cnp.float64_t pi_max_squared = pi_max*pi_max
     cdef cnp.float64_t xperiod = double_mesh.xperiod
@@ -98,7 +98,7 @@ def npairs_projected_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dxy_sq, dz_sq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef int Ni, Nj, i, j, k, l
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
@@ -123,9 +123,9 @@ def npairs_projected_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -187,7 +187,7 @@ def npairs_projected_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                             counts[k] += 1
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts)
 
 

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_s_mu_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_s_mu_engine.pyx
@@ -16,7 +16,7 @@ __all__ = ('npairs_s_mu_engine', )
 @cython.nonecheck(False)
 def npairs_s_mu_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     s_bins_in, mu_bins_in, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of projected separation.
+    r""" Cython engine for counting pairs of points as a function of projected separation.
 
     Parameters
     ------------
@@ -33,7 +33,7 @@ def npairs_s_mu_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
         numpy array of boundaries defining the radial bins in which pairs are counted.
 
     mu_bins_in : array_like
-        numpy array of boundaries defining bins in :math:`\\sin(\\theta_{\\rm los})`
+        numpy array of boundaries defining bins in :math:`\sin(\theta_{\rm los})`
         in which the pairs are counted in.
         Note that using the sine is not common convention for
         calculating the two point correlation function (see notes).
@@ -193,9 +193,9 @@ def npairs_s_mu_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                         mu = sqrt(dxy_sq)/s
                                     else:
                                         mu=0.0
-                                    
+
                                     if (s <= s_max) & (mu <= mu_max):
-                                        
+
                                         k = num_s_bins-2
                                         while k!=-1:
                                             if s > s_bins[k]: break

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_xy_z_engine.pyx
@@ -4,8 +4,8 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
-from libc.math cimport ceil 
+cimport cython
+from libc.math cimport ceil
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
 __all__ = ('npairs_xy_z_engine', )
@@ -13,40 +13,40 @@ __all__ = ('npairs_xy_z_engine', )
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     rp_bins, pi_bins, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of projected separation. 
+    r""" Cython engine for counting pairs of points as a function of projected separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
     rp_bins : array_like
-        numpy array of boundaries defining the bins of separation in the xy-plane 
-        :math:`r_{\\rm p}` in which pairs are counted.
+        numpy array of boundaries defining the bins of separation in the xy-plane
+        :math:`r_{\rm p}` in which pairs are counted.
 
     pi_bins : numpy.array
         array defining parallel separation in which to sum the pair counts
- 
+
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rp_bins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rp_bins``. 
+    counts : array
+        Integer array of length len(rp_bins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rp_bins``.
 
-    """    
+    """
     cdef cnp.float64_t[:] rp_bins_squared = rp_bins*rp_bins
     cdef cnp.float64_t[:] pi_bins_squared = pi_bins*pi_bins
     cdef cnp.float64_t xperiod = double_mesh.xperiod
@@ -99,7 +99,7 @@ def npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dxy_sq, dz_sq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef int Ni, Nj, i, j, k, l, g, max_k
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
@@ -124,9 +124,9 @@ def npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -191,7 +191,7 @@ def npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                             if g<0: break
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts)
 
 

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distances.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distances.pyx
@@ -28,64 +28,64 @@ def pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
                              np.ndarray[np.float64_t, ndim=1] y_icell2,
                              np.ndarray[np.float64_t, ndim=1] z_icell2,
                              np.float64_t max_r):
-    
-    """
+
+    r"""
     Calculate the limited pairwise distance matrix, :math:`d_{ij}`.
-    
-    calculate the distance between all pairs with sperations less than or equal 
+
+    calculate the distance between all pairs with sperations less than or equal
     to ``max_r``.
-    
+
     Parameters
     ----------
     x_icell1 : numpy.array
         array of x positions of length N1 (data1)
-    
+
     y_icell1 : numpy.array
         array of y positions of length N1 (data1)
-    
+
     z_icell1 : numpy.array
         array of z positions of length N1 (data1)
-    
+
     x_icell2 : numpy.array
         array of x positions of length N2 (data2)
-    
+
     y_icell2 : numpy.array
         array of y positions of length N2 (data2)
-    
+
     z_icell2 : numpy.array
         array of z positions of length N2 (data2)
-    
+
     max_r : float
         maximum separation to record
-    
+
     Returns
     -------
     d : numpy.array
         array of pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices
-    
+
     j : numpy.array
         array of 0-indexed indices
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    unit cube.
+
     >>> Npts = 1000
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
-    
+
     Calculate the distance between all pairs with separations less than 0.5:
-    
+
     >>> r_max = 0.5
     >>> d,i,j = pairwise_distance_no_pbc(x,y,z,x,y,z,r_max)
     """
-    
+
     #c definitions
     cdef vector[np.int_t] i_ind
     cdef vector[np.int_t] j_ind
@@ -94,29 +94,29 @@ def pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
     cdef np.int_t i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
-    
+
     #square the distance to avoid taking a square root in a tight loop
     max_r = max_r**2
-    
+
     #loop over points in grid1's cells
     n=0
     for i in range(0,Ni):
         #loop over points in grid2's cells
         for j in range(0,Nj):
-                        
+
             #calculate the square distance
             d = square_distance(
                 x_icell1[i],y_icell1[i],z_icell1[i],
                 x_icell2[j],y_icell2[j],z_icell2[j])
-                        
+
             #add distance to result
             if d<=max_r:
                 distances.push_back(d)
                 i_ind.push_back(i)
                 j_ind.push_back(j)
                 n = n+1
-    
-    return (np.sqrt(distances).astype(float), 
+
+    return (np.sqrt(distances).astype(float),
         np.array(i_ind).astype(int),np.array(j_ind).astype(int))
 
 
@@ -131,69 +131,69 @@ def pairwise_distance_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
                              np.ndarray[np.float64_t, ndim=1] z_icell2,
                              np.ndarray[np.float64_t, ndim=1] period,
                              np.float64_t max_r):
-    
+
     """
     Calculate the limited pairwise distance matrix, :math:`d_{ij}`, with periodic boundary conditions (PBC).
-    
-    calculate the distance between all pairs with sperations less than or equal 
+
+    calculate the distance between all pairs with sperations less than or equal
     to ``max_r``.
-    
+
     Parameters
     ----------
     x_icell1 : numpy.array
         array of x positions of length N1 (data1)
-    
+
     y_icell1 : numpy.array
         array of y positions of length N1 (data1)
-    
+
     z_icell1 : numpy.array
         array of z positions of length N1 (data1)
-    
+
     x_icell2 : numpy.array
         array of x positions of length N2 (data2)
-    
+
     y_icell2 : numpy.array
         array of y positions of length N2 (data2)
-    
+
     z_icell2 : numpy.array
         array of z positions of length N2 (data2)
-    
+
     period : numpy.array
         array defining  periodic boundary conditions.
-    
+
     max_r : float
         maximum separation to record
-    
+
     Returns
     -------
     d : numpy.array
         array of pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices
-    
+
     j : numpy.array
         array of 0-indexed indices
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    periodic unit cube.
+
     >>> Npts = 1000
     >>> Lbox = 1.0
     >>> period = np.array([Lbox,Lbox,Lbox])
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
-    
+
     Calculate the distance between all pairs with separations less than 0.5:
-    
+
     >>> r_max = 0.5
     >>> d,i,j = pairwise_distance_pbc(x,y,z,x,y,z,period,r_max)
     """
-    
+
     #c definitions
     cdef vector[np.int_t] i_ind
     cdef vector[np.int_t] j_ind
@@ -202,30 +202,30 @@ def pairwise_distance_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
     cdef int i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
-    
+
     #square the distance to avoid taking a square root in a tight loop
     max_r = max_r**2
-    
+
     #loop over points in grid1's cells
     n=0
     for i in range(0,Ni):
         #loop over points in grid2's cells
         for j in range(0,Nj):
-                        
+
             #calculate the square distance
             d = periodic_square_distance(
                 x_icell1[i],y_icell1[i],z_icell1[i],
                 x_icell2[j],y_icell2[j],z_icell2[j],
                 <np.float64_t*> period.data)
-                        
+
             #add distance to result
             if d<=max_r:
                 distances.push_back(d)
                 i_ind.push_back(i)
                 j_ind.push_back(j)
                 n = n+1
-    
-    return (np.sqrt(distances).astype(float), 
+
+    return (np.sqrt(distances).astype(float),
         np.array(i_ind).astype(int), np.array(j_ind).astype(int))
 
 
@@ -241,71 +241,71 @@ def pairwise_xy_z_distance_no_pbc(
     np.ndarray[np.float64_t, ndim=1] z_icell2,
     np.float64_t max_rp, np.float64_t max_pi):
     """
-    Calculate the limited pairwise distance matrices, :math:`d_{{\\perp}ij}` and :math:`d_{{\\parallel}ij}`.
-    
-    Calculate the perpendicular and parallel distance between all pairs with separations 
+    Calculate the limited pairwise distance matrices, :math:`d_{{\perp}ij}` and :math:`d_{{\parallel}ij}`.
+
+    Calculate the perpendicular and parallel distance between all pairs with separations
     less than or equal to ``max_rp`` and ``max_pi`` wrt to the z-direction, repsectively.
-    
+
     Parameters
     ----------
     x_icell1 : numpy.array
         array of x positions of length N1 (data1)
-    
+
     y_icell1 : numpy.array
         array of y positions of length N1 (data1)
-    
+
     z_icell1 : numpy.array
         array of z positions of length N1 (data1)
-    
+
     x_icell2 : numpy.array
         array of x positions of length N2 (data2)
-    
+
     y_icell2 : numpy.array
         array of y positions of length N2 (data2)
-    
+
     z_icell2 : numpy.array
         array of z positions of length N2 (data2)
-    
+
     max_rp : float
         maximum perpendicular separation to record
-    
+
     max_pi : float
         maximum parallel separation to record
-    
+
     Returns
     -------
     d_perp : numpy.array
         array of perpendicular pairwise separation distances
-    
+
     d_para : numpy.array
         array of parallel pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices
-    
+
     j : numpy.array
         array of 0-indexed indices
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    unit cube.
+
     >>> Npts = 1000
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
-    
+
     Calculate the distance between all pairs with perpednicular separations less than 0.25
     and parallel sperations of 0.5:
-    
+
     >>> max_rp = 0.25
     >>> max_pi = 0.5
     >>> d_perp,d_para,i,j = pairwise_xy_z_distance_no_pbc(x,y,z,x,y,z,max_rp,max_para)
     """
-    
-    
+
+
     #c definitions
     cdef vector[np.int_t] i_ind
     cdef vector[np.int_t] j_ind
@@ -315,23 +315,23 @@ def pairwise_xy_z_distance_no_pbc(
     cdef int i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
-    
+
     #square the distance bins to avoid taking a square root in a tight loop
     max_rp = max_rp**2
     max_pi = max_pi**2
-    
+
     #loop over points in grid1's cells
     n=0
     for i in range(0,Ni):
         #loop over points in grid2's cells
         for j in range(0,Nj):
-                        
+
             #calculate the square distance
             d_perp = perp_square_distance(
                 x_icell1[i], y_icell1[i],
                 x_icell2[j], y_icell2[j])
             d_para = para_square_distance(z_icell1[i], z_icell2[j])
-                        
+
             #add distance to result
             if (d_perp<=max_rp) & (d_para<=max_pi):
                 perp_distances.push_back(d_perp)
@@ -339,8 +339,8 @@ def pairwise_xy_z_distance_no_pbc(
                 i_ind.push_back(i)
                 j_ind.push_back(j)
                 n = n+1
-    
-    return (np.sqrt(perp_distances).astype(float), 
+
+    return (np.sqrt(perp_distances).astype(float),
         np.sqrt(para_distances).astype(float),
         np.array(i_ind).astype(int), np.array(j_ind).astype(int))
 
@@ -357,77 +357,77 @@ def pairwise_xy_z_distance_pbc(
     np.ndarray[np.float64_t, ndim=1] z_icell2,
     np.ndarray[np.float64_t, ndim=1] period,
     np.float64_t max_rp, np.float64_t max_pi):
-    
+
     """
-    Calculate the limited pairwise distance matrices, :math:`d_{{\\perp}ij}` and :math:`d_{{\\parallel}ij}`, with periodic boundary conditions (PBC).
-    
-    Calculate the perpendicular and parallel distance between all pairs with separations 
+    Calculate the limited pairwise distance matrices, :math:`d_{{\perp}ij}` and :math:`d_{{\parallel}ij}`, with periodic boundary conditions (PBC).
+
+    Calculate the perpendicular and parallel distance between all pairs with separations
     less than or equal to ``max_rp`` and ``max_pi`` wrt to the z-direction, repsectively.
-    
+
     Parameters
     ----------
     x_icell1 : numpy.array
         array of x positions of length N1 (data1)
-    
+
     y_icell1 : numpy.array
         array of y positions of length N1 (data1)
-    
+
     z_icell1 : numpy.array
         array of z positions of length N1 (data1)
-    
+
     x_icell2 : numpy.array
         array of x positions of length N2 (data2)
-    
+
     y_icell2 : numpy.array
         array of y positions of length N2 (data2)
-    
+
     z_icell2 : numpy.array
         array of z positions of length N2 (data2)
-    
+
     period : numpy.array
         array defining  periodic boundary conditions.
-    
+
     max_rp : float
         maximum perpendicular separation to record
-    
+
     max_pi : float
         maximum parallel separation to record
-    
+
     Returns
     -------
     d_perp : numpy.array
         array of perpendicular pairwise separation distances
-    
+
     d_para : numpy.array
         array of parallel pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices
-    
+
     j : numpy.array
         array of 0-indexed indices
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    periodic unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    periodic unit cube.
+
     >>> Npts = 1000
     >>> Lbox = 1.0
     >>> period = np.array([Lbox,Lbox,Lbox])
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
-    
+
     Calculate the distance between all pairs with perpednicular separations less than 0.25
     and parallel sperations of 0.5:
-    
+
     >>> max_rp = 0.25
     >>> max_pi = 0.5
     >>> d_perp, d_para,i,j = pairwise_xy_z_distance_no_pbc(x,y,z,x,y,z,period,max_rp,max_para)
     """
-    
+
     #c definitions
     cdef vector[np.int_t] i_ind
     cdef vector[np.int_t] j_ind
@@ -437,17 +437,17 @@ def pairwise_xy_z_distance_pbc(
     cdef int i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
-    
+
     #square the distance bins to avoid taking a square root in a tight loop
     max_rp = max_rp**2
     max_pi = max_pi**2
-    
+
     #loop over points in grid1's cells
     n=0
     for i in range(0,Ni):
         #loop over points in grid2's cells
         for j in range(0,Nj):
-                        
+
             #calculate the square distance
             d_perp = periodic_perp_square_distance(
                 x_icell1[i],y_icell1[i],
@@ -455,7 +455,7 @@ def pairwise_xy_z_distance_pbc(
                 <np.float64_t*>period.data)
             d_para = periodic_para_square_distance(
                 z_icell1[i], z_icell2[j],<np.float64_t*>period.data)
-                        
+
             #add distance to result
             if (d_perp<=max_rp) & (d_para<=max_pi):
                 perp_distances.push_back(d_perp)
@@ -463,9 +463,9 @@ def pairwise_xy_z_distance_pbc(
                 i_ind.push_back(i)
                 j_ind.push_back(j)
                 n = n+1
-    
-    return (np.sqrt(perp_distances).astype(float), 
+
+    return (np.sqrt(perp_distances).astype(float),
         np.sqrt(para_distances).astype(float),
         np.array(i_ind).astype(int), np.array(j_ind).astype(int))
-    
-    
+
+

--- a/halotools/mock_observables/pair_counters/marked_cpairs/conditional_pairwise_distances.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/conditional_pairwise_distances.pyx
@@ -31,75 +31,75 @@ def conditional_pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icel
                              np.ndarray[np.float64_t, ndim=2] w_icell1,
                              np.ndarray[np.float64_t, ndim=2] w_icell2,
                              np.int_t cond_func_id):
-    
+
     """
     Calculate the conditional limited pairwise distance matrix, :math:`d_{ij}`.
-    
-    calculate the distance between all pairs with sperations less than or equal 
+
+    calculate the distance between all pairs with sperations less than or equal
     to ``max_r`` if a conditon is met.
-    
+
     Parameters
     ----------
     x_icell1 : numpy.array
         array of x positions of length N1 (data1)
-    
+
     y_icell1 : numpy.array
         array of y positions of length N1 (data1)
-    
+
     z_icell1 : numpy.array
         array of z positions of length N1 (data1)
-    
+
     x_icell2 : numpy.array
         array of x positions of length N2 (data2)
-    
+
     y_icell2 : numpy.array
         array of y positions of length N2 (data2)
-    
+
     z_icell2 : numpy.array
         array of z positions of length N2 (data2)
-    
+
     max_r : float
         maximum separation to record
-    
+
     w_icell1 : numpy.array
         array of floats
-    
+
     w_icell2 : numpy.array
         array of floats
-    
+
     cond_func_id : int
         integer ID of conditional function
-        
+
     Returns
     -------
     d : numpy.array
         array of pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices
-    
+
     j : numpy.array
         array of 0-indexed indices
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    unit cube.
+
     >>> Npts = 1000
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
     >>> weights = np.random.random(Npts)
-    
-    Calculate the distance between all pairs with separations less than 0.5 if 
+
+    Calculate the distance between all pairs with separations less than 0.5 if
     the weight associated with the first point is larger than the second point:
-    
+
     >>> r_max = 0.5
     >>> d,i,j = conditional_pairwise_distance_no_pbc(x,y,z,x,y,z,r_max,weights,weights,1)
     """
-    
+
     #c definitions
     cdef vector[np.int_t] i_ind
     cdef vector[np.int_t] j_ind
@@ -108,31 +108,31 @@ def conditional_pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icel
     cdef np.int_t i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
-    
+
     #square the distance to avoid taking a square root in a tight loop
     max_r = max_r**2
-    
+
     cond_func = return_conditional_function(cond_func_id)
-    
+
     #loop over points in grid1's cells
     n=0
     for i in range(0,Ni):
         #loop over points in grid2's cells
         for j in range(0,Nj):
-            
+
             if cond_func(&w_icell1[i,0],&w_icell2[j,0]):
-            
+
                 #calculate the square distance
                 d = square_distance(x_icell1[i],y_icell1[i],z_icell1[i],\
                                 x_icell2[j],y_icell2[j],z_icell2[j])
-                
+
                 #add distance to result
                 if d<=max_r:
                     distances.push_back(d)
                     i_ind.push_back(i)
                     j_ind.push_back(j)
                     n = n+1
-    
+
     return np.sqrt(distances).astype(float), np.array(i_ind).astype(int),\
            np.array(j_ind).astype(int)
 
@@ -151,82 +151,82 @@ def conditional_pairwise_xy_z_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x
                                   np.ndarray[np.float64_t, ndim=2] w_icell2,
                                   np.int_t cond_func_id):
     """
-    Calculate the conditional limited pairwise distance matrices, :math:`d_{{\\perp}ij}` and :math:`d_{{\\parallel}ij}`.
-    
-    Calculate the perpendicular and parallel distance between all pairs with separations 
+    Calculate the conditional limited pairwise distance matrices, :math:`d_{{\perp}ij}` and :math:`d_{{\parallel}ij}`.
+
+    Calculate the perpendicular and parallel distance between all pairs with separations
     less than or equal to ``max_rp`` and ``max_pi`` wrt to the z-direction, repsectively,
     if a conditon is met.
-    
+
     Parameters
     ----------
     x_icell1 : numpy.array
         array of x positions of length N1 (data1)
-    
+
     y_icell1 : numpy.array
         array of y positions of length N1 (data1)
-    
+
     z_icell1 : numpy.array
         array of z positions of length N1 (data1)
-    
+
     x_icell2 : numpy.array
         array of x positions of length N2 (data2)
-    
+
     y_icell2 : numpy.array
         array of y positions of length N2 (data2)
-    
+
     z_icell2 : numpy.array
         array of z positions of length N2 (data2)
-    
+
     max_rp : float
         maximum perpendicular separation to record
-    
+
     max_pi : float
         maximum parallel separation to record
-    
+
     w_icell1 : numpy.array
         array of floats
-    
+
     w_icell2 : numpy.array
         array of floats
-    
+
     cond_func_id : int
         integer ID of conditional function
-    
+
     Returns
     -------
     d_perp : numpy.array
         array of perpendicular pairwise separation distances
-    
+
     d_para : numpy.array
         array of parallel pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices
-    
+
     j : numpy.array
         array of 0-indexed indices
-    
+
     Examples
     --------
-    For demonstration purposes we create a randomly distributed set of points within a 
-    unit cube. 
-    
+    For demonstration purposes we create a randomly distributed set of points within a
+    unit cube.
+
     >>> Npts = 1000
-    
+
     >>> x = np.random.random(Npts)
     >>> y = np.random.random(Npts)
     >>> z = np.random.random(Npts)
     >>> weights = np.random.random(Npts)
-    
+
     Calculate the distance between all pairs with perpednicular separations less than 0.25
     and parallel sperations of 0.5:
-    
+
     >>> max_rp = 0.25
     >>> max_pi = 0.5
     >>> d_perp,d_para,i,j = conditional_pairwise_xy_z_distance_no_pbc(x,y,z,x,y,z,max_rp,max_para,weights,weights,1)
     """
-    
-    
+
+
     #c definitions
     cdef vector[np.int_t] i_ind
     cdef vector[np.int_t] j_ind
@@ -236,26 +236,26 @@ def conditional_pairwise_xy_z_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x
     cdef int i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
-    
+
     #square the distance bins to avoid taking a square root in a tight loop
     max_rp = max_rp**2
     max_pi = max_pi**2
-    
+
     cond_func = return_conditional_function(cond_func_id)
-    
+
     #loop over points in grid1's cells
     n=0
     for i in range(0,Ni):
         #loop over points in grid2's cells
         for j in range(0,Nj):
-            
+
             if cond_func(&w_icell1[i,0],&w_icell2[j,0]):
-            
+
                 #calculate the square distance
                 d_perp = perp_square_distance(x_icell1[i], y_icell1[i],\
                                           x_icell2[j], y_icell2[j])
                 d_para = para_square_distance(z_icell1[i], z_icell2[j])
-                
+
                 #add distance to result
                 if (d_perp<=max_rp) & (d_para<=max_pi):
                     perp_distances.push_back(d_perp)
@@ -263,7 +263,7 @@ def conditional_pairwise_xy_z_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x
                     i_ind.push_back(i)
                     j_ind.push_back(j)
                     n = n+1
-    
+
     return np.sqrt(perp_distances).astype(float), np.sqrt(para_distances).astype(float),\
            np.array(i_ind).astype(int), np.array(j_ind).astype(int)
 
@@ -321,7 +321,7 @@ cdef f_type return_conditional_function(cond_func_id):
     """
     returns a pointer to the user-specified conditional function.
     """
-    
+
     if cond_func_id==1:
         return gt_cond
     if cond_func_id==2:

--- a/halotools/mock_observables/pair_counters/marked_cpairs/marked_npairs_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/marked_npairs_xy_z_engine.pyx
@@ -1,10 +1,10 @@
-"""
+r"""
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil
 
 from .marking_functions cimport *
@@ -18,46 +18,46 @@ ctypedef double (*f_type)(cnp.float64_t* w1, cnp.float64_t* w2)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     weights1in, weights2in, weight_func_idin, rp_bins, pi_bins, cell1_tuple):
-    """ Cython engine for counting pairs of points 
-    as a function of three-dimensional separation. 
+    r""" Cython engine for counting pairs of points
+    as a function of three-dimensional separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
     weight_func_id : int, optional
-        weighting function integer ID. 
+        weighting function integer ID.
 
-    weights1in : array 
+    weights1in : array
 
-    weights2in : array 
+    weights2in : array
 
     rp_bins : array_like
-        numpy array of boundaries defining the bins of separation in the xy-plane 
-        :math:`r_{\\rm p}` in which pairs are counted.
+        numpy array of boundaries defining the bins of separation in the xy-plane
+        :math:`r_{\rm p}` in which pairs are counted.
 
     pi_bins : numpy.array
         array defining parallel separation in which to sum the pair counts
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rp_bins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rp_bins``. 
+    counts : array
+        Integer array of length len(rp_bins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rp_bins``.
 
     """
     cdef int weight_func_id = weight_func_idin
@@ -119,7 +119,7 @@ def marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dxy_sq, dz_sq, weight
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef int Ni, Nj, i, j, k, l, g
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
@@ -151,9 +151,9 @@ def marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -223,7 +223,7 @@ def marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                             if g<0: break
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts)
 
 
@@ -231,7 +231,7 @@ cdef f_type return_weighting_function(weight_func_id):
     """
     returns a pointer to the user-specified weighting function.
     """
-    
+
     if weight_func_id==0:
         return custom_func
     elif weight_func_id==1:

--- a/halotools/mock_observables/pair_counters/marked_npairs_xy_z.py
+++ b/halotools/mock_observables/pair_counters/marked_npairs_xy_z.py
@@ -1,4 +1,4 @@
-""" Module containing the `~halotools.mock_observables.npairs_3d` function
+r""" Module containing the `~halotools.mock_observables.npairs_3d` function
 used to count pairs as a function of separation.
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -23,11 +23,11 @@ def marked_npairs_xy_z(sample1, sample2, rp_bins, pi_bins,
                   period=None, weights1=None, weights2=None,
                   weight_func_id=0, verbose=False, num_threads=1,
                   approx_cell1_size=None, approx_cell2_size=None):
-    """
+    r"""
     Calculate the number of weighted pairs with separations greater than
-    or equal to :math:`r_{\\perp}` and :math:`r_{\\parallel}`, :math:`W(>r_{\\perp},>r_{\\parallel})`.
+    or equal to :math:`r_{\perp}` and :math:`r_{\parallel}`, :math:`W(>r_{\perp},>r_{\parallel})`.
 
-    :math:`r_{\\perp}` and :math:`r_{\\parallel}` are defined wrt the z-direction.
+    :math:`r_{\perp}` and :math:`r_{\parallel}` are defined wrt the z-direction.
 
     The weight given to each pair is determined by the weights for a pair,
     :math:`w_1`, :math:`w_2`, and a user-specified "weighting function", indicated

--- a/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
+++ b/halotools/mock_observables/pair_counters/npairs_jackknife_3d.py
@@ -1,4 +1,4 @@
-""" Module containing the `~halotools.mock_observables.npairs_jackknife_3d` function
+r""" Module containing the `~halotools.mock_observables.npairs_jackknife_3d` function
 used to estimate errors in the `~halotools.mock_observables.tpcf` function.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -23,7 +23,7 @@ __all__ = ('npairs_jackknife_3d', )
 def npairs_jackknife_3d(sample1, sample2, rbins, period=None, weights1=None, weights2=None,
         jtags1=None, jtags2=None, N_samples=0, verbose=False, num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None):
-    """
+    r"""
     Pair counter used to make jackknife error estimates of real-space pair counter
     `~halotools.mock_observables.pair_counters.npairs`.
 
@@ -101,7 +101,7 @@ def npairs_jackknife_3d(sample1, sample2, rbins, period=None, weights1=None, wei
         The sub-array N_pairs[0, :] stores numbers of pairs
         in the input bins for the entire sample.
         The sub-array N_pairs[i, :] stores numbers of pairs
-        in the input bins for the :math:`i^{\\rm th}` jackknife sub-sample.
+        in the input bins for the :math:`i^{\rm th}` jackknife sub-sample.
 
     Notes
     -----

--- a/halotools/mock_observables/pair_counters/npairs_s_mu.py
+++ b/halotools/mock_observables/pair_counters/npairs_s_mu.py
@@ -1,4 +1,4 @@
-""" Module containing the `~halotools.mock_observables.npairs_s_mu` function
+r""" Module containing the `~halotools.mock_observables.npairs_s_mu` function
 used to count pairs as a function of separation.
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -19,11 +19,11 @@ __all__ = ('npairs_s_mu', )
 
 def npairs_s_mu(sample1, sample2, s_bins, mu_bins, period=None,
         verbose=False, num_threads=1, approx_cell1_size=None, approx_cell2_size=None):
-    """
+    r"""
     Function counts the number of pairs of points separated by less than
-    radial separation, *s,* and :math:`\\mu\\equiv\\sin(\\theta_{\\rm los})`,
-    where :math:`\\theta_{\\rm los}` is the line-of-sight angle
-    between points and :math:`s^2 = r_{\\rm parallel}^2 + r_{\\rm perp}^2`.
+    radial separation, *s,* and :math:`\mu\equiv\sin(\theta_{\rm los})`,
+    where :math:`\theta_{\rm los}` is the line-of-sight angle
+    between points and :math:`s^2 = r_{\rm parallel}^2 + r_{\rm perp}^2`.
 
     Note that if sample1 == sample2 that the
     `~halotools.mock_observables.npairs_s_mu` function double-counts pairs.
@@ -55,7 +55,7 @@ def npairs_s_mu(sample1, sample2, s_bins, mu_bins, period=None,
         numpy array of :math:`s` boundaries defining the bins in which pairs are counted.
 
     mu_bins : array_like
-        numpy array of :math:`\\cos(\\theta_{\\rm LOS})` boundaries defining the bins in
+        numpy array of :math:`\cos(\theta_{\rm LOS})` boundaries defining the bins in
         which pairs are counted, and must be between [0,1].
 
         Note that using the sine is not common convention for
@@ -98,11 +98,11 @@ def npairs_s_mu(sample1, sample2, s_bins, mu_bins, period=None,
 
     Notes
     ------
-    The quantity :math:`\\mu` is defined as the :math:`\\sin(\\theta_{\\rm los})`
-    and not the conventional :math:`\\cos(\\theta_{\\rm los})`. This is
+    The quantity :math:`\mu` is defined as the :math:`\sin(\theta_{\rm los})`
+    and not the conventional :math:`\cos(\theta_{\rm los})`. This is
     because the pair counter has been optimized under the assumption that its
-    separation variable (in this case, :math:`\\mu`) *increases*
-    as :math:`\\theta_{\\rm los})` increases.
+    separation variable (in this case, :math:`\mu`) *increases*
+    as :math:`\theta_{\rm los})` increases.
 
     One final point of clarification concerning double-counting may be in order.
     Suppose sample1==sample2 and rbins[0]==0. Then the returned value for this bin

--- a/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.los_pvd_vs_rp` function
 used to calculate the pairwise line-of-sight velocity dispersion
 as a function of projected distance between the pairs.
@@ -23,8 +23,8 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
         velocities2=None, period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
         approx_cell1_size=None, approx_cell2_size=None, seed=None):
-    """
-    Calculate the pairwise line-of-sight (LOS) velocity dispersion (PVD), :math:`\\sigma_{z12}(r_p)`.
+    r"""
+    Calculate the pairwise line-of-sight (LOS) velocity dispersion (PVD), :math:`\sigma_{z12}(r_p)`.
 
     Example calls to this function appear in the documentation below.
 
@@ -76,19 +76,19 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
     -------
     sigma_12 : numpy.array
         *len(rbins)-1* length array containing the dispersion of the pairwise velocity,
-        :math:`\\sigma_{12}(r)`, computed in each of the bins defined by ``rbins``.
+        :math:`\sigma_{12}(r)`, computed in each of the bins defined by ``rbins``.
 
     Notes
     -----
     The pairwise LOS velocity, :math:`v_{z12}(r)`, is defined as:
 
     .. math::
-        v_{z12} = |\\vec{v}_{\\rm 1, pec}\\cdot \\hat{z}-\\vec{v}_{\\rm 2, pec}\\cdot\\hat{z}|
+        v_{z12} = |\vec{v}_{\rm 1, pec}\cdot \hat{z}-\vec{v}_{\rm 2, pec}\cdot\hat{z}|
 
-    where :math:`\\vec{v}_{\\rm 1, pec}` is the peculiar velocity of object 1, and
-    :math:`\\hat{z}` is the unit-z vector.
+    where :math:`\vec{v}_{\rm 1, pec}` is the peculiar velocity of object 1, and
+    :math:`\hat{z}` is the unit-z vector.
 
-    :math:`\\sigma_{z12}(r_p)` is the standard deviation of this quantity in
+    :math:`\sigma_{z12}(r_p)` is the standard deviation of this quantity in
     projected radial bins.
 
     Pairs and radial velocities are calculated using

--- a/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.mean_los_velocity_vs_rp` function
 used to calculate the pairwise mean line-of-sight velocity
 as a function of projected distance between the pairs.
@@ -23,9 +23,9 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
         period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
         approx_cell1_size=None, approx_cell2_size=None, seed=None):
-    """
+    r"""
     Calculate the mean pairwise line-of-sight (LOS) velocity
-    as a function of projected separation, :math:`\\bar{v}_{z,12}(r_p)`.
+    as a function of projected separation, :math:`\bar{v}_{z,12}(r_p)`.
 
     Example calls to this function appear in the documentation below.
 
@@ -91,19 +91,19 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
     -------
     vz_12 : numpy.array
         *len(rbins)-1* length array containing the mean pairwise LOS velocity,
-        :math:`\\bar{v}_{z12}(r)`, computed in each of the bins defined by ``rp_bins``.
+        :math:`\bar{v}_{z12}(r)`, computed in each of the bins defined by ``rp_bins``.
 
     Notes
     -----
     The pairwise LOS velocity, :math:`v_{z12}(r)`, is defined as:
 
     .. math::
-        v_{z12} = |\\vec{v}_{\\rm 1, pec} \\cdot \\hat{z}-\\vec{v}_{\\rm 2, pec}\\cdot\\hat{z}|
+        v_{z12} = |\vec{v}_{\rm 1, pec} \cdot \hat{z}-\vec{v}_{\rm 2, pec}\cdot\hat{z}|
 
-    where :math:`\\vec{v}_{\\rm 1, pec}` is the peculiar velocity of object 1, and
-    :math:`\\hat{z}` is the unit-z vector.
+    where :math:`\vec{v}_{\rm 1, pec}` is the peculiar velocity of object 1, and
+    :math:`\hat{z}` is the unit-z vector.
 
-    :math:`\\bar{v}_{z12}(r_p)` is the mean of this quantity in projected radial bins.
+    :math:`\bar{v}_{z12}(r_p)` is the mean of this quantity in projected radial bins.
 
     Pairs and radial velocities are calculated using
     `~halotools.mock_observables.pair_counters.velocity_marked_npairs_xy_z`.

--- a/halotools/mock_observables/pairwise_velocities/mean_radial_velocity_vs_r.py
+++ b/halotools/mock_observables/pairwise_velocities/mean_radial_velocity_vs_r.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.mean_radial_velocity_vs_r` function
 used to calculate the pairwise mean radial velocity
 as a function of 3d distance between the pairs.
@@ -23,8 +23,8 @@ def mean_radial_velocity_vs_r(sample1, velocities1, rbins,
         period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
         approx_cell1_size=None, approx_cell2_size=None, seed=None):
-    """
-    Calculate the mean pairwise velocity, :math:`\\bar{v}_{12}(r)`.
+    r"""
+    Calculate the mean pairwise velocity, :math:`\bar{v}_{12}(r)`.
 
     Example calls to this function appear in the documentation below.
     See the :ref:`mock_obs_pos_formatting` documentation page for
@@ -92,19 +92,19 @@ def mean_radial_velocity_vs_r(sample1, velocities1, rbins,
     -------
     v_12 : numpy.array
         *len(rbins)-1* length array containing the mean pairwise velocity,
-        :math:`\\bar{v}_{12}(r)`, computed in each of the bins defined by ``rbins``.
+        :math:`\bar{v}_{12}(r)`, computed in each of the bins defined by ``rbins``.
 
     Notes
     -----
     The pairwise velocity, :math:`v_{12}(r)`, is defined as:
 
     .. math::
-        v_{12}(r) = \\vec{v}_{\\rm 1, pec} \\cdot \\vec{r}_{12}-\\vec{v}_{\\rm 2, pec} \\cdot \\vec{r}_{12}
+        v_{12}(r) = \vec{v}_{\rm 1, pec} \cdot \vec{r}_{12}-\vec{v}_{\rm 2, pec} \cdot \vec{r}_{12}
 
-    where :math:`\\vec{v}_{\\rm 1, pec}` is the peculiar velocity of object 1, and
-    :math:`\\vec{r}_{12}` is the radial vector connecting object 1 and 2.
+    where :math:`\vec{v}_{\rm 1, pec}` is the peculiar velocity of object 1, and
+    :math:`\vec{r}_{12}` is the radial vector connecting object 1 and 2.
 
-    :math:`\\bar{v}_{12}(r)` is the mean of that quantity calculated in radial bins.
+    :math:`\bar{v}_{12}(r)` is the mean of that quantity calculated in radial bins.
 
     Pairs and radial velocities are calculated using
     `~halotools.mock_observables.pair_counters.velocity_marked_npairs`.

--- a/halotools/mock_observables/pairwise_velocities/radial_pvd_vs_r.py
+++ b/halotools/mock_observables/pairwise_velocities/radial_pvd_vs_r.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.radial_pvd_vs_r` function
 used to calculate the pairwise radial velocity dispersion
 as a function of 3d distance between the pairs.
@@ -22,8 +22,8 @@ def radial_pvd_vs_r(sample1, velocities1, rbins, sample2=None,
         velocities2=None, period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6),
         approx_cell1_size=None, approx_cell2_size=None, seed=None):
-    """
-    Calculate the pairwise velocity dispersion (PVD), :math:`\\sigma_{12}(r)`.
+    r"""
+    Calculate the pairwise velocity dispersion (PVD), :math:`\sigma_{12}(r)`.
 
     Example calls to this function appear in the documentation below.
 
@@ -74,19 +74,19 @@ def radial_pvd_vs_r(sample1, velocities1, rbins, sample2=None,
     -------
     sigma_12 : numpy.array
         *len(rbins)-1* length array containing the dispersion of the pairwise velocity,
-        :math:`\\sigma_{12}(r)`, computed in each of the bins defined by ``rbins``.
+        :math:`\sigma_{12}(r)`, computed in each of the bins defined by ``rbins``.
 
     Notes
     -----
     The pairwise velocity, :math:`v_{12}(r)`, is defined as:
 
     .. math::
-        v_{12}(r) = \\vec{v}_{\\rm 1, pec} \\cdot \\vec{r}_{12}-\\vec{v}_{\\rm 2, pec} \\cdot \\vec{r}_{12}
+        v_{12}(r) = \vec{v}_{\rm 1, pec} \cdot \vec{r}_{12}-\vec{v}_{\rm 2, pec} \cdot \vec{r}_{12}
 
-    where :math:`\\vec{v}_{\\rm 1, pec}` is the peculiar velocity of object 1, and
-    :math:`\\vec{r}_{12}` is the radial vector connecting object 1 and 2.
+    where :math:`\vec{v}_{\rm 1, pec}` is the peculiar velocity of object 1, and
+    :math:`\vec{r}_{12}` is the radial vector connecting object 1 and 2.
 
-    :math:`\\sigma_{12}(r)` is the standard deviation of this quantity in radial bins.
+    :math:`\sigma_{12}(r)` is the standard deviation of this quantity in radial bins.
 
     Pairs and radial velocities are calculated using
     `~halotools.mock_observables.pair_counters.velocity_marked_npairs`.

--- a/halotools/mock_observables/pairwise_velocities/velocity_marked_npairs_xy_z.py
+++ b/halotools/mock_observables/pairwise_velocities/velocity_marked_npairs_xy_z.py
@@ -10,8 +10,6 @@ from .velocity_marked_npairs_3d import (
     _func_signature_int_from_vel_weight_func_id, _velocity_marked_npairs_3d_process_weights)
 from .engines import velocity_marked_npairs_xy_z_engine
 
-from ...custom_exceptions import HalotoolsError
-
 __author__ = ('Duncan Campbell', 'Andrew Hearin')
 
 
@@ -22,12 +20,12 @@ def velocity_marked_npairs_xy_z(sample1, sample2, rp_bins, pi_bins, period=None,
         weights1=None, weights2=None,
         weight_func_id=0, verbose=False, num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None):
-    """
+    r"""
     Calculate the number of velocity weighted pairs
     with separations greater than or equal to
-    :math:`r_{\\perp}` and :math:`r_{\\parallel}`, :math:`W(>r_{\\perp},>r_{\\parallel})`.
+    :math:`r_{\perp}` and :math:`r_{\parallel}`, :math:`W(>r_{\perp},>r_{\parallel})`.
 
-    :math:`r_{\\perp}` and :math:`r_{\\parallel}` are defined wrt the z-direction.
+    :math:`r_{\perp}` and :math:`r_{\parallel}` are defined wrt the z-direction.
 
     The weight given to each pair is determined by the weights for a pair,
     :math:`w_1`, :math:`w_2`, and a user-specified "velocity weighting function", indicated

--- a/halotools/mock_observables/radial_profiles/radial_profile_3d.py
+++ b/halotools/mock_observables/radial_profiles/radial_profile_3d.py
@@ -1,4 +1,4 @@
-""" Module containing the `~halotools.mock_observables.radial_profile_3d` function
+r""" Module containing the `~halotools.mock_observables.radial_profile_3d` function
 used to calculate radial profiles as a function of 3d separation.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -26,7 +26,7 @@ def radial_profile_3d(sample1, sample2, sample2_quantity,
         rbins_absolute=None, rbins_normalized=None, normalize_rbins_by=None,
         return_counts=False, period=None, num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None):
-    """ Function used to calculate the mean value of some quantity in ``sample2``
+    r""" Function used to calculate the mean value of some quantity in ``sample2``
     as a function of 3d distance from the points in ``sample1``.
 
     As illustrated in the Examples section below,
@@ -35,7 +35,7 @@ def radial_profile_3d(sample1, sample2, sample2_quantity,
     optionally normalize the 3d distances according to
     some scaling factor defined by the points in ``sample1``. The documentation below
     shows how to calculate the mean mass accretion rate of ``sample2`` as a function
-    of :math:`r / R_{\\rm vir}`, the Rvir-normalized halo-centric distance from points in ``sample1``.
+    of :math:`r / R_{\rm vir}`, the Rvir-normalized halo-centric distance from points in ``sample1``.
 
     Note that this function can also be used to calculate number density profiles
     of ``sample2`` points as a function of halo-centric distance
@@ -68,10 +68,10 @@ def radial_profile_3d(sample1, sample2, sample2_quantity,
 
     rbins_normalized : array_like, optional
         Array of length *Nrbins+1* defining the bin boundaries *x*, where
-        :math:`x = r / R_{\\rm vir}`, in which mean quantities and number counts are computed.
-        The quantity :math:`R_{\\rm vir}` can vary from point to point in ``sample1``
+        :math:`x = r / R_{\rm vir}`, in which mean quantities and number counts are computed.
+        The quantity :math:`R_{\rm vir}` can vary from point to point in ``sample1``
         and is passed in via the ``normalize_rbins_by`` argument.
-        While scaling by :math:`R_{\\rm vir}` is common, you are not limited to this
+        While scaling by :math:`R_{\rm vir}` is common, you are not limited to this
         normalization choice; in principle you can use the ``rbins_normalized`` and
         ``normalize_rbins_by`` arguments to scale your distances by any length-scale
         associated with points in ``sample1``.
@@ -82,7 +82,7 @@ def radial_profile_3d(sample1, sample2, sample2_quantity,
         will be normalized. For example, if ``normalize_rbins_by`` is defined to be the
         virial radius of each point in ``sample1``, then the input numerical values *x*
         stored in ``rbins_normalized`` will be interpreted as referring to
-        bins of :math:`x = r / R_{\\rm vir}`. Default is None, in which case
+        bins of :math:`x = r / R_{\rm vir}`. Default is None, in which case
         the input ``rbins_absolute`` argument must be passed instead of
         ``rbins_normalized``.
 
@@ -169,10 +169,10 @@ def radial_profile_3d(sample1, sample2, sample2_quantity,
     >>> result1, counts = radial_profile_3d(sample1, sample2, dmdt_sample2, rbins_absolute=rbins_absolute, period=halocat.Lbox, return_counts=True)
 
     Now suppose that you wish to calculate the same quantity,
-    but instead as a function of :math:`x = r / R_{\\rm vir}`.
+    but instead as a function of :math:`x = r / R_{\rm vir}`.
     In this case, we use the ``rbins_normalized`` and ``normalize_rbins_by`` arguments.
     The following choices for these arguments will give us 15 separation bins linearly spaced in *x*
-    between :math:`\\frac{1}{2}R_{\\rm vir}` and :math:`10R_{\\rm vir}`.
+    between :math:`\frac{1}{2}R_{\rm vir}` and :math:`10R_{\rm vir}`.
 
     >>> rvir = halo_sample1['halo_rvir']
     >>> rbins_normalized = np.linspace(0.5, 10, 15)

--- a/halotools/mock_observables/surface_density/surface_density_helpers.py
+++ b/halotools/mock_observables/surface_density/surface_density_helpers.py
@@ -12,7 +12,7 @@ __author__ = ('Andrew Hearin', 'Shun Saito')
 
 
 def annular_area_weighted_midpoints(rp_bins):
-    """ Calculate the radius that bisects the areas a set of circles.
+    r""" Calculate the radius that bisects the areas a set of circles.
 
     Parameters
     ----------
@@ -33,7 +33,7 @@ def annular_area_weighted_midpoints(rp_bins):
 
 
 def log_interpolation_with_inner_zero_masking(onep_sig_in, rp_bins, rp_mids):
-    """ Given an array ``onep_sig_in`` whose values are tabulated at
+    r""" Given an array ``onep_sig_in`` whose values are tabulated at
     ``rp_bins``, interolate in log-space to evaluate the array values at
     ``rp_mids``, taking care to mask over any zeros in ``onep_sig_in``.
 
@@ -64,7 +64,7 @@ def log_interpolation_with_inner_zero_masking(onep_sig_in, rp_bins, rp_mids):
 
 
 def rho_matter_comoving_in_halotools_units(cosmology):
-    """ Calculate the comoving matter density in units of
+    r""" Calculate the comoving matter density in units of
     :math:`M_{\odot}/{\rm Mpc}^3` assuming :math:`h = 1`.
 
     Parameters

--- a/halotools/mock_observables/two_point_clustering/angular_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/angular_tpcf.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.angular_tpcf` function used to
 calculate galaxy clustering as a function of angular separation.
 """
@@ -29,8 +29,8 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
         max_sample_size=int(1e6), seed=None):
-    """
-    Calculate the angular two-point correlation function, :math:`w(\\theta)`.
+    r"""
+    Calculate the angular two-point correlation function, :math:`w(\theta)`.
 
     Example calls to this function appear in the documentation below.
     See the :ref:`mock_obs_pos_formatting` documentation page for
@@ -91,15 +91,15 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
     -------
     correlation_function(s) : numpy.array
         *len(theta_bins)-1* length array containing the correlation function
-        :math:`w(\\theta)` computed in each of the bins defined by input ``theta_bins``.
+        :math:`w(\theta)` computed in each of the bins defined by input ``theta_bins``.
 
         .. math::
-            1 + w(\\theta) \\equiv \\mathrm{DD}(\\theta) / \\mathrm{RR}(\\theta),
+            1 + w(\theta) \equiv \mathrm{DD}(\theta) / \mathrm{RR}(\theta),
 
-        If ``estimator`` is set to 'Natural'.  :math:`\\mathrm{DD}(\\theta)` is the number
-        of sample pairs with separations equal to :math:`\\theta`, calculated by the pair
-        counter.  :math:`\\mathrm{RR}(\\theta)` is the number of random pairs with
-        separations equal to :math:`\\theta`, and is counted internally using
+        If ``estimator`` is set to 'Natural'.  :math:`\mathrm{DD}(\theta)` is the number
+        of sample pairs with separations equal to :math:`\theta`, calculated by the pair
+        counter.  :math:`\mathrm{RR}(\theta)` is the number of random pairs with
+        separations equal to :math:`\theta`, and is counted internally using
         "analytic randoms" if ``randoms`` is set to None (see notes for an explanation),
         otherwise it is calculated using the pair counter.
 
@@ -108,7 +108,7 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
         then three arrays of length *len(rbins)-1* are returned:
 
         .. math::
-            w_{11}(\\theta), w_{12}(\\theta), w_{22}(\\theta),
+            w_{11}(\theta), w_{12}(\theta), w_{22}(\theta),
 
         the autocorrelation of ``sample1``, the cross-correlation between ``sample1`` and
         ``sample2``, and the autocorrelation of ``sample2``, respectively.

--- a/halotools/mock_observables/two_point_clustering/marked_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/marked_tpcf.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.marked_tpcf` function used to
 calculate the marked two-point correlation function.
 """
@@ -30,8 +30,8 @@ def marked_tpcf(sample1, rbins, sample2=None,
         marks1=None, marks2=None, period=None, do_auto=True, do_cross=True,
         num_threads=1, max_sample_size=int(1e6), weight_func_id=1,
         normalize_by='random_marks', iterations=1, randomize_marks=None, seed=None):
-    """
-    Calculate the real space marked two-point correlation function, :math:`\\mathcal{M}(r)`.
+    r"""
+    Calculate the real space marked two-point correlation function, :math:`\mathcal{M}(r)`.
 
     Example calls to this function appear in the documentation below.
     See the :ref:`mock_obs_pos_formatting` documentation page for
@@ -126,24 +126,24 @@ def marked_tpcf(sample1, rbins, sample2=None,
     -------
     marked_correlation_function(s) : numpy.array
         *len(rbins)-1* length array containing the marked correlation function
-        :math:`\\mathcal{M}(r)` computed in each of the bins defined by ``rbins``.
+        :math:`\mathcal{M}(r)` computed in each of the bins defined by ``rbins``.
 
         .. math::
-            \\mathcal{M}(r) \\equiv \\mathrm{WW}(r) / \\mathrm{XX}(r),
+            \mathcal{M}(r) \equiv \mathrm{WW}(r) / \mathrm{XX}(r),
 
-        where :math:`\\mathrm{WW}(r)` is the weighted number of pairs with separations
-        equal to :math:`r`, and :math:`\\mathrm{XX}(r)` is dependent on the choice of the
+        where :math:`\mathrm{WW}(r)` is the weighted number of pairs with separations
+        equal to :math:`r`, and :math:`\mathrm{XX}(r)` is dependent on the choice of the
         ``normalize_by`` parameter.  If ``normalize_by`` is 'random_marks'
-        :math:`XX \\equiv \\mathcal{RR}`, the weighted pair counts where the marks have
+        :math:`XX \equiv \mathcal{RR}`, the weighted pair counts where the marks have
         been randomized marks.  If ``normalize_by`` is 'number_counts'
-        :math:`XX \\equiv DD`, the unweighted pair counts.
+        :math:`XX \equiv DD`, the unweighted pair counts.
         See Notes for more detail.
 
         If ``sample2`` is passed as input, three arrays of length *len(rbins)-1* are
         returned:
 
         .. math::
-            \\mathcal{M}_{11}(r), \\ \\mathcal{M}_{12}(r), \\ \\mathcal{M}_{22}(r),
+            \mathcal{M}_{11}(r), \ \mathcal{M}_{12}(r), \ \mathcal{M}_{22}(r),
 
         the autocorrelation of ``sample1``, the cross-correlation between ``sample1`` and
         ``sample2``, and the autocorrelation of ``sample2``.  If ``do_auto`` or
@@ -157,13 +157,13 @@ def marked_tpcf(sample1, rbins, sample2=None,
     If the ``period`` argument is passed in, the ith coordinate of all points
     must be between 0 and period[i].
 
-    ``normalize_by`` indicates how to calculate :math:`\\mathrm{XX}`.  If ``normalize_by``
-    is 'random_marks', then :math:`\\mathrm{XX} \\equiv \\mathcal{RR}`, and
-    :math:`\\mathcal{RR}` is calculated by randomizing the marks among points according
+    ``normalize_by`` indicates how to calculate :math:`\mathrm{XX}`.  If ``normalize_by``
+    is 'random_marks', then :math:`\mathrm{XX} \equiv \mathcal{RR}`, and
+    :math:`\mathcal{RR}` is calculated by randomizing the marks among points according
     to the ``randomize_marks`` mask.  This marked correlation function is then:
 
     .. math::
-        \\mathcal{M}(r) \\equiv \\frac{\\sum_{ij}f(m_i,m_j)}{\\sum_{kl}f(m_k,m_l)}
+        \mathcal{M}(r) \equiv \frac{\sum_{ij}f(m_i,m_j)}{\sum_{kl}f(m_k,m_l)}
 
     where the sum in the numerator is of pairs :math:`i,j` with separation :math:`r`,
     and marks :math:`m_i,m_j`.  :math:`f()` is the marking function, ``weight_func_id``.  The sum
@@ -172,13 +172,13 @@ def marked_tpcf(sample1, rbins, sample2=None,
     parameter. The mean of the sum is then taken amongst iterations and used in the
     calculation.
 
-    If ``normalize_by`` is 'number_counts', then :math:`\\mathrm{XX} \\equiv \\mathrm{DD}`
+    If ``normalize_by`` is 'number_counts', then :math:`\mathrm{XX} \equiv \mathrm{DD}`
     is calculated by counting total number of pairs using
     `~halotools.mock_observables.pair_counters.npairs_3d`.
     This is:
 
     .. math::
-        \\mathcal{M}(r) \\equiv \\frac{\\sum_{ij}f(m_i,m_j)}{\\sum_{ij} 1},
+        \mathcal{M}(r) \equiv \frac{\sum_{ij}f(m_i,m_j)}{\sum_{ij} 1},
 
     There are multiple marking functions available.  In general, each requires a different
     number of marks per point, N_marks.  The marking function gets passed two vectors
@@ -187,7 +187,7 @@ def marked_tpcf(sample1, rbins, sample2=None,
 
     #. multiplicaitive weights (N_marks = 1)
         .. math::
-            f(w_1,w_2) = w_1[0] \\times w_2[0]
+            f(w_1,w_2) = w_1[0] \times w_2[0]
 
     #. summed weights (N_marks = 1)
         .. math::
@@ -196,82 +196,82 @@ def marked_tpcf(sample1, rbins, sample2=None,
     #. equality weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_1[1]\\times w_2[1] & : w_1[0] = w_2[0] \\\\
-                    0.0 & : w_1[0] \\neq w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_1[1]\times w_2[1] & : w_1[0] = w_2[0] \\
+                    0.0 & : w_1[0] \neq w_2[0] \\
+                \end{array}
+                \right.
 
     #. inequality weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_1[1]\\times w_2[1] & : w_1[0] \\neq w_2[0] \\\\
-                    0.0 & : w_1[0] = w_2[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_1[1]\times w_2[1] & : w_1[0] \neq w_2[0] \\
+                    0.0 & : w_1[0] = w_2[0] \\
+                \end{array}
+                \right.
 
     #. greater than weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_1[1]\\times w_2[1] & : w_2[0] > w_1[0] \\\\
-                    0.0 & : w_2[0] \\leq w_1[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_1[1]\times w_2[1] & : w_2[0] > w_1[0] \\
+                    0.0 & : w_2[0] \leq w_1[0] \\
+                \end{array}
+                \right.
 
     #. less than weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_1[1]\\times w_2[1] & : w_2[0] < w_1[0] \\\\
-                    0.0 & : w_2[0] \\geq w_1[0] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_1[1]\times w_2[1] & : w_2[0] < w_1[0] \\
+                    0.0 & : w_2[0] \geq w_1[0] \\
+                \end{array}
+                \right.
 
     #. greater than tolerance weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_2[1] & : w_2[0]>(w_1[0]+w_1[1]) \\\\
-                    0.0 & : w_2[0] \\leq (w_1[0]+w_1[1]) \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_2[1] & : w_2[0]>(w_1[0]+w_1[1]) \\
+                    0.0 & : w_2[0] \leq (w_1[0]+w_1[1]) \\
+                \end{array}
+                \right.
 
     #. less than tolerance weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_2[1] & : w_2[0]<(w_1[0]+w_1[1]) \\\\
-                    0.0 & : w_2[0] \\geq (w_1[0]+w_1[1]) \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_2[1] & : w_2[0]<(w_1[0]+w_1[1]) \\
+                    0.0 & : w_2[0] \geq (w_1[0]+w_1[1]) \\
+                \end{array}
+                \right.
 
     #. tolerance weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_2[1] & : |w_1[0]-w_2[0]|<w_1[1] \\\\
-                    0.0 & : |w_1[0]-w_2[0]| \\geq w_1[1] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_2[1] & : |w_1[0]-w_2[0]|<w_1[1] \\
+                    0.0 & : |w_1[0]-w_2[0]| \geq w_1[1] \\
+                \end{array}
+                \right.
 
     #. exclusion weights (N_marks = 2)
         .. math::
             f(w_1,w_2) =
-                \\left \\{
-                \\begin{array}{ll}
-                    w_2[1] & : |w_1[0]-w_2[0]|>w_1[1] \\\\
-                    0.0 & : |w_1[0]-w_2[0]| \\leq w_1[1] \\\\
-                \\end{array}
-                \\right.
+                \left \{
+                \begin{array}{ll}
+                    w_2[1] & : |w_1[0]-w_2[0]|>w_1[1] \\
+                    0.0 & : |w_1[0]-w_2[0]| \leq w_1[1] \\
+                \end{array}
+                \right.
 
     Examples
     --------
@@ -301,7 +301,7 @@ def marked_tpcf(sample1, rbins, sample2=None,
     >>> rbins = np.logspace(-2,-1,10)
     >>> MCF = marked_tpcf(coords, rbins, marks1=marks, period=period, normalize_by='number_counts', weight_func_id=1)
 
-    The result should be consistent with :math:`\\langle {\\rm mark}\\rangle^2` at all *r*
+    The result should be consistent with :math:`\langle {\rm mark}\rangle^2` at all *r*
     within the statistical errors.
     """
 

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
@@ -1,6 +1,6 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.rp_pi_tpcf` function used to
-calculate the redshift-space two-point correlation function in 3d, :math:`\\xi(r_{p}, \\pi)`
+calculate the redshift-space two-point correlation function in 3d, :math:`\xi(r_{p}, \pi)`
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -29,8 +29,8 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         period=None, do_auto=True, do_cross=True, estimator='Natural',
         num_threads=1, max_sample_size=int(1e6), approx_cell1_size=None,
         approx_cell2_size=None, approx_cellran_size=None, seed=None):
-    """
-    Calculate the redshift space correlation function, :math:`\\xi(r_{p}, \\pi)`
+    r"""
+    Calculate the redshift space correlation function, :math:`\xi(r_{p}, \pi)`
 
     Calculate the correlation function as a function of pair separation perpendicular to
     the line-of-sight (LOS) and parallel to the LOS.
@@ -139,14 +139,14 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
     -------
     correlation_function(s) : numpy.ndarray
         *len(rp_bins)-1* by *len(pi_bins)-1* ndarray containing the correlation function
-        :math:`\\xi(r_p, \\pi)` computed in each of the bins defined by input ``rp_bins``
+        :math:`\xi(r_p, \pi)` computed in each of the bins defined by input ``rp_bins``
         and ``pi_bins``.
 
         .. math::
-            1 + \\xi(r_{p},\\pi) = \\mathrm{DD}r_{p},\\pi) / \\mathrm{RR}r_{p},\\pi)
+            1 + \xi(r_{p},\pi) = \mathrm{DD}r_{p},\pi) / \mathrm{RR}r_{p},\pi)
 
-        if ``estimator`` is set to 'Natural', where  :math:`\\mathrm{DD}(r_{p},\\pi)`
-        is calculated by the pair counter, and :math:`\\mathrm{RR}(r_{p},\\pi)` is counted
+        if ``estimator`` is set to 'Natural', where  :math:`\mathrm{DD}(r_{p},\pi)`
+        is calculated by the pair counter, and :math:`\mathrm{RR}(r_{p},\pi)` is counted
         internally using "analytic randoms" if ``randoms`` is set to None
         (see notes for further details).
 
@@ -154,7 +154,7 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         three arrays of shape *len(rp_bins)-1* by *len(pi_bins)-1* are returned:
 
         .. math::
-            \\xi_{11}(r_{p},\\pi), \\xi_{12}(r_{p},\\pi), \\xi_{22}(r_{p},\\pi),
+            \xi_{11}(r_{p},\pi), \xi_{12}(r_{p},\pi), \xi_{22}(r_{p},\pi),
 
         the autocorrelation of ``sample1``, the cross-correlation between ``sample1`` and
         ``sample2``, and the autocorrelation of ``sample2``, respectively. If
@@ -279,7 +279,7 @@ def cylinder_volume(R, h):
 def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
         PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
         approx_cell1_size, approx_cell2_size, approx_cellran_size):
-    """
+    r"""
     Count random pairs.  There are two high level branches:
         1. w/ or wo/ PBCs and randoms.
         2. PBCs and analytical randoms

--- a/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
@@ -1,6 +1,6 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.s_mu_tpcf` function used to
-calculate the redshift-space two-point correlation function , :math:`\\xi(s, \\mu)`.
+calculate the redshift-space two-point correlation function , :math:`\xi(s, \mu)`.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
@@ -26,8 +26,8 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         period=None, do_auto=True, do_cross=True, estimator='Natural',
         num_threads=1, max_sample_size=int(1e6), approx_cell1_size=None,
         approx_cell2_size=None, approx_cellran_size=None, seed=None):
-    """
-    Calculate the redshift space correlation function, :math:`\\xi(s, \\mu)`
+    r"""
+    Calculate the redshift space correlation function, :math:`\xi(s, \mu)`
 
     Divide redshift space into bins of radial separation and angle to to the line-of-sight
     (LOS).  This is a pre-step for calculating correlation function multipoles.
@@ -56,7 +56,7 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         numpy array of :math:`s` boundaries defining the bins in which pairs are counted.
 
     mu_bins : array_like
-        numpy array of :math:`mu = \\cos(\\theta_{\\rm LOS})` boundaries defining the bins in
+        numpy array of :math:`mu = \cos(\theta_{\rm LOS})` boundaries defining the bins in
         which pairs are counted, and must be between [0,1].
 
     sample2 : array_like, optional
@@ -132,14 +132,14 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
     -------
     correlation_function(s) : np.ndarray
         *len(s_bins)-1* by *len(mu_bins)-1* ndarray containing the correlation function
-        :math:`\\xi(s, \\mu)` computed in each of the bins defined by input ``s_bins``
+        :math:`\xi(s, \mu)` computed in each of the bins defined by input ``s_bins``
         and ``mu_bins``.
 
         .. math::
-            1 + \\xi(s,\\mu) = \\mathrm{DD}(s,\\mu) / \\mathrm{RR}(s,\\mu)
+            1 + \xi(s,\mu) = \mathrm{DD}(s,\mu) / \mathrm{RR}(s,\mu)
 
-        if ``estimator`` is set to 'Natural', where  :math:`\\mathrm{DD}(s,\\mu)` is
-        calculated by the pair counter, and :math:`\\mathrm{RR}(s,\\mu)` is counted
+        if ``estimator`` is set to 'Natural', where  :math:`\mathrm{DD}(s,\mu)` is
+        calculated by the pair counter, and :math:`\mathrm{RR}(s,\mu)` is counted
         internally using "analytic randoms" if ``randoms`` is set to None
         (see notes for further details).
 
@@ -148,7 +148,7 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         three arrays of shape *len(s_bins)-1* by *len(mu_bins)-1* are returned:
 
         .. math::
-            \\xi_{11}(s,\\mu), \\xi_{12}(s,\\mu), \\xi_{22}(s,\\mu),
+            \xi_{11}(s,\mu), \xi_{12}(s,\mu), \xi_{22}(s,\mu),
 
         the autocorrelation of ``sample1``, the cross-correlation between ``sample1`` and
         ``sample2``, and the autocorrelation of ``sample2``, respectively. If
@@ -157,19 +157,19 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
 
     Notes
     -----
-    Let :math:`\\vec{s}` be the radial vector connnecting two points.
+    Let :math:`\vec{s}` be the radial vector connnecting two points.
     The magnitude, :math:`s`, is:
 
     .. math::
-        s = \\sqrt{r_{\\parallel}^2+r_{\\perp}^2},
+        s = \sqrt{r_{\parallel}^2+r_{\perp}^2},
 
-    where :math:`r_{\\parallel}` is the separation parallel to the LOS
-    and :math:`r_{\\perp}` is the separation perpednicular to the LOS.  :math:`\\mu` is
-    the cosine of the angle, :math:`\\theta_{\\rm LOS}`, between the LOS
-    and :math:`\\vec{s}`:
+    where :math:`r_{\parallel}` is the separation parallel to the LOS
+    and :math:`r_{\perp}` is the separation perpednicular to the LOS.  :math:`\mu` is
+    the cosine of the angle, :math:`\theta_{\rm LOS}`, between the LOS
+    and :math:`\vec{s}`:
 
     .. math::
-        \\mu = \\cos(\\theta_{\\rm LOS}) \\equiv r_{\\parallel}/s.
+        \mu = \cos(\theta_{\rm LOS}) \equiv r_{\parallel}/s.
 
     Pairs are counted using
     `~halotools.mock_observables.pair_counters.npairs_s_mu`.
@@ -233,7 +233,7 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         period, PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
         approx_cell1_size, approx_cell2_size, approx_cellran_size)
 
-    # return results.  remember to reverse the final result because we used 
+    # return results.  remember to reverse the final result because we used
     # mu_prime = sin(theta_los) bins instead of the user passed in mu = cos(theta_los).
     if _sample1_is_sample2:
         xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)[:, ::-1]
@@ -270,7 +270,7 @@ def spherical_sector_volume(s, mu_prime):
 def random_counts(sample1, sample2, randoms, s_bins, mu_prime_bins,
         period, PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
         approx_cell1_size, approx_cell2_size, approx_cellran_size):
-    """
+    r"""
     Count random pairs.  There are two high level branches:
         1. w/ or wo/ PBCs and randoms.
         2. PBCs and analytical randoms

--- a/halotools/mock_observables/two_point_clustering/tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.tpcf` function used to
 calculate the two-point correlation function in 3d (aka galaxy clustering).
 """
@@ -31,7 +31,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def _random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
         do_RR, do_DR, _sample1_is_sample2, approx_cell1_size,
         approx_cell2_size, approx_cellran_size):
-    """
+    r"""
     Internal function used to random pairs during the calculation of the tpcf.
     There are two high level branches:
         1. w/ or wo/ PBCs and randoms.
@@ -113,7 +113,7 @@ def _random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
 def _pair_counts(sample1, sample2, rbins,
         period, num_threads, do_auto, do_cross,
         _sample1_is_sample2, approx_cell1_size, approx_cell2_size):
-    """
+    r"""
     Internal function used calculate DD-pairs during the calculation of the tpcf.
     """
     if do_auto is True:
@@ -155,8 +155,8 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
         max_sample_size=int(1e6), approx_cell1_size=None,
         approx_cell2_size=None, approx_cellran_size=None,
         RR_precomputed=None, NR_precomputed=None, seed=None):
-    """
-    Calculate the real space two-point correlation function, :math:`\\xi(r)`.
+    r"""
+    Calculate the real space two-point correlation function, :math:`\xi(r)`.
 
     Example calls to this function appear in the documentation below.
     See the :ref:`mock_obs_pos_formatting` documentation page for
@@ -266,15 +266,15 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
     Returns
     -------
     correlation_function(s) : numpy.array
-        *len(rbins)-1* length array containing the correlation function :math:`\\xi(r)`
+        *len(rbins)-1* length array containing the correlation function :math:`\xi(r)`
         computed in each of the bins defined by input ``rbins``.
 
         .. math::
-            1 + \\xi(r) \\equiv \\mathrm{DD}(r) / \\mathrm{RR}(r),
+            1 + \xi(r) \equiv \mathrm{DD}(r) / \mathrm{RR}(r),
 
-        If ``estimator`` is set to 'Natural'.  :math:`\\mathrm{DD}(r)` is the number
+        If ``estimator`` is set to 'Natural'.  :math:`\mathrm{DD}(r)` is the number
         of sample pairs with separations equal to :math:`r`, calculated by the pair
-        counter.  :math:`\\mathrm{RR}(r)` is the number of random pairs with separations
+        counter.  :math:`\mathrm{RR}(r)` is the number of random pairs with separations
         equal to :math:`r`, and is counted internally using "analytic randoms" if
         ``randoms`` is set to None (see notes for an explanation), otherwise it is
         calculated using the pair counter.
@@ -284,7 +284,7 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
         then three arrays of length *len(rbins)-1* are returned:
 
         .. math::
-            \\xi_{11}(r), \\xi_{12}(r), \\xi_{22}(r),
+            \xi_{11}(r), \xi_{12}(r), \xi_{22}(r),
 
         the autocorrelation of ``sample1``, the cross-correlation between ``sample1`` and
         ``sample2``, and the autocorrelation of ``sample2``, respectively.

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.tpcf_jackknife` function used to
 calculate the two point correlation function and covariance matrix.
 """
@@ -29,8 +29,8 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
         sample2=None, period=None, do_auto=True, do_cross=True,
         estimator='Natural', num_threads=1, max_sample_size=int(1e6), seed=None):
-    """
-    Calculate the two-point correlation function, :math:`\\xi(r)` and the covariance
+    r"""
+    Calculate the two-point correlation function, :math:`\xi(r)` and the covariance
     matrix, :math:`{C}_{ij}`, between ith and jth radial bin.
 
     The covariance matrix is calculated using spatial jackknife sampling of the data
@@ -130,14 +130,14 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
     Returns
     -------
     correlation_function(s) : numpy.array
-        *len(rbins)-1* length array containing correlation function :math:`\\xi(r)`
+        *len(rbins)-1* length array containing correlation function :math:`\xi(r)`
         computed in each of the radial bins defined by input ``rbins``.
 
         If ``sample2`` is passed as input, three arrays of length *len(rbins)-1* are
         returned:
 
         .. math::
-            \\xi_{11}(r), \\xi_{12}(r), \\xi_{22}(r)
+            \xi_{11}(r), \xi_{12}(r), \xi_{22}(r)
 
         The autocorrelation of ``sample1``, the cross-correlation between
         ``sample1`` and ``sample2``, and the autocorrelation of ``sample2``. If
@@ -156,7 +156,7 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
             C^{11}_{ij}, C^{12}_{ij}, C^{22}_{ij},
 
         the associated covariance matrices of
-        :math:`\\xi_{11}(r), \\xi_{12}(r), \\xi_{22}(r)`. If ``do_auto`` or ``do_cross``
+        :math:`\xi_{11}(r), \xi_{12}(r), \xi_{22}(r)`. If ``do_auto`` or ``do_cross``
         is set to False, the appropriate result(s) is not returned.
 
     Notes
@@ -168,14 +168,14 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
     pair in subvolumes :math:`i` and :math:`j`:
 
     .. math::
-        D_i D_j += \\left \\{
-            \\begin{array}{ll}
-                1.0  & : i \\neq k, j \\neq k \\\\
-                0.5  & : i \\neq k, j=k \\\\
-                0.5  & : i = k, j \\neq k \\\\
-                0.0  & : i=j=k \\\\
-            \\end{array}
-                   \\right.
+        D_i D_j += \left \{
+            \begin{array}{ll}
+                1.0  & : i \neq k, j \neq k \\
+                0.5  & : i \neq k, j=k \\
+                0.5  & : i = k, j \neq k \\
+                0.0  & : i=j=k \\
+            \end{array}
+                   \right.
 
     Examples
     --------

--- a/halotools/mock_observables/two_point_clustering/tpcf_multipole.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_multipole.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.tpcf_multipole` function used to
 calculate the multipoles of the redshift-space two-point correlation function,
 aka the RSD multipoles.
@@ -16,7 +16,7 @@ __author__ = ['Duncan Campbell']
 
 
 def tpcf_multipole(s_mu_tcpf_result, mu_bins, order=0):
-    """
+    r"""
     Calculate the multipoles of the two point correlation function
     after first computing `~halotools.mock_observables.s_mu_tpcf`.
 
@@ -24,10 +24,10 @@ def tpcf_multipole(s_mu_tcpf_result, mu_bins, order=0):
     ----------
     s_mu_tcpf_result : np.ndarray
         2-D array with the two point correlation function calculated in bins
-        of :math:`s` and :math:`\\mu`.  See `~halotools.mock_observables.s_mu_tpcf`.
+        of :math:`s` and :math:`\mu`.  See `~halotools.mock_observables.s_mu_tpcf`.
 
     mu_bins : array_like
-        array of :math:`\\mu = \\cos(\\theta_{\\rm LOS})`
+        array of :math:`\mu = \cos(\theta_{\rm LOS})`
         bins for which ``s_mu_tcpf_result`` has been calculated.
         Must be between [0,1].
 

--- a/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.tpcf` function used to
 calculate the 1-halo, 2-halo decomposition of the
 two-point correlation function in 3d.
@@ -37,9 +37,9 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
         num_threads=1, max_sample_size=int(1e6),
         approx_cell1_size=None, approx_cell2_size=None,
         approx_cellran_size=None, seed=None):
-    """
+    r"""
     Calculate the real space one-halo and two-halo decomposed two-point correlation
-    functions, :math:`\\xi^{1h}(r)` and :math:`\\xi^{2h}(r)`.
+    functions, :math:`\xi^{1h}(r)` and :math:`\xi^{2h}(r)`.
 
     This returns the correlation function for galaxies which reside in the same halo, and
     those that reside in separate halos, as indicated by a host halo ID.
@@ -144,14 +144,14 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
     -------
     correlation_function(s) : numpy.array
         Two *len(rbins)-1* length arrays containing the one and two halo correlation
-        functions, :math:`\\xi^{1h}(r)` and :math:`\\xi^{2h}(r)`, computed in each of the
+        functions, :math:`\xi^{1h}(r)` and :math:`\xi^{2h}(r)`, computed in each of the
         radial bins defined by input ``rbins``.
 
         .. math::
-            1 + \\xi(r) \\equiv \\mathrm{DD} / \\mathrm{RR},
+            1 + \xi(r) \equiv \mathrm{DD} / \mathrm{RR},
 
-        if ``estimator`` is set to 'Natural', where  :math:`\\mathrm{DD}` is calculated
-        by the pair counter, and :math:`\\mathrm{RR}` is counted internally using
+        if ``estimator`` is set to 'Natural', where  :math:`\mathrm{DD}` is calculated
+        by the pair counter, and :math:`\mathrm{RR}` is counted internally using
         "analytic randoms" if no ``randoms`` are passed as an argument
         (see notes for an explanation).  If a different ``estimator`` is specified, the
         appropiate formula is used.
@@ -161,11 +161,11 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
         returned:
 
         .. math::
-            \\xi^{1h}_{11}(r), \\ \\xi^{2h}_{11}(r),
+            \xi^{1h}_{11}(r), \ \xi^{2h}_{11}(r),
         .. math::
-            \\xi^{1h}_{12}(r), \\ \\xi^{2h}_{12}(r),
+            \xi^{1h}_{12}(r), \ \xi^{2h}_{12}(r),
         .. math::
-            \\xi^{1h}_{22}(r), \\ \\xi^{2h}_{22}(r),
+            \xi^{1h}_{22}(r), \ \xi^{2h}_{22}(r),
 
         the autocorrelation of one and two halo autocorrelation of ``sample1``,
         the one and two halo cross-correlation between ``sample1`` and ``sample2``,
@@ -274,7 +274,7 @@ def nball_volume(R, k=3):
 def random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
         do_RR, do_DR, _sample1_is_sample2, approx_cell1_size,
         approx_cell2_size, approx_cellran_size):
-    """
+    r"""
     Count random pairs.  There are two high level branches:
         1. w/ or wo/ PBCs and randoms.
         2. PBCs and analytical randoms

--- a/halotools/mock_observables/two_point_clustering/wp.py
+++ b/halotools/mock_observables/two_point_clustering/wp.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module containing the `~halotools.mock_observables.wp` function used to
 calculate the projected two-point correlation function (aka projected galaxy clustering).
 """
@@ -21,7 +21,7 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
         max_sample_size=int(1e6), approx_cell1_size=None, approx_cell2_size=None,
         approx_cellran_size=None, seed=None):
-    """
+    r"""
     Calculate the projected two point correlation function, :math:`w_{p}(r_p)`,
     where :math:`r_p` is the separation perpendicular to the line-of-sight (LOS).
 
@@ -143,7 +143,7 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         three arrays of length *len(rp_bins)-1* are returned:
 
         .. math::
-            w_{p11}(r_p), \\ w_{p12}(r_p), \\ w_{p22}(r_p),
+            w_{p11}(r_p), \ w_{p12}(r_p), \ w_{p22}(r_p),
 
         the autocorrelation of ``sample1``, the cross-correlation between ``sample1``
         and ``sample2``, and the autocorrelation of ``sample2``.  If ``do_auto`` or ``do_cross``
@@ -156,9 +156,9 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
     `~halotools.mock_observables.rp_pi_tpcf`:
 
     .. math::
-        w_p(r_p) = \\int_0^{\\pi_{\\rm max}}2.0\\xi(r_p,\\pi)\\mathrm{d}\\pi
+        w_p(r_p) = \int_0^{\pi_{\rm max}}2.0\xi(r_p,\pi)\mathrm{d}\pi
 
-    where :math:`\\pi_{\\rm max}` is ``pi_max`` and :math:`\\xi(r_p,\\pi)`
+    where :math:`\pi_{\rm max}` is ``pi_max`` and :math:`\xi(r_p,\pi)`
     is the redshift space correlation function.
 
     For a higher-performance implementation of the wp function,

--- a/halotools/sim_manager/rockstar_hlist_reader.py
+++ b/halotools/sim_manager/rockstar_hlist_reader.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Module storing the `~halotools.sim_manager.RockstarHlistReader` class,
 the primary class used by Halotools to process
 publicly available Rockstar hlist files and store them in cache.
@@ -27,7 +27,7 @@ uninstalled_h5py_msg = ("\nYou must have h5py installed if you want to \n"
 
 
 def _infer_redshift_from_input_fname(fname):
-    """ Method extracts the portion of the Rockstar hlist fname
+    r""" Method extracts the portion of the Rockstar hlist fname
     that contains the scale factor of the snapshot, and returns a
     float for the redshift inferred from this substring.
 
@@ -60,7 +60,7 @@ def _infer_redshift_from_input_fname(fname):
 
 
 class RockstarHlistReader(TabularAsciiReader):
-    """
+    r"""
     The `RockstarHlistReader` reads Rockstar hlist ASCII files,
     stores them as hdf5 files in the Halotools cache, and updates the cache log.
 
@@ -85,7 +85,7 @@ class RockstarHlistReader(TabularAsciiReader):
             row_cut_eq_dict={}, row_cut_neq_dict={},
             overwrite=False, ignore_nearby_redshifts=False, dz_tol=0.05,
             processing_notes=' ', **kwargs):
-        """
+        r"""
         Parameters
         -----------
         input_fname : string
@@ -290,7 +290,7 @@ class RockstarHlistReader(TabularAsciiReader):
         >>> print(halocat.version_name) # doctest: +SKIP
 
         Now suppose that for your science target of interest,
-        subhalos in your simulation with :math:`M_{\\rm vir} < 10^{10} M_{\\odot}/h`
+        subhalos in your simulation with :math:`M_{\rm vir} < 10^{10} M_{\odot}/h`
         are not properly resolved. In this case you can use the ``row_cut_min_dict`` keyword
         argument to discard such halos as the file is read.
 
@@ -302,7 +302,7 @@ class RockstarHlistReader(TabularAsciiReader):
         >>> reader.read_halocat(['halo_rvir'], write_to_disk = True, update_cache_log = True) # doctest: +SKIP
 
         Note the list we passed to the `read_halocat` method via the columns_to_convert_from_kpc_to_mpc
-        argument. In common rockstar catalogs, :math:`R_{\\rm vir}` is stored in kpc/h units,
+        argument. In common rockstar catalogs, :math:`R_{\rm vir}` is stored in kpc/h units,
         while halo centers are stored in Mpc/h units, a potential source of buggy behavior.
         Take note of all units in your raw halo catalog before caching reductions of it.
 
@@ -323,7 +323,7 @@ class RockstarHlistReader(TabularAsciiReader):
 
         Any cut you placed on the catalog during its initial
         reduction is automatically bound to the cached halo catalog as additional metadata.
-        In this case, since we placed a lower bound on :math:`M_{\\rm vir}`:
+        In this case, since we placed a lower bound on :math:`M_{\rm vir}`:
 
         >>> print(halocat.halo_mvir_row_cut_min) # doctest: +SKIP
         >>> 100 # doctest: +SKIP
@@ -524,7 +524,7 @@ class RockstarHlistReader(TabularAsciiReader):
     def read_halocat(self, columns_to_convert_from_kpc_to_mpc,
             write_to_disk=False, update_cache_log=False,
             add_supplementary_halocat_columns=True, **kwargs):
-        """ Method reads the ascii data and
+        r""" Method reads the ascii data and
         binds the resulting catalog to ``self.halo_table``.
 
         By default, the optional ``write_to_disk`` and ``update_cache_log``
@@ -635,7 +635,7 @@ class RockstarHlistReader(TabularAsciiReader):
                     raise HalotoolsError(msg)
 
     def _read_ascii(self, **kwargs):
-        """ Method reads the input ascii and returns
+        r""" Method reads the input ascii and returns
         a structured Numpy array of the data
         that passes the row- and column-cuts.
 

--- a/halotools/utils/table_utils.py
+++ b/halotools/utils/table_utils.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Modules performing small, commonly used tasks throughout the package.
 """
 
@@ -15,7 +15,7 @@ __all__ = ['SampleSelector']
 
 
 def compute_conditional_percentiles(**kwargs):
-    """
+    r"""
     In bins of the ``prim_haloprop``, compute the rank-order percentile
     of the input ``table`` based on the value of ``sec_haloprop``.
 
@@ -92,7 +92,7 @@ def compute_conditional_percentiles(**kwargs):
             raise HalotoolsError(msg)
 
     def compute_prim_haloprop_bins(dlog10_prim_haloprop=0.05, **kwargs):
-        """
+        r"""
         Parameters
         ----------
         prim_haloprop : array
@@ -183,12 +183,12 @@ def compute_conditional_percentiles(**kwargs):
 
 
 class SampleSelector(object):
-    """ Container class for commonly used sample selections.
+    r""" Container class for commonly used sample selections.
     """
 
     @staticmethod
     def host_halo_selection(return_subhalos=False, **kwargs):
-        """ Method divides sample in to host halos and subhalos, and returns
+        r""" Method divides sample in to host halos and subhalos, and returns
         either the hosts or the hosts and the subs depending
         on the value of the input ``return_subhalos``.
         """
@@ -202,7 +202,7 @@ class SampleSelector(object):
     @staticmethod
     def property_range(lower_bound=-float("inf"), upper_bound=float("inf"),
             return_complement=False, host_halos_only=False, subhalos_only=False, **kwargs):
-        """ Method makes a cut on an input table column based on an input upper and lower bound, and
+        r""" Method makes a cut on an input table column based on an input upper and lower bound, and
         returns the cut table.
 
         Parameters
@@ -213,10 +213,10 @@ class SampleSelector(object):
             Column name that will be used to apply the cut
 
         lower_bound : float, optional keyword argument
-            Minimum value for the input column of the returned table. Default is :math:`-\\infty`.
+            Minimum value for the input column of the returned table. Default is :math:`-\infty`.
 
         upper_bound : float, optional keyword argument
-            Maximum value for the input column of the returned table. Default is :math:`+\\infty`.
+            Maximum value for the input column of the returned table. Default is :math:`+\infty`.
 
         return_complement : bool, optional keyword argument
             If True, `property_range` gives the table elements that do not pass the cut
@@ -279,7 +279,7 @@ class SampleSelector(object):
 
     @staticmethod
     def split_sample(**kwargs):
-        """ Method divides a sample into subsamples based on the percentile ranking of a given property.
+        r""" Method divides a sample into subsamples based on the percentile ranking of a given property.
 
         Parameters
         ----------


### PR DESCRIPTION
There is only one change I am aware of that will be necessary to gain python 3.6 compatibility: math-mode docstrings need to be changed so that `\\` is replaced by `\`, and all docstrings with such appearances need to be raw strings. I *think*, but I am not sure, that these changes will address all failures shared by @eteq with me in a recent bug report on `v0.5rc1`. 

CC @bsipocz - this PR replaces your #648. Since the `empirical_models.phase_space_models` sub-package received such a massive overhaul with #709, I found it easier to just start over rather than rebase. 

Currently I am sparing Travis some computation load by having commented out most environments while I'm working on `python 3.6`. These will be reinstated prior to merging this PR. 