### PR TITLE
high-z redshift-distortion feature to `return_xyz_formatted_array` function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@
 
 - The ``gal_types`` attribute of HODModelFactory-produced models is now sorted so that ``centrals`` always appears before ``satellites``. This new default behavior is more common for interdependent occupation models, where satellite abundance depends upon central galaxy characteristics, rather than the other way around. See https://github.com/astropy/halotools/pull/729
 
+- Added new keyword arguments to `return_xyz_formatted_array` function enabling application of redshift-space distortions for galaxy samples at higher redshift. Previously, the user needed to do this manually). Default behavior of this function is unchanged, provided users had not locally modified the `sim_defaults` module to have set `default_redshift` greater than zero.
+
 
 0.4 (2016-08-11)
 ----------------

--- a/docs/quickstart_and_tutorials/mock_observations/mock_obs_pos_formatting.rst
+++ b/docs/quickstart_and_tutorials/mock_observations/mock_obs_pos_formatting.rst
@@ -6,22 +6,22 @@
 Formatting your xyz coordinates for Mock Observables calculations
 **************************************************************************
 
-The `~halotools.mock_observables` package adopts a specific convention for 
-how its functions accept spatial coordinate inputs. 
-If you have a collection of *Npts* coordinates for either *Ndim=2* or *Ndim=3*, 
-the convention is that you will pass a multi-dimensional Numpy array 
-of shape *(Npts, Ndim)* storing the coordinates. 
-All the `~halotools.mock_observables` functions that operate on multi-dimensional data 
-follow this convention. For example, 
-`~halotools.mock_observables.tpcf`, `~halotools.mock_observables.void_prob_func` 
-and `~halotools.mock_observables.delta_sigma` all accept data formatted as 
-`~numpy.ndarray` of shape *(Npts, 3)*, while `~halotools.mock_observables.angular_tpcf` accepts 
-a `~numpy.ndarray` of shape *(Npts, 2)*. 
+The `~halotools.mock_observables` package adopts a specific convention for
+how its functions accept spatial coordinate inputs.
+If you have a collection of *Npts* coordinates for either *Ndim=2* or *Ndim=3*,
+the convention is that you will pass a multi-dimensional Numpy array
+of shape *(Npts, Ndim)* storing the coordinates.
+All the `~halotools.mock_observables` functions that operate on multi-dimensional data
+follow this convention. For example,
+`~halotools.mock_observables.tpcf`, `~halotools.mock_observables.void_prob_func`
+and `~halotools.mock_observables.delta_sigma` all accept data formatted as
+`~numpy.ndarray` of shape *(Npts, 3)*, while `~halotools.mock_observables.angular_tpcf` accepts
+a `~numpy.ndarray` of shape *(Npts, 2)*.
 
 Example of how to transform your coordinates
 ===============================================
-Suppose you have a collection of *x, y, z* arrays 
-storing the spatial positions of halos or galaxies. 
+Suppose you have a collection of *x, y, z* arrays
+storing the spatial positions of halos or galaxies.
 
 >>> Npts = int(1e5)
 >>> Lbox = 250
@@ -30,13 +30,13 @@ storing the spatial positions of halos or galaxies.
 >>> y = np.random.uniform(0, Lbox, Npts)
 >>> z = np.random.uniform(0, Lbox, Npts)
 
-In order to bundle these arrays into the shape of the multi-dimensional array 
+In order to bundle these arrays into the shape of the multi-dimensional array
 used by the `~halotools.mock_observables` package:
 
 >>> pos = np.vstack((x, y, z)).T
 
-The ``pos`` array is now formatted in a form that can be directly passed, for example, 
-to the `~halotools.mock_observables.tpcf` function as the first positional argument. 
+The ``pos`` array is now formatted in a form that can be directly passed, for example,
+to the `~halotools.mock_observables.tpcf` function as the first positional argument.
 
 If you had two-dimensional data instead:
 
@@ -44,52 +44,63 @@ If you had two-dimensional data instead:
 >>> dec = np.random.uniform(-np.pi/2., np.pi/2, Npts)
 >>> angular_coords = np.vstack((ra, dec)).T
 
-The ``angular_coords`` array is now formatted in a form that can be directly passed, for example, 
-to the `~halotools.mock_observables.angular_tpcf` function as the first positional argument. 
+The ``angular_coords`` array is now formatted in a form that can be directly passed, for example,
+to the `~halotools.mock_observables.angular_tpcf` function as the first positional argument.
 
 Using the `~halotools.mock_observables.return_xyz_formatted_array` convenience function
 =========================================================================================
 
