### PR TITLE
Relax unit-testing requirements on halocat formatting

### DIFF
--- a/halotools/sim_manager/tests/test_cached_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_cached_halo_catalog.py
@@ -124,8 +124,20 @@ class TestCachedHaloCatalog(TestCase):
                 hf.close()
                 pf.close()
 
-            except InvalidCacheLogEntry:
-                pass
+            except (HalotoolsError, InvalidCacheLogEntry):
+                fname = halo_log_entry.fname
+                simname = halo_log_entry.simname
+                redshift = halo_log_entry.redshift
+                if APH_MACHINE:
+                    allowed_failure = (redshift > 0) & (simname == 'bolshoi' or simname == 'multidark')
+                    if allowed_failure:
+                        pass
+                    else:
+                        msg = ("APH_MACHINE should never have inconsistent halo/ptcl tables\n"
+                            "fname = {0}\nsimname = {1}\nredshift = {2}")
+                        raise HalotoolsError(msg.format(fname, simname, redshift))
+                else:
+                    pass
 
     def test_default_catalog(self):
         """ Verify that the default halo catalog loads if it is available

--- a/halotools/sim_manager/tests/test_supported_sims.py
+++ b/halotools/sim_manager/tests/test_supported_sims.py
@@ -7,7 +7,7 @@ import numpy as np
 from astropy.config.paths import _find_home
 from astropy.tests.helper import pytest
 
-from ..cached_halo_catalog import CachedHaloCatalog
+from ..cached_halo_catalog import CachedHaloCatalog, InvalidCacheLogEntry
 
 from ...custom_exceptions import HalotoolsError
 
@@ -102,5 +102,9 @@ def test_lbox_vector():
         try:
             halocat = CachedHaloCatalog(simname=simname, redshift=z)
             assert len(halocat.Lbox) == 3
-        except HalotoolsError:
-            pass
+        except (InvalidCacheLogEntry, HalotoolsError):
+            if APH_MACHINE:
+                raise HalotoolsError("APH_MACHINE should never fail Lbox_vector test\n"
+                    "simname = {0}\nscale factor = {1}".format(simname, a))
+            else:
+                pass


### PR DESCRIPTION
This PR relaxes a couple of unnecessary tests on CachedHaloCatalog, resolving #719 and #720. 
