### PR TITLE
Added science verification warning about tinker13 and zu_mandelbaum15

### DIFF
--- a/halotools/empirical_models/factories/prebuilt_model_factory.py
+++ b/halotools/empirical_models/factories/prebuilt_model_factory.py
@@ -4,6 +4,7 @@ Module storing `~halotools.empirical_models.PrebuiltSubhaloModelFactory` and
 the factories used to generate Halotools-provided composite models
 of the galaxy-halo connection.
 """
+from warnings import warn
 
 from ..factories import SubhaloModelFactory, HodModelFactory
 
@@ -11,6 +12,13 @@ from ...custom_exceptions import HalotoolsError
 
 __all__ = ('PrebuiltSubhaloModelFactory', 'PrebuiltHodModelFactory')
 __author__ = ['Andrew Hearin']
+
+
+under_development_warning = ("This particular model is "
+    "still being tested in collaboration with {0}.\n"
+    "If you need to use this prebuilt model for science, \n"
+    "you will either need to test it yourself \n"
+    "or wait for the Halotools developers to finish science verification.\n")
 
 
 class PrebuiltSubhaloModelFactory(SubhaloModelFactory):
@@ -244,10 +252,13 @@ class PrebuiltHodModelFactory(HodModelFactory):
         elif model_nickname == 'hearin15':
             dictionary_retriever = hod_models.hearin15_model_dictionary
         elif model_nickname == 'tinker13':
+            warn(under_development_warning.format("Jeremy Tinker"))
             dictionary_retriever = hod_models.tinker13_model_dictionary
         elif model_nickname == 'zu_mandelbaum15':
+            warn(under_development_warning.format("Ying Zu"))
             dictionary_retriever = hod_models.zu_mandelbaum15_model_dictionary
         elif model_nickname == 'zu_mandelbaum16':
+            warn(under_development_warning.format("Ying Zu"))
             dictionary_retriever = hod_models.zu_mandelbaum16_model_dictionary
         else:
             msg = ("\nThe ``%s`` model_nickname is not recognized by Halotools\n")

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_biased_nfw/test_mockpop.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_biased_nfw/test_mockpop.py
@@ -89,7 +89,7 @@ def test_mockpop1():
     min_host_mass_to_search_for = 10**16.001
     mask16_0p1 = _nearest_lower_value_mask(sats_0p1['halo_mvir'],
                         min_host_mass_to_search_for)
-    galaxy_sample_m16_0p1 = model.mock.galaxy_table[mask16_0p1]
+    galaxy_sample_m16_0p1 = sats_0p1[mask16_0p1]
     std_vr_0p1 = np.std(_radial_velocities(galaxy_sample_m16_0p1, halocat.Lbox))
 
     model.param_dict['conc_gal_bias'] = gal_bias_bins.max()
@@ -104,7 +104,7 @@ def test_mockpop1():
     min_host_mass_to_search_for = 10**16.001
     mask16_10 = _nearest_lower_value_mask(sats_10['halo_mvir'],
                         min_host_mass_to_search_for)
-    galaxy_sample_m16_10 = model.mock.galaxy_table[mask16_10]
+    galaxy_sample_m16_10 = sats_10[mask16_10]
     std_vr_10 = np.std(_radial_velocities(galaxy_sample_m16_10, halocat.Lbox))
 
     msg = ("Radial velocity dispersions should be smaller for larger values of ``conc_gal_bias`` ")
@@ -138,17 +138,19 @@ def test_mockpop2():
     enforce_host_centric_distance_exists(model.mock.galaxy_table)
 
     # Select a galaxy sample with the same host halo mass ~ 10**14, and another with 10**16
+    satmask = model.mock.galaxy_table['gal_type'] == 'satellites'
+    sats = model.mock.galaxy_table[satmask]
     min_host_mass_to_search_for = 10**14.001
-    mask14 = _nearest_lower_value_mask(model.mock.galaxy_table['halo_mvir'],
+    mask14 = _nearest_lower_value_mask(sats['halo_mvir'],
                         min_host_mass_to_search_for)
-    galaxy_sample_m14 = model.mock.galaxy_table[mask14]
+    galaxy_sample_m14 = sats[mask14]
     assert np.all(galaxy_sample_m14['halo_mvir'] == 10**14)
     enforce_correct_conc_gal_bias(galaxy_sample_m14, gal_bias_bins.min())
 
     min_host_mass_to_search_for = 10**16.001
-    mask16 = _nearest_lower_value_mask(model.mock.galaxy_table['halo_mvir'],
+    mask16 = _nearest_lower_value_mask(sats['halo_mvir'],
                         min_host_mass_to_search_for)
-    galaxy_sample_m16 = model.mock.galaxy_table[mask16]
+    galaxy_sample_m16 = sats[mask16]
     assert np.all(galaxy_sample_m16['halo_mvir'] == 10**16)
     enforce_correct_conc_gal_bias(galaxy_sample_m16, gal_bias_bins.max())
 

--- a/halotools/empirical_models/smhm_models/zu_mandelbaum15.py
+++ b/halotools/empirical_models/smhm_models/zu_mandelbaum15.py
@@ -11,17 +11,6 @@ from ..component_model_templates import PrimGalpropModel
 
 __all__ = ('ZuMandelbaum15SmHm', )
 
-mdef_warning_msg = ("The best-fit parameters of the Zu & Mandelbaum 2015 model \n"
-    "were fit to SDSS data using ``halo_m200m`` as the mass definition.\n"
-    "You have selected {0} instead, so if you wish to use their exact model, \n"
-    "you will need to adjust the parameters accordingly.\n"
-    "If the ``halo_m200m`` column does not appear in the halo catalog you are using, \n"
-    "this is a commonly available column in all publicly available Rockstar catalogs,\n"
-    "so for those catalogs you can create your own CachedHaloCatalog that includes this column.\n"
-    "Alternatively, you can use your current catalog together with the \n"
-    "Colossus python package (https://bdiemer.bitbucket.io) to add a new column\n"
-    "to your existing catalog.")
-
 
 class ZuMandelbaum15SmHm(PrimGalpropModel):
     """ Stellar-to-halo-mass relation based on
@@ -45,7 +34,7 @@ class ZuMandelbaum15SmHm(PrimGalpropModel):
 
         Notes
         -----
-        Note also that the best-fit parameters of this model are based on the
+        Note that the best-fit parameters of this model are based on the
         ``halo_m200m`` halo mass definition.
         Using alternative choices of mass definition will require altering the
         model parameters in order to mock up the same model published in Zu & Mandelbaum 2015.
@@ -57,9 +46,6 @@ class ZuMandelbaum15SmHm(PrimGalpropModel):
 
         super(ZuMandelbaum15SmHm, self).__init__(
             galprop_name='stellar_mass', prim_haloprop_key=prim_haloprop_key, **kwargs)
-
-        if self.prim_haloprop_key is not 'halo_m200m':
-            warn(mdef_warning_msg.format(self.prim_haloprop_key))
 
         self.param_dict = self.retrieve_default_param_dict()
 


### PR DESCRIPTION
Testing the `tinker13` and `zu_mandelbaum15` models against externally provided code has ground to a halt for various reasons. Since the remainder of the code is ready for release and has been for months, I just added a caveat warning if users instantiate these models. 

The `zu_mandelbaum15` model now also no longer issues a warning if a different halo mass definition is used - this was redundant and already covered in the docstring. 