### PR TITLE
Added forgotten `__all__` statement to noisy_percentile module

### DIFF
--- a/halotools/empirical_models/abunmatch/noisy_percentile.py
+++ b/halotools/empirical_models/abunmatch/noisy_percentile.py
@@ -4,6 +4,8 @@ import numpy as np
 from scipy.special import erf, erfinv
 from astropy.utils.misc import NumpyRNGContext
 
+__all__ = ('noisy_percentile', )
+
 
 def noisy_percentile(percentile, correlation_coeff, seed=None, random_percentile=None):
     r"""


### PR DESCRIPTION
After this PR, it will now be possible to import `noisy_percentile` function directly from `empirical_models as follows:

```
>>> from halotools.empirical_models import noisy_percentile
```

This did not work prior to this PR as a result of a forgotten `__all__`