### PR TITLE
Improved documentation on delta_sigma

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -68,6 +68,11 @@ Calculating galaxy-galaxy lensing in a hydro simulation
 
 The `delta_sigma` function has had a complete overhaul, including a change to the function signature. The new implementation is faster and more accurate than the previous version, and now supports calculating the lensing signal for cases where the simulation particles have variable mass, such as hydro simulations or boxes with massive neutrinos.
 
+.. note::
+
+    The function signature of `delta_sigma` no longer has a ``pi_max`` argument, as the calculation is now performed by computing the mass distribution projecting along the entire length of the z-axis of the simulation. Users of the `delta_sigma` function in previous Halotools releases will need to update their code. See the function docstring for further details.
+
+
 Calculating galaxy-galaxy lensing from pre-computed pairs
 -----------------------------------------------------------
 There is also a new `delta_sigma_from_precomputed_pairs` that allows users to pre-compute the mass surrounding each model galaxy and then compute :math:`\Delta\Sigma` directly from an input mask; for cases where the *candidate* positions of galaxies are known in advance, the `delta_sigma_from_precomputed_pairs` will generally improve runtimes for calculating :math:`\Delta\Sigma` by orders of magnitude.

--- a/halotools/mock_observables/surface_density/delta_sigma.py
+++ b/halotools/mock_observables/surface_density/delta_sigma.py
@@ -183,6 +183,20 @@ def delta_sigma(galaxies, particles, particle_masses, downsampling_factor,
     *physical* units of :math:`M_{\odot} / {\rm pc}^2` using the value of
     little h appropriate for your assumed cosmology.
 
+    The code shown above demonstrates how to calculate :math:`\Delta\Sigma` via the excess
+    surface density of mass using the z-axis as the axis of projection. However, it may be useful
+    to project along the other Cartesian axes, for example to help beat down sample variance.
+    While the `delta_sigma` function is written to always use the "third" dimension as the
+    projection axis, you can easily hack the code to project along, say, the y-axis by simply
+    transposing your y- and z-coordinates when you pack them into a 2-d array:
+
+    >>> particles = np.vstack((px, pz, py)).T
+    >>> galaxies = np.vstack((x, z, y)).T
+
+    Using the above ``particles`` and ``galaxies`` and otherwise calling the `delta_sigma`
+    function as normal will instead calculate the surface mass density by projecting
+    along the y-axis.
+
     See also
     --------
     :ref:`galaxy_catalog_analysis_tutorial3`


### PR DESCRIPTION
The docstring of delta_sigma now includes explicit discussion of how to project along alternative axes besides z, resolving #700. Thanks to @surhudm pointing out the apparent shortcoming and @johannesulf for pointing out the simple way to hack the code to achieve the desired result. 

The *What's New?* section of the documentation has also been updated to call explicit attention to the API change of `delta_sigma`, resolving #730.