### PR TITLE
Fixed bug in ZuMandelbaum15SmHm

### DIFF
--- a/halotools/empirical_models/component_model_templates/scatter_models.py
+++ b/halotools/empirical_models/component_model_templates/scatter_models.py
@@ -101,7 +101,7 @@ class LogNormalScatterModel(object):
         elif 'prim_haloprop' in list(kwargs.keys()):
             mass = kwargs['prim_haloprop']
         else:
-            raise KeyError("Must pass one of the following keyword arguments to mean_occupation:\n"
+            raise KeyError("Must pass one of the following keyword arguments to mean_scatter:\n"
                 "``table`` or ``prim_haloprop``")
 
         self._update_interpol()

--- a/halotools/empirical_models/smhm_models/tests/test_zu_mandelbaum15.py
+++ b/halotools/empirical_models/smhm_models/tests/test_zu_mandelbaum15.py
@@ -1,0 +1,15 @@
+"""
+"""
+from __future__ import division, print_function, absolute_import, unicode_literals
+
+import numpy as np
+
+from ...smhm_models import ZuMandelbaum15SmHm
+
+
+__all__ = ('test_mc_scatter1', )
+
+
+def test_mc_scatter1():
+    model = ZuMandelbaum15SmHm()
+    sm = model.mc_stellar_mass(prim_haloprop=1e12)


### PR DESCRIPTION
The `mc_stellar_mass` method of ZuMandelbaum15SmHm previously raised an exception due to some hard-coding of the model parameters governing the scatter. This PR provides a bug-fix for this behavior by over-riding the super-class methods. 

In a future PR, it may be better to just entirely do away with the template models for the SMHM, e.g., #746. 