-When using the `~halotools.mock_observables` package, 
-the above transformation is so commonly encountered that there is a convenience function 
+When using the `~halotools.mock_observables` package,
+the above transformation is so commonly encountered that there is a convenience function
 dedicated to handling it:
 
 >>> from halotools.mock_observables import return_xyz_formatted_array
 >>> pos = return_xyz_formatted_array(x, y, z)
 
-There is no difference between using 
-`~halotools.mock_observables.return_xyz_formatted_array` or `numpy.vstack`. 
-However, the `~halotools.mock_observables.return_xyz_formatted_array` function comes 
-with two additional features that are worthy of special mention. 
+There is no difference between using
+`~halotools.mock_observables.return_xyz_formatted_array` or `numpy.vstack`.
+However, the `~halotools.mock_observables.return_xyz_formatted_array` function comes
+with two additional features that are worthy of special mention.
 
-Applying redshift-space distortions 
+Applying redshift-space distortions
 ---------------------------------------
-For some science targets, you may wish to apply redshift-space distortions to your 
-coordinates before computing the observable statistic. 
-For example, RSD has a very significant impact on galaxy group identification, 
-and so most applications using the `~halotools.mock_observables.FoFGroups` feature 
-will want to account for this effect. 
-To do, you can use the ``velocity_distortion_dimension`` keyword argument together 
-with the ``velocity`` keyword storing an array with 
-the peculiar velocity in whatever dimension you want to distort:
+For some science targets, you may wish to apply redshift-space distortions to your
+coordinates before computing the observable statistic.
+For example, RSD has a very significant impact on galaxy group identification,
+and so most applications using the `~halotools.mock_observables.FoFGroups` feature
+will want to account for this effect.
+To do, you can use the ``velocity_distortion_dimension`` keyword argument together
+with the ``velocity`` keyword storing an array with
+the peculiar velocity in whatever dimension you want to distort. In the code below,
+we'll apply redshift-space distortions assuming the default cosmology and redshift:
 
 >>> velz = np.random.normal(loc=0, scale=100, size=Npts)
 >>> pos_zdist = return_xyz_formatted_array(x, y, z, velocity=velz, velocity_distortion_dimension='z')
 
-Under the distant-observer approximation, 
-the ``pos_zdist`` array includes the effect of redshift-space distortions, 
-so that pos_zdist[:, 0] and pos_zdist[:,1] slices 
-can serve as the directions perpendicular to the line-of-sight, 
-and pos_zdist[:, 2] the direction parallel to the line-of-sight. 
+Under the distant-observer approximation,
+the ``pos_zdist`` array includes the effect of redshift-space distortions,
+so that pos_zdist[:, 0] and pos_zdist[:,1] slices
+can serve as the directions perpendicular to the line-of-sight,
+and pos_zdist[:, 2] the direction parallel to the line-of-sight.
 
-Selecting subsamples 
+You may wish to use the `return_xyz_formatted_array` function to apply realistic z-space
+distortions for mock galaxy samples "observed" at higher redshift, and/or assuming a different cosmology.
+This can be handled using the ``redshift`` and/or ``cosmology`` keyword arguments:
+
+>>> from astropy.cosmology import Planck15
+>>> redshift = 0.45
+>>> velz = np.random.normal(loc=0, scale=100, size=Npts)
+>>> pos_zdist = return_xyz_formatted_array(x, y, z, velocity=velz, velocity_distortion_dimension='z', cosmology=Planck15, redshift=redshift)
+
+
+Selecting subsamples
 -----------------------
-There is an additional feature of the 
-`~halotools.mock_observables.return_xyz_formatted_array` function 
-that allows you to retrieve a specific subsample of your coordinates. 
-Let's see how this works in a realistic example: 
-retrieving the spatial positions of quiescent and star-forming samples 
-in a mock galaxy catalog. 
+There is an additional feature of the
+`~halotools.mock_observables.return_xyz_formatted_array` function
+that allows you to retrieve a specific subsample of your coordinates.
+Let's see how this works in a realistic example:
+retrieving the spatial positions of quiescent and star-forming samples
+in a mock galaxy catalog.
 
 >>> from halotools.empirical_models import PrebuiltSubhaloModelFactory
 >>> model = PrebuiltSubhaloModelFactory('smhm_binary_sfr')
@@ -97,8 +108,8 @@ in a mock galaxy catalog.
 >>> halocat = FakeSim()
 >>> model.populate_mock(halocat)
 
