### PR TITLE
Removing superflous dependencies from CONDA_DEPENDENCIES

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "numpy cython sphinx pytest h5py beautifulsoup4 requests astropy scipy"
+      CONDA_DEPENDENCIES: "cython h5py beautifulsoup4 requests scipy"
 
   matrix:
 


### PR DESCRIPTION
This should fix #773 (actually is just a workaround).

You don't need to list numpy and astropy as those are taken care of with ``NUMPY_VERSION`` and ``ASTROPY_VERSION``. Also pytest is always installed by ci-helpers, as well as sphinx when it's a documentation build.