### PR TITLE
Corrected error in isolation criteria tutorial

### DIFF
--- a/docs/notebooks/galcat_analysis/intermediate_examples/galaxy_catalog_intermediate_analysis_tutorial1.ipynb
+++ b/docs/notebooks/galcat_analysis/intermediate_examples/galaxy_catalog_intermediate_analysis_tutorial1.ipynb
@@ -1,433 +1,391 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:cbeb7b203a6f631806059f23f3a5486e3aa851fd6696cdab04bca4392f652359"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "heading",
-     "level": 1,
-     "metadata": {},
-     "source": [
-      "Galaxy Catalog Analysis Example: Identifying isolated galaxies, Part II"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In this tutorial, we'll start from a mock galaxy catalog and show how to determine which galaxies are \"isolated\" according to a variety of criteria. This tutorial demos more advanced usage of the isolation criteria functionality. For example, for each galaxy in some sample, you may wish to have an isolation criterion that depends on the stellar mass of the galaxy in question. This tutorial gives several examples of how to apply such a condition to a mock galaxy sample. "
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Generate a mock galaxy catalog \n"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Let's start out by generating a mock galaxy catalog into an N-body\n",
-      "simulation in the usual way. Here we'll assume you have the `z=0`\n",
-      "rockstar halos for the bolshoi simulation, as this is the\n",
-      "default halo catalog. \n"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.empirical_models import PrebuiltSubhaloModelFactory\n",
-      "model = PrebuiltSubhaloModelFactory('smhm_binary_sfr')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.sim_manager import CachedHaloCatalog\n",
-      "halocat = CachedHaloCatalog(simname = 'bolshoi', redshift = 0, halo_finder = 'rockstar')\n",
-      "\n",
-      "model.populate_mock(halocat)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Example 1: Variable isolation criteria in 3d"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "For the first example we'll find \"isolated\" galaxies using a 3d search criteria that depends on stellar mass in the following manner. From our mock, we know the stellar mass of every galaxy. The underlying model that generated the mock has a `mean_log_halo_mass` method that provides a map from $M_{\\ast}^{\\rm cen}$ to $M_{\\rm vir}^{\\rm host}.$ There is also a `halo_mass_to_halo_radius` function in the `empirical_models` that provides a map from $M_{\\rm vir}^{\\rm host}$ to $R_{\\rm vir}.$ We will use these two functions together to draw a sphere of radius $R_{\\rm vir}$ around each galaxy; a galaxy will be said to be isolated if there are no other galaxies in the sample within this search radius. Of course, some of the galaxies in our sample are not central galaxies, and there is also scatter between $M_{\\ast}^{\\rm cen}$ and $M_{\\rm vir}^{\\rm host},$ and so this criteria will not be perfect; since you know the true central/satellite designation in the mock, you can always test this assumption with a standard purity/completeness analysis. \n",
-      "\n",
-      "Let's select a sample of galaxies with $M_{\\ast}>10^{10}M_{\\odot},$ and focus on identifying isolated galaxies in a specific stellar mass range of $10^{10.4}M_{\\odot} < M_{\\ast} < 10^{10.5}M_{\\odot}:$ "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "all_gal_mask = model.mock.galaxy_table['stellar_mass'] > 1e10\n",
-      "all_gals = model.mock.galaxy_table[all_gal_mask]\n",
-      "\n",
-      "sample_mask = (all_gals['stellar_mass'] > 4e10) & (all_gals['stellar_mass'] < 5e10)\n",
-      "sm_selected_gals = all_gals[sample_mask]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "logsm = np.log10(sm_selected_gals['stellar_mass'])\n",
-      "presumed_mvir = 10**model.mean_log_halo_mass(logsm)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.empirical_models import halo_mass_to_halo_radius"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "presumed_rvir = halo_mass_to_halo_radius(presumed_mvir, \n",
-      "                cosmology = model.mock.cosmology, \n",
-      "                redshift = model.mock.redshift, \n",
-      "                mdef = 'vir')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.mock_observables import conditional_spherical_isolation"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The calling signature of `conditional_spherical_isolation` accepts a multi-dimensional array storing the x, y, z positions of each point. You can place your points into the appropriate form using `np.vstack([x, y, z]).T`, but below we'll demo how to use the `~halotools.mock_observables.return_xyz_formatted_array` function for this purpose, as this function provides additional convenient behavior that we'll use later in the tutorial. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.mock_observables import return_xyz_formatted_array"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sample1_pos = return_xyz_formatted_array(sm_selected_gals['x'], sm_selected_gals['y'], sm_selected_gals['z'])\n",
-      "sample2_pos = return_xyz_formatted_array(all_gals['x'], all_gals['y'], all_gals['z'])"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, presumed_rvir, period = model.mock.Lbox)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The boolean-valued array `is_isolated` is equal to `True` for those galaxies in `sm_selected_gals` with zero other galaxies located within a sphere of their presumed value of $R_{\\rm vir}.$"
-     ]
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Example 2: $M_{\\ast}-$dependent isolation criteria"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In this next example we'll show how to apply an isolation criterion that depends on the stellar mass of the galaxies. This calculation, as well as the remaining ones in this tutorial, will make use of Halotools marking functions. The way this works is as follows. Every galaxy in both `sample1` and `sample2` are given a \"mark\"; arrays storing these marks are passed to the `conditional_spherical_isolation` function together with the normal arrays storing galaxy positions. Additionally, you must select a \"condition function\", $f;$ the condition function $f$ acceps a mark $m_{1}$ from a galaxy in `sample1` and a mark $m_{2}$ from a galaxy in `sample2` and returns a boolean. For each galaxy in ``sample1``, the `conditional_spherical_isolation` function searches ``sample2`` for spatially nearby neighbors. A galaxy in `sample2` will only be considered as a candidate neighbor if it lies within the `r_max` value of the point in `sample1` *and* if the marking function $f(m_{1}, m_{2})$ returns `True`.\n",
-      "\n",
-      "For example, suppose we define the conditional function to be $f(m_{1}, m_{2}) = {\\rm True}$ if $m_{1} < m_{2}$ and `False` otherwise, and suppose that for our marks we passed in the stellar mass $M_{\\ast}$ of each galaxy. When evaluating whether some galaxy in `sample1` is isolated, what this choice for the conditional function would do is to ignore all those galaxies in `sample2` that are less massive than the `sample1` galaxy under consideration. So with this choice, the adopted definition of isolation is whether or not a *more massive galaxy* resides within some search radius. Let's see how to apply this isolation criterion to the galaxy samples defined above. \n",
-      "\n",
-      "For simplicity, we'll select a fixed `r_max`, but you are free to apply variable values of `r_max` together with the conditional function formalism. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "r_max = 0.5"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "marks1 = sm_selected_gals['stellar_mass']\n",
-      "marks2 = all_gals['stellar_mass']"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cond_func = 2 # See the docstring of conditional_spherical_isolation for the function <==> function ID correspondence"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max, \n",
-      "                    marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Example 3: Alternative $M_{\\ast}-$dependent isolation criteria"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "In this example, we'll do a similar calculation to the one above, except we'll make a slight variation to the definition of isolation: a galaxy in `sample1` will be said to be isolated if there are no `sample2` galaxies more massive than $M_{\\ast} + $0.5dex within 1 Mpc/h of the galaxy in `sample1`. \n",
-      "\n",
-      "For this calculation, we'll need to use `cond_func` = 5, which is defined as $f(m^{a}_{1}, m^{b}_{1}, m^{a}_{2}, m^{b}_{2}) = {\\rm True}$ if $m^{a}_{1} > m^{a}_{2} + m^{b}_{2},$ and `False` otherwise. For $m^{a}_{i}$ we will pass in $\\log_{10}(M_{\\ast}),$ and for $m^{b}_{i}$ we pass in $0.5.$ We will bundle the marks into a multi-dimensional Numpy array using the same `np.vstack` method we used to bundle our spatial positions into a *Npts x 3* array."
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "marks1 = np.vstack([np.log10(sm_selected_gals['stellar_mass']), np.zeros(len(sm_selected_gals))+0.5]).T\n",
-      "marks2 = np.vstack([np.log10(all_gals['stellar_mass']), np.zeros(len(all_gals))+0.5]).T"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "cond_func = 5"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max, \n",
-      "                    marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "heading",
-     "level": 2,
-     "metadata": {},
-     "source": [
-      "Example 4: $M_{\\ast}-$dependent isolation criteria in redshift-space"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "We will conclude this tutorial by putting together all of the features of the `isolation_functions` sub-package into a single,  observationally realistic example. We will demonstrate how to apply the following isolation criteria on a mock galaxy sample:\n",
-      "\n",
-      "Around each `sample1` galaxy with stellar mass $M_{\\ast}$, we will draw a cylinder of radius $2R_{\\rm vir}$ and length $3V_{\\rm vir},$ where $R_{\\rm vir}$ and $V_{\\rm vir}$ are the virial radius and velocity inferred from the underlying stellar-to-halo mass relation. In order for a `sample1` galaxy to be isolated, there must be no other `sample2` galaxies more massive than $0.5$dex within this cylinder. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.empirical_models import halo_mass_to_virial_velocity"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "presumed_vvir = halo_mass_to_virial_velocity(presumed_mvir, \n",
-      "                cosmology = model.mock.cosmology, \n",
-      "                redshift = model.mock.redshift, \n",
-      "                mdef = 'vir')"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "The units of `presumed_vvir` are in km/s, so we must convert these to units of length. Recall that *h=1* and that all Halotools length-units are in Mpc/h. "
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "H0 = 100.0 # Hubble constant in h=1 units of km/s/Mpc\n",
-      "pi_max = 3*presumed_vvir/H0\n",
-      "rp_max = 2*presumed_rvir"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "Our marks and `cond_func` are the same as before, repeated below for convenience:"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "marks1 = np.vstack([np.log10(sm_selected_gals['stellar_mass']), np.zeros(len(sm_selected_gals))+0.5]).T\n",
-      "marks2 = np.vstack([np.log10(all_gals['stellar_mass']), np.zeros(len(all_gals))+0.5]).T\n",
-      "\n",
-      "cond_func = 5"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from halotools.mock_observables import conditional_cylindrical_isolation"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "is_isolated = conditional_cylindrical_isolation(sample1_pos, sample2_pos, rp_max, pi_max, \n",
-      "                    marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Galaxy Catalog Analysis Example: Identifying isolated galaxies, Part II"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we'll start from a mock galaxy catalog and show how to determine which galaxies are \"isolated\" according to a variety of criteria. This tutorial demos more advanced usage of the isolation criteria functionality. For example, for each galaxy in some sample, you may wish to have an isolation criterion that depends on the stellar mass of the galaxy in question. This tutorial gives several examples of how to apply such a condition to a mock galaxy sample. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate a mock galaxy catalog "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's start out by generating a mock galaxy catalog into an N-body\n",
+    "simulation in the usual way. Here we'll assume you have the `z=0`\n",
+    "rockstar halos for the bolshoi simulation, as this is the\n",
+    "default halo catalog. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.empirical_models import PrebuiltSubhaloModelFactory\n",
+    "model = PrebuiltSubhaloModelFactory('smhm_binary_sfr')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.sim_manager import CachedHaloCatalog\n",
+    "halocat = CachedHaloCatalog(simname = 'bolshoi', redshift = 0, halo_finder = 'rockstar')\n",
+    "\n",
+    "model.populate_mock(halocat)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 1: Variable isolation criteria in 3d"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the first example we'll find \"isolated\" galaxies using a 3d search criteria that depends on stellar mass in the following manner. From our mock, we know the stellar mass of every galaxy. The underlying model that generated the mock has a `mean_log_halo_mass` method that provides a map from $M_{\\ast}^{\\rm cen}$ to $M_{\\rm vir}^{\\rm host}.$ There is also a `halo_mass_to_halo_radius` function in the `empirical_models` that provides a map from $M_{\\rm vir}^{\\rm host}$ to $R_{\\rm vir}.$ We will use these two functions together to draw a sphere of radius $R_{\\rm vir}$ around each galaxy; a galaxy will be said to be isolated if there are no other galaxies in the sample within this search radius. Of course, some of the galaxies in our sample are not central galaxies, and there is also scatter between $M_{\\ast}^{\\rm cen}$ and $M_{\\rm vir}^{\\rm host},$ and so this criteria will not be perfect; since you know the true central/satellite designation in the mock, you can always test this assumption with a standard purity/completeness analysis. \n",
+    "\n",
+    "Let's select a sample of galaxies with $M_{\\ast}>10^{10}M_{\\odot},$ and focus on identifying isolated galaxies in a specific stellar mass range of $10^{10.4}M_{\\odot} < M_{\\ast} < 10^{10.5}M_{\\odot}:$ "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_gal_mask = model.mock.galaxy_table['stellar_mass'] > 1e10\n",
+    "all_gals = model.mock.galaxy_table[all_gal_mask]\n",
+    "\n",
+    "sample_mask = (all_gals['stellar_mass'] > 4e10) & (all_gals['stellar_mass'] < 5e10)\n",
+    "sm_selected_gals = all_gals[sample_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logsm = np.log10(sm_selected_gals['stellar_mass'])\n",
+    "presumed_mvir = 10**model.mean_log_halo_mass(logsm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.empirical_models import halo_mass_to_halo_radius"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "presumed_rvir = halo_mass_to_halo_radius(presumed_mvir, \n",
+    "                cosmology = model.mock.cosmology, \n",
+    "                redshift = model.mock.redshift, \n",
+    "                mdef = 'vir')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.mock_observables import conditional_spherical_isolation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The calling signature of `conditional_spherical_isolation` accepts a multi-dimensional array storing the x, y, z positions of each point. You can place your points into the appropriate form using `np.vstack([x, y, z]).T`, but below we'll demo how to use the `~halotools.mock_observables.return_xyz_formatted_array` function for this purpose, as this function provides additional convenient behavior that we'll use later in the tutorial. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.mock_observables import return_xyz_formatted_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample1_pos = return_xyz_formatted_array(sm_selected_gals['x'], sm_selected_gals['y'], sm_selected_gals['z'])\n",
+    "sample2_pos = return_xyz_formatted_array(all_gals['x'], all_gals['y'], all_gals['z'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, presumed_rvir, period = model.mock.Lbox)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The boolean-valued array `is_isolated` is equal to `True` for those galaxies in `sm_selected_gals` with zero other galaxies located within a sphere of their presumed value of $R_{\\rm vir}.$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 2: $M_{\\ast}-$dependent isolation criteria"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this next example we'll show how to apply an isolation criterion that depends on the stellar mass of the galaxies. This calculation, as well as the remaining ones in this tutorial, will make use of Halotools marking functions. The way this works is as follows. Every galaxy in both `sample1` and `sample2` are given a \"mark\"; arrays storing these marks are passed to the `conditional_spherical_isolation` function together with the normal arrays storing galaxy positions. Additionally, you must select a \"condition function\", $f;$ the condition function $f$ acceps a mark $m_{1}$ from a galaxy in `sample1` and a mark $m_{2}$ from a galaxy in `sample2` and returns a boolean. For each galaxy in ``sample1``, the `conditional_spherical_isolation` function searches ``sample2`` for spatially nearby neighbors. A galaxy in `sample2` will only be considered as a candidate neighbor if it lies within the `r_max` value of the point in `sample1` *and* if the marking function $f(m_{1}, m_{2})$ returns `True`.\n",
+    "\n",
+    "For example, suppose we define the conditional function to be $f(m_{1}, m_{2}) = {\\rm True}$ if $m_{1} < m_{2}$ and `False` otherwise, and suppose that for our marks we passed in the stellar mass $M_{\\ast}$ of each galaxy. When evaluating whether some galaxy in `sample1` is isolated, what this choice for the conditional function would do is to ignore all those galaxies in `sample2` that are less massive than the `sample1` galaxy under consideration. So with this choice, the adopted definition of isolation is whether or not a *more massive galaxy* resides within some search radius. Let's see how to apply this isolation criterion to the galaxy samples defined above. \n",
+    "\n",
+    "For simplicity, we'll select a fixed `r_max`, but you are free to apply variable values of `r_max` together with the conditional function formalism. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r_max = 0.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marks1 = sm_selected_gals['stellar_mass']\n",
+    "marks2 = all_gals['stellar_mass']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cond_func = 2 # See the docstring of conditional_spherical_isolation for the function <==> function ID correspondence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max, \n",
+    "                    marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 3: Alternative $M_{\\ast}-$dependent isolation criteria"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, we'll do a similar calculation to the one above, except we'll make a slight variation to the definition of isolation: a galaxy in `sample1` will be said to be isolated if there are no `sample2` galaxies more massive than $M_{\\ast} + $0.5dex within 1 Mpc/h of the galaxy in `sample1`. \n",
+    "\n",
+    "For this calculation, we'll need to use `cond_func` = 6, which is defined as $f(m^{a}_{1}, m^{b}_{1}, m^{a}_{2}, m^{b}_{2}) = {\\rm True}$ if $m^{a}_{1} < m^{b}_{1} + m^{a}_{2},$ and `False` otherwise. For $m^{a}_{i}$ we will pass in $\\log_{10}(M_{\\ast}),$ and for $m^{b}_{i}$ we pass in $0.5.$ We will bundle the marks into a multi-dimensional Numpy array using the same `np.vstack` method we used to bundle our spatial positions into a *Npts x 3* array."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marks1 = np.vstack([np.log10(sm_selected_gals['stellar_mass']), np.zeros(len(sm_selected_gals))+0.5]).T\n",
+    "marks2 = np.vstack([np.log10(all_gals['stellar_mass']), np.zeros(len(all_gals))+0.5]).T"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cond_func = 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max, \n",
+    "                    marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4: $M_{\\ast}-$dependent isolation criteria in redshift-space"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will conclude this tutorial by putting together all of the features of the `isolation_functions` sub-package into a single,  observationally realistic example. We will demonstrate how to apply the following isolation criteria on a mock galaxy sample:\n",
+    "\n",
+    "Around each `sample1` galaxy with stellar mass $M_{\\ast}$, we will draw a cylinder of radius $2R_{\\rm vir}$ and length $3V_{\\rm vir},$ where $R_{\\rm vir}$ and $V_{\\rm vir}$ are the virial radius and velocity inferred from the underlying stellar-to-halo mass relation. In order for a `sample1` galaxy to be isolated, there must be no other `sample2` galaxies more massive than $0.5$dex within this cylinder. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.empirical_models import halo_mass_to_virial_velocity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "presumed_vvir = halo_mass_to_virial_velocity(presumed_mvir, \n",
+    "                cosmology = model.mock.cosmology, \n",
+    "                redshift = model.mock.redshift, \n",
+    "                mdef = 'vir')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The units of `presumed_vvir` are in km/s, so we must convert these to units of length. Recall that *h=1* and that all Halotools length-units are in Mpc/h. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "H0 = 100.0 # Hubble constant in h=1 units of km/s/Mpc\n",
+    "pi_max = 3*presumed_vvir/H0\n",
+    "rp_max = 2*presumed_rvir"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Our marks and `cond_func` are the same as before, repeated below for convenience:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "marks1 = np.vstack([np.log10(sm_selected_gals['stellar_mass']), np.zeros(len(sm_selected_gals))+0.5]).T\n",
+    "marks2 = np.vstack([np.log10(all_gals['stellar_mass']), np.zeros(len(all_gals))+0.5]).T\n",
+    "\n",
+    "cond_func = 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from halotools.mock_observables import conditional_cylindrical_isolation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_isolated = conditional_cylindrical_isolation(sample1_pos, sample2_pos, rp_max, pi_max, \n",
+    "                    marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [default]",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/intermediate_examples/isolation_criteria/galaxy_catalog_intermediate_analysis_tutorial1.rst
+++ b/docs/quickstart_and_tutorials/tutorials/catalog_analysis/galcat_analysis/intermediate_examples/isolation_criteria/galaxy_catalog_intermediate_analysis_tutorial1.rst
@@ -11,18 +11,18 @@ may wish to have an isolation criterion that depends on the stellar mass
 of the galaxy in question. This tutorial gives several examples of how
 to apply such a condition to a mock galaxy sample.
 
-This is a companion tutorial to :ref:`galaxy_catalog_analysis_tutorial10`. 
-Be sure you have read and understand that tutorial before proceeding. 
+This is a companion tutorial to :ref:`galaxy_catalog_analysis_tutorial10`.
+Be sure you have read and understand that tutorial before proceeding.
 
-There is also an IPython Notebook in the following location that can be 
+There is also an IPython Notebook in the following location that can be
 used as a companion to the material in this section of the tutorial:
 
 
     **halotools/docs/notebooks/galcat_analysis/intermediate_examples/galaxy_catalog_intermediate_analysis_tutorial1.ipynb**
 
-By following this tutorial together with this notebook, 
-you can play around with your own variations of the calculation 
-as you learn the basic syntax. 
+By following this tutorial together with this notebook,
+you can play around with your own variations of the calculation
+as you learn the basic syntax.
 
 Generate a mock galaxy catalog
 ------------------------------
@@ -38,8 +38,8 @@ default halo catalog.
     model = PrebuiltSubhaloModelFactory('smhm_binary_sfr')
 
     from halotools.sim_manager import CachedHaloCatalog
-    halocat = CachedHaloCatalog(simname = 'bolshoi', redshift = 0, halo_finder = 'rockstar')
-    
+    halocat = CachedHaloCatalog(simname='bolshoi', redshift=0, halo_finder = 'rockstar')
+
     model.populate_mock(halocat)
 
 
@@ -49,11 +49,11 @@ Example 1: Variable isolation criteria in 3d
 For the first example we'll find "isolated" galaxies using a 3d search
 criteria that depends on stellar mass in the following manner. From our
 mock, we know the stellar mass of every galaxy. The stellar mass component of the underlying model
-that generated the mock, `halotools.empirical_models.Behroozi10SmHm`, 
-has a `halotools.empirical_models.Behroozi10SmHm.mean_log_halo_mass` 
+that generated the mock, `halotools.empirical_models.Behroozi10SmHm`,
+has a `halotools.empirical_models.Behroozi10SmHm.mean_log_halo_mass`
 method that provides a map from :math:`M_{\ast}^{\rm cen}` to
 :math:`M_{\rm vir}^{\rm host}.` There is also a
-`~halotools.empirical_models.halo_mass_to_halo_radius` function 
+`~halotools.empirical_models.halo_mass_to_halo_radius` function
 in `~halotools.empirical_models` that provides a map from :math:`M_{\rm vir}^{\rm host}` to
 :math:`R_{\rm vir}.` We will use these two functions together to draw a
 sphere of radius :math:`R_{\rm vir}` around each galaxy; a galaxy will
@@ -74,7 +74,7 @@ galaxies in a specific stellar mass range of
 
     all_gal_mask = model.mock.galaxy_table['stellar_mass'] > 1e10
     all_gals = model.mock.galaxy_table[all_gal_mask]
-    
+
     sample_mask = (all_gals['stellar_mass'] > 4e10) & (all_gals['stellar_mass'] < 5e10)
     sm_selected_gals = all_gals[sample_mask]
 
@@ -83,14 +83,14 @@ galaxies in a specific stellar mass range of
 
     from halotools.empirical_models import halo_mass_to_halo_radius
 
-    presumed_rvir = halo_mass_to_halo_radius(presumed_mvir, 
-                    cosmology = model.mock.cosmology, 
-                    redshift = model.mock.redshift, 
+    presumed_rvir = halo_mass_to_halo_radius(presumed_mvir,
+                    cosmology = model.mock.cosmology,
+                    redshift = model.mock.redshift,
                     mdef = 'vir')
 
     from halotools.mock_observables import conditional_spherical_isolation
 
-The calling signature of `~halotools.mock_observables.conditional_spherical_isolation` 
+The calling signature of `~halotools.mock_observables.conditional_spherical_isolation`
 accepts a multi-dimensional array storing the x, y, z positions of each point. You
 can place your points into the appropriate form using
 `numpy.vstack`, but below we'll demo how to use the
@@ -154,13 +154,13 @@ function formalism.
     marks1 = sm_selected_gals['stellar_mass']
     marks2 = all_gals['stellar_mass']
 
-Now we select the value of ``cond_func`` for the conditional function described above. 
-See the docstring of `~halotools.mock_observables.conditional_spherical_isolation` 
-for the function <==> function ID correspondence. 
+Now we select the value of ``cond_func`` for the conditional function described above.
+See the docstring of `~halotools.mock_observables.conditional_spherical_isolation`
+for the function <==> function ID correspondence.
 
     cond_func = 2
 
-    is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max, 
+    is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max,
                         marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)
 
 Example 3: Alternative :math:`M_{\ast}` dependent isolation criteria
@@ -172,10 +172,10 @@ in ``sample1`` will be said to be isolated if there are no ``sample2``
 galaxies more massive than :math:`M_{\ast}` + *0.5dex* within 1
 Mpc/h of the galaxy in ``sample1``.
 
-For this calculation, we'll need to use ``cond_func`` = 5, which is
+For this calculation, we'll need to use ``cond_func`` = 6, which is
 defined as
 :math:`f(m^{a}_{1}, m^{b}_{1}, m^{a}_{2}, m^{b}_{2}) = {\rm True}` if
-:math:`m^{a}_{1} > m^{a}_{2} + m^{b}_{2},` and ``False`` otherwise. For
+:math:`m^{a}_{1} < m^{a}_{2} + m^{b}_{1},` and ``False`` otherwise. For
 :math:`m^{a}_{i}` we will pass in :math:`\log_{10}(M_{\ast}),` and for
 :math:`m^{b}_{i}` we pass in :math:`0.5.` We will bundle the marks into
 a multi-dimensional Numpy array using the same `numpy.vstack` method we
@@ -186,9 +186,9 @@ used to bundle our spatial positions into a *Npts x 3* array.
     marks1 = np.vstack([np.log10(sm_selected_gals['stellar_mass']), np.zeros(len(sm_selected_gals))+0.5]).T
     marks2 = np.vstack([np.log10(all_gals['stellar_mass']), np.zeros(len(all_gals))+0.5]).T
 
-    cond_func = 5
+    cond_func = 6
 
-    is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max, 
+    is_isolated = conditional_spherical_isolation(sample1_pos, sample2_pos, r_max,
                         marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)
 
 Example 4: :math:`M_{\ast}` dependent isolation criteria in redshift-space
@@ -207,17 +207,17 @@ stellar-to-halo mass relation. In order for a ``sample1`` galaxy to be
 isolated, there must be no other ``sample2`` galaxies more massive than
 *0.5* dex within this cylinder.
 
-We already computed :math:`R_{\rm vir}` above; 
-we will compute :math:`V_{\rm vir}` using the 
+We already computed :math:`R_{\rm vir}` above;
+we will compute :math:`V_{\rm vir}` using the
 `~halotools.mock_observables.halo_mass_to_virial_velocity` function:
 
 .. code:: python
 
     from halotools.empirical_models import halo_mass_to_virial_velocity
 
-    presumed_vvir = halo_mass_to_virial_velocity(presumed_mvir, 
-                    cosmology = model.mock.cosmology, 
-                    redshift = model.mock.redshift, 
+    presumed_vvir = halo_mass_to_virial_velocity(presumed_mvir,
+                    cosmology = model.mock.cosmology,
+                    redshift = model.mock.redshift,
                     mdef = 'vir')
 
 The units of ``presumed_vvir`` are in km/s, so we must convert these to
@@ -236,10 +236,10 @@ Our marks and ``cond_func`` are the same as before, repeated below for convenien
 
     marks1 = np.vstack([np.log10(sm_selected_gals['stellar_mass']), np.zeros(len(sm_selected_gals))+0.5]).T
     marks2 = np.vstack([np.log10(all_gals['stellar_mass']), np.zeros(len(all_gals))+0.5]).T
-    
-    cond_func = 5
+
+    cond_func = 6
 
     from halotools.mock_observables import conditional_cylindrical_isolation
 
-    is_isolated = conditional_cylindrical_isolation(sample1_pos, sample2_pos, rp_max, pi_max, 
+    is_isolated = conditional_cylindrical_isolation(sample1_pos, sample2_pos, rp_max, pi_max,
                         marks1=marks1, marks2=marks2, cond_func=cond_func, period = model.mock.Lbox)


### PR DESCRIPTION
The tutorial incorrectly wrote `cond_func=5` instead of `cond_func=6` when describing how to implement stellar mass-dependent isolation criteria. This PR fixes the documentation. 