-Our ``model`` now has a ``mock`` object attached to it with a ``galaxy_table`` 
-storing the mock galaxies in the form of an Astropy `~astropy.table.Table`. 
+Our ``model`` now has a ``mock`` object attached to it with a ``galaxy_table``
+storing the mock galaxies in the form of an Astropy `~astropy.table.Table`.
 
 >>> x = model.mock.galaxy_table['x']
 >>> y = model.mock.galaxy_table['y']

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -110,14 +110,14 @@ def return_xyz_formatted_array(x, y, z, period=np.inf,
     Parameters
     -----------
     x, y, z : sequence of length-Npts arrays
-        Units of Mpc assuming h=1, as throughout Halotools.
+        Comoving units of Mpc assuming h=1, as throughout Halotools.
 
     velocity : array, optional
-        Length-Npts array of velocities in units of km/s
+        Length-Npts array of velocities in *physical* units of km/s
         used to apply peculiar velocity distortions, e.g.,
-        :math:`z_{\rm dist} = z + v/H_{0}`.
-        Since Halotools workes exclusively in h=1 units,
-        in the above formula :math:`H_{0} = 100 km/s/Mpc`.
+        :math:`z_{\rm dist} = z_{\rm true} + v_{\rm z}/aH`,
+        where *a* and *H* are the scale factor and Hubble expansion rate
+        evaluated at the input ``redshift``.
 
         If ``velocity`` argument is passed,
         ``velocity_distortion_dimension`` must also be passed.
@@ -156,7 +156,7 @@ def return_xyz_formatted_array(x, y, z, period=np.inf,
     Returns
     --------
     pos : array_like
-        Numpy array with shape *(Npts, 3)*.
+        Numpy array with shape *(Npts, 3)* with units of comoving Mpc/h.
 
     Examples
     ---------
@@ -165,15 +165,21 @@ def return_xyz_formatted_array(x, y, z, period=np.inf,
     >>> x = np.random.uniform(0, Lbox, npts)
     >>> y = np.random.uniform(0, Lbox, npts)
     >>> z = np.random.uniform(0, Lbox, npts)
-    >>> pos = return_xyz_formatted_array(x, y, z, period = Lbox)
+    >>> pos = return_xyz_formatted_array(x, y, z, period=Lbox)
 
     Now we will define an array of random velocities that we will use
-    to apply z-space distortions to the z-dimension. For our random velocities
+    to apply z-space distortions to the z-dimension, assuming the mock galaxy
+    sample is at the default redshift. For our random velocities
     we'll assume the values are drawn from a Gaussian centered at zero
     using `numpy.random.normal`.
 
     >>> velocity = np.random.normal(loc=0, scale=100, size=npts)
-    >>> pos = return_xyz_formatted_array(x, y, z, period = Lbox, velocity = velocity, velocity_distortion_dimension='z')
+    >>> pos = return_xyz_formatted_array(x, y, z, period=Lbox, velocity=velocity, velocity_distortion_dimension='z')
+
+    If we wanted to introduce redshift-space distortions at some higher redshift:
+
+    >>> pos = return_xyz_formatted_array(x, y, z, period=Lbox, velocity=velocity, velocity_distortion_dimension='z', redshift=1.5)
+
 
     """
     period = np.atleast_1d(period)

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -102,7 +102,8 @@ def return_xyz_formatted_array(x, y, z, period=np.inf,
         cosmology=default_cosmology, redshift=default_redshift, **kwargs):
     r""" Returns a Numpy array of shape *(Npts, 3)* storing the
     xyz-positions in the format used throughout
-    the `~halotools.mock_observables` package.
+    the `~halotools.mock_observables` package, optionally applying redshift-space
+    distortions according to the input ``velocity``, ``redshift`` and ``cosmology``.
 
     See :ref:`mock_obs_pos_formatting` for a tutorial.
 
@@ -131,11 +132,13 @@ def return_xyz_formatted_array(x, y, z, period=np.inf,
         Default is no distortions.
 
     cosmology : object, optional
-        Cosmology to assume when applying redshift-space distortions.
+        Cosmology to assume when applying redshift-space distortions,
+        e.g., the cosmology of the simulation.
         Default is set in `sim_manager.sim_defaults`.
 
     redshift : float, optional
-        Redshift to assume when applying redshift-space distortions.
+        Redshift of the mock galaxy sample,
+        e.g., the redshift of the simulation snapshot.
         Default is set in `sim_manager.sim_defaults`.
 
     mask : array_like, optional

--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -6,6 +6,7 @@ import numpy as np
 from scipy.stats import binned_statistic
 
 from ..empirical_models import enforce_periodicity_of_box
+from ..sim_manager.sim_defaults import default_cosmology, default_redshift
 
 from ..custom_exceptions import HalotoolsError
 
@@ -97,7 +98,8 @@ def mean_y_vs_x(x, y, error_estimator='error_on_mean', **kwargs):
     return bin_midpoints, mean, err
 
 
-def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
+def return_xyz_formatted_array(x, y, z, period=np.inf,
+        cosmology=default_cosmology, redshift=default_redshift, **kwargs):
     r""" Returns a Numpy array of shape *(Npts, 3)* storing the
     xyz-positions in the format used throughout
     the `~halotools.mock_observables` package.
@@ -127,6 +129,14 @@ def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
         then ``pos`` can be treated as physically observed
         galaxy positions under the distant-observer approximation.
         Default is no distortions.
+
+    cosmology : object, optional
+        Cosmology to assume when applying redshift-space distortions.
+        Default is set in `sim_manager.sim_defaults`.
+
+    redshift : float, optional
+        Redshift to assume when applying redshift-space distortions.
+        Default is set in `sim_manager.sim_defaults`.
 
     mask : array_like, optional
         Boolean mask that can be used to select the positions
@@ -192,7 +202,8 @@ def return_xyz_formatted_array(x, y, z, period=np.inf, **kwargs):
     if apply_distortion is True:
         try:
             assert vel_dist_dim in ('x', 'y', 'z')
-            posdict[vel_dist_dim] = np.copy(posdict[vel_dist_dim]) + np.copy(velocity/100.)
+            spatial_distortion = (1. + redshift)*np.copy(velocity)/100./cosmology.efunc(redshift)
+            posdict[vel_dist_dim] = np.copy(posdict[vel_dist_dim]) + spatial_distortion
             Lbox = period_dict[vel_dist_dim]
             if Lbox != np.inf:
                 posdict[vel_dist_dim] = enforce_periodicity_of_box(

--- a/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
+++ b/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
@@ -233,7 +233,7 @@ def test_relative_velocities4():
     assert np.all(vrel == -correct_result)
 
 
-def test_return_xyz_formatted_array():
+def test_return_xyz_formatted_array1():
     npts = 10
     period = [1, 2, 3]
     x = np.linspace(0.001, period[0]-0.001, npts)
@@ -248,11 +248,44 @@ def test_return_xyz_formatted_array():
         velocity_distortion_dimension='x', period=period)
     result6 = cat_helpers.return_xyz_formatted_array(x, y, z, velocity=v,
         velocity_distortion_dimension='y', period=period)
+
     assert np.all(result1 == result2)
     assert np.all(result1 == result3)
     assert np.all(result1 == result4)
     assert np.all(result1 == result5)
     assert np.all(result1 == result6)
+
+
+def test_return_xyz_formatted_array2():
+    """ verify that redshift keyword is operative
+    """
+    npts = int(1e4)
+    x = np.linspace(0.001, 0.999, npts)
+    y = np.linspace(0.001, 0.999, npts)
+    z = np.linspace(0.001, 0.999, npts)
+    v = np.random.normal(loc=0, scale=150, size=npts)
+    result_z0 = cat_helpers.return_xyz_formatted_array(x, y, z,
+        velocity=v, velocity_distortion_dimension='x', redshift=0)
+    result_z1 = cat_helpers.return_xyz_formatted_array(x, y, z,
+        velocity=v, velocity_distortion_dimension='x', redshift=1)
+    assert not np.all(result_z0 == result_z1)
+
+
+def test_return_xyz_formatted_array3():
+    """ verify that cosmology keyword is operative
+    """
+    npts = int(1e4)
+    x = np.linspace(0.001, 0.999, npts)
+    y = np.linspace(0.001, 0.999, npts)
+    z = np.linspace(0.001, 0.999, npts)
+    v = np.random.normal(loc=0, scale=150, size=npts)
+
+    from astropy.cosmology import WMAP5, Planck15
+    result_z0a = cat_helpers.return_xyz_formatted_array(x, y, z,
+        velocity=v, velocity_distortion_dimension='x', redshift=0.5, cosmology=WMAP5)
+    result_z0b = cat_helpers.return_xyz_formatted_array(x, y, z,
+        velocity=v, velocity_distortion_dimension='x', redshift=0.5, cosmology=Planck15)
+    assert not np.all(result_z0a == result_z0b)
 
 
 class TestCatalogAnalysisHelpers(TestCase):


### PR DESCRIPTION
Add option to the `return_xyz_formatted_array` function to apply z-space distortions assuming any cosmology and redshift.

Despite the feature-freeze, I am going to apply this to `v0.5` since this is borderline a bug in the code - at the very least the previous API was misleading and poorly documented.

Thanks to @johannesulf for the suggestion.