### PR TITLE
Now sorting Hod model gal_types so that centrals appear first

### DIFF
--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -574,7 +574,7 @@ class HodModelFactory(ModelFactory):
         _gal_type_list = []
         for component_model in list(self.model_dictionary.values()):
             _gal_type_list.append(component_model.gal_type)
-        self.gal_types = list(set(_gal_type_list))
+        self.gal_types = sorted(list(set(_gal_type_list)))
 
     def set_primary_behaviors(self):
         """ Creates names and behaviors for the primary methods of `HodModelFactory`


### PR DESCRIPTION
This is to ensure consistency with the default settings for the mock-generation calling-sequence