### PR TITLE
Bug-fix for Monte Carlo realizations of radial velocity profiles

### DIFF
--- a/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py
@@ -567,6 +567,7 @@ class MonteCarloGalProf(object):
 
         virial_velocities = self.virial_velocity(total_mass)
         radial_dispersions = virial_velocities*dimensionless_radial_dispersions
+        radial_dispersions = np.where(radial_dispersions < 0, 0, radial_dispersions)
 
         seed = kwargs.get('seed', None)
         with NumpyRNGContext(seed):


### PR DESCRIPTION
When generating velocity profiles by solving the Jeans equation, there are very occasional cases where a negative value will be passed to `radial_velocities = np.random.normal(scale=radial_dispersions)` during calls to the `mc_radial_velocity` function in the `MonteCarloGalProf` class. These negative values are always very small and are a numerical artifact of interpolation, but they cause the code to raise an exception. This PR clips these values to zero so that no exception is raised. 
