### PR TITLE
Bugfix for occupation components

### DIFF
--- a/halotools/empirical_models/occupation_models/leauthaud11_components.py
+++ b/halotools/empirical_models/occupation_models/leauthaud11_components.py
@@ -305,7 +305,7 @@ class Leauthaud11Sats(OccupationComponent):
         if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
         elif 'prim_haloprop' in list(kwargs.keys()):
-            mass = kwargs['prim_haloprop']
+            mass = np.atleast_1d(kwargs['prim_haloprop'])
         else:
             raise KeyError("Must pass one of the following keyword arguments "
                 "to mean_occupation:\n``table`` or ``prim_haloprop``")

--- a/halotools/empirical_models/occupation_models/tests/test_tinker13.py
+++ b/halotools/empirical_models/occupation_models/tests/test_tinker13.py
@@ -59,7 +59,7 @@ def test_Tinker13Cens5():
 
 def test_Tinker13Cens6():
     prim_haloprop = np.zeros(2) + 1e12
-    sfr_designation = str('Cuba Gooding Jr.')
+    sfr_designation = 'Cuba Gooding Jr.'
     model = Tinker13Cens()
     with pytest.raises(HalotoolsError) as err:
         __ = model.mean_occupation(prim_haloprop=prim_haloprop, sfr_designation=sfr_designation)

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -148,7 +148,7 @@ class Tinker13Cens(OccupationComponent):
             np.log10(self._quiescent_fraction_abscissa), model_ordinates)
 
         if 'prim_haloprop' in kwargs:
-            prim_haloprop = kwargs['prim_haloprop']
+            prim_haloprop = np.atleast_1d(kwargs['prim_haloprop'])
         elif 'table' in kwargs:
             table = kwargs['table']
             try:
@@ -196,8 +196,8 @@ class Tinker13Cens(OccupationComponent):
                 raise HalotoolsError(msg % self.sfr_designation_key)
         else:
             try:
-                prim_haloprop = kwargs['prim_haloprop']
-                sfr_designation = kwargs['sfr_designation']
+                prim_haloprop = np.atleast_1d(kwargs['prim_haloprop'])
+                sfr_designation = np.atleast_1d(kwargs['sfr_designation'])
             except KeyError:
                 msg = ("If not passing a ``table`` keyword argument to the ``mean_occupation`` method,\n"
                     "you must pass both ``prim_haloprop`` and ``sfr_designation`` keyword arguments")
@@ -454,7 +454,7 @@ class Tinker13QuiescentSats(OccupationComponent):
         if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
         elif 'prim_haloprop' in list(kwargs.keys()):
-            mass = kwargs['prim_haloprop']
+            mass = np.atleast_1d(kwargs['prim_haloprop'])
         else:
             function_name = "Tinker13QuiescentSats.mean_occupation"
             raise HalotoolsError(function_name)
@@ -620,7 +620,7 @@ class Tinker13ActiveSats(OccupationComponent):
         if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
         elif 'prim_haloprop' in list(kwargs.keys()):
-            mass = kwargs['prim_haloprop']
+            mass = np.atleast_1d(kwargs['prim_haloprop'])
         else:
             function_name = "Tinker13ActiveSats.mean_occupation"
             raise HalotoolsError(function_name)

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -202,8 +202,7 @@ class Tinker13Cens(OccupationComponent):
                 msg = ("If not passing a ``table`` keyword argument to the ``mean_occupation`` method,\n"
                     "you must pass both ``prim_haloprop`` and ``sfr_designation`` keyword arguments")
                 raise HalotoolsError(msg)
-            if type(sfr_designation) == str:
-                sfr_designation = np.repeat(sfr_designation, custom_len(prim_haloprop))
+            if type(sfr_designation[0]) in (str, unicode, np.string_, np.unicode_):
                 if sfr_designation[0] not in ['active', 'quiescent']:
                     msg = ("The only acceptable values of "
                         "``sfr_designation`` are ``active`` or ``quiescent``")

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -127,7 +127,7 @@ class Zheng07Cens(OccupationComponent):
         if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
         elif 'prim_haloprop' in list(kwargs.keys()):
-            mass = kwargs['prim_haloprop']
+            mass = np.atleast_1d(kwargs['prim_haloprop'])
         else:
             msg = ("\nYou must pass either a ``table`` or ``prim_haloprop`` argument \n"
                 "to the ``mean_occupation`` function of the ``Zheng07Cens`` class.\n")
@@ -397,14 +397,11 @@ class Zheng07Sats(OccupationComponent):
         if 'table' in list(kwargs.keys()):
             mass = kwargs['table'][self.prim_haloprop_key]
         elif 'prim_haloprop' in list(kwargs.keys()):
-            mass = kwargs['prim_haloprop']
+            mass = np.atleast_1d(kwargs['prim_haloprop'])
         else:
             msg = ("\nYou must pass either a ``table`` or ``prim_haloprop`` argument \n"
                 "to the ``mean_occupation`` function of the ``Zheng07Sats`` class.\n")
             raise HalotoolsError(msg)
-        mass = np.array(mass)
-        if np.shape(mass) == ():
-            mass = np.array([mass])
 
         M0 = 10.**self.param_dict['logM0']
         M1 = 10.**self.param_dict['logM1']

--- a/halotools/empirical_models/occupation_models/zu_mandelbaum15_components.py
+++ b/halotools/empirical_models/occupation_models/zu_mandelbaum15_components.py
@@ -272,7 +272,7 @@ class ZuMandelbaum15Sats(OccupationComponent):
         if 'table' in list(kwargs.keys()):
             halo_mass = kwargs['table'][self.prim_haloprop_key]
         elif 'prim_haloprop' in list(kwargs.keys()):
-            halo_mass = kwargs['prim_haloprop']
+            halo_mass = np.atleast_1d(kwargs['prim_haloprop'])
         else:
             raise KeyError("Must pass one of the following keyword arguments "
                 "to mean_occupation:\n``table`` or ``prim_haloprop``")


### PR DESCRIPTION
Now converting all prim_haloprop arguments with np.atleast_1d to protect against float vs. iterable confusion. This PR resolves #723. 