### PR TITLE
Python3.6 needs pytest3 to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
     - 3.5
+    - 3.6
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -32,8 +33,6 @@ env:
     matrix:
         # Make sure that egg_info works without dependencies
         - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
 
 matrix:
     include:
@@ -68,30 +67,24 @@ matrix:
         # Try Astropy development version
         - python: 2.7
           env: ASTROPY_VERSION=development
-        - python: 3.5
+        - python: 3.6
           env: ASTROPY_VERSION=development
 
         # Try older numpy version, 1.9 is tested above with py3.3
-        - python: 2.7
+        - python: 3.4
           env: NUMPY_VERSION=1.10
+        # Try older numpy version, 1.9 is tested above with py3.3
+        - python: 3.5
+          env: NUMPY_VERSION=1.11
 
         # Try numpy pre-release version, this runs only when a pre-release
         # is available on pypi.
-        - python: 3.5
+        - python: 3.6
           env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7
           env: CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ h5py//'`" # this magic incantation removes the substring " h5py" from the dependencies
-
-        - python: 3.6
-          env: SETUP_CMD='test'
-
-    allow_failures:
-        # Python 3.6 currently has a DeprecationWarning related to pytest
-        # that we don't understand at the moment.
-        - python: 3.6
-          env: SETUP_CMD='test'
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 
 python:
+    - 2.7
+    - 3.3
+    - 3.4
     - 3.5
     - 3.6
 
@@ -36,9 +39,6 @@ env:
 
 matrix:
     include:
-        - python: 2.7
-          env: SETUP_CMD='egg_info'
-
         # Do a coverage test in Python 2.
         - python: 2.7
           env: SETUP_CMD='test --coverage'
@@ -58,9 +58,6 @@ matrix:
                CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
         - python: 3.4
-          env: SETUP_CMD='egg_info'
-
-        - python: 3.4
           env: NUMPY_VERSION=1.11
                CONDA_DEPENDENCIES='cython scipy requests matplotlib h5py beautiful-soup'
 
@@ -68,19 +65,16 @@ matrix:
         - python: 2.7
           env: ASTROPY_VERSION=development
         - python: 3.6
-          env: ASTROPY_VERSION=development
+          env: ASTROPY_VERSION=development ASTROPY_USE_SYSTEM_PYTEST=1
 
-        # Try older numpy version, 1.9 is tested above with py3.3
-        - python: 3.4
-          env: NUMPY_VERSION=1.10
-        # Try older numpy version, 1.9 is tested above with py3.3
+        # Try older numpy version, 1.9 is tested above with py3.3 and 1.11 with py3.4
         - python: 3.5
-          env: NUMPY_VERSION=1.11
+          env: NUMPY_VERSION=1.10
 
         # Try numpy pre-release version, this runs only when a pre-release
         # is available on pypi.
         - python: 3.6
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
+          env: NUMPY_VERSION=prerelease SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7


### PR DESCRIPTION
Adding ``ASTROPY_USE_SYSTEM_PYTEST=1`` to the py3.6 builds should fix the failures, at least it worked for astroqeury (thanks @pllim for hinting that this issue should have been fixed upstream already).
