### PR TITLE
Isolation brute force

### DIFF
--- a/halotools/mock_observables/isolation_functions/cylindrical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/cylindrical_isolation.py
@@ -221,8 +221,8 @@ def _cylindrical_isolation_process_args(sample1, sample2, rp_max, pi_max, period
     if period is None:
         x1, y1, z1, x2, y2, z2, period = (
             _enclose_in_box(
-                sample1[:, 0], sample1[:, 2], sample1[:, 2],
-                sample2[:, 0], sample2[:, 2], sample2[:, 2],
+                sample1[:, 0], sample1[:, 1], sample1[:, 2],
+                sample2[:, 0], sample2[:, 1], sample2[:, 2],
                 min_size=[max_rp_max*3.0, max_rp_max*3.0, max_pi_max*3.0]))
     else:
         x1 = sample1[:, 0]

--- a/halotools/mock_observables/isolation_functions/spherical_isolation.py
+++ b/halotools/mock_observables/isolation_functions/spherical_isolation.py
@@ -204,8 +204,8 @@ def _spherical_isolation_process_args(sample1, sample2, r_max, period,
     if period is None:
         x1, y1, z1, x2, y2, z2, period = (
             _enclose_in_box(
-                sample1[:, 0], sample1[:, 2], sample1[:, 2],
-                sample2[:, 0], sample2[:, 2], sample2[:, 2],
+                sample1[:, 0], sample1[:, 1], sample1[:, 2],
+                sample2[:, 0], sample2[:, 1], sample2[:, 2],
                 min_size=[max_r_max*3.0, max_r_max*3.0, max_r_max*3.0]))
     else:
         x1 = sample1[:, 0]

--- a/halotools/mock_observables/isolation_functions/tests/pure_python_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/pure_python_isolation.py
@@ -23,3 +23,24 @@ def naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
             is_isolated[i] = True
     return is_isolated
 
+
+def naive_cylindrical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        rp_max, pi_max, xperiod, yperiod, zperiod):
+    """
+    """
+    npts1 = len(x1arr)
+    is_isolated = np.zeros(npts1, dtype=bool)
+    for i, x1, y1, z1 in zip(range(npts1), x1arr, y1arr, z1arr):
+        dx = np.abs(x2arr - x1)
+        dy = np.abs(y2arr - y1)
+        dz = np.abs(z2arr - z1)
+        dx = np.where(dx > xperiod/2., xperiod - dx, dx)
+        dy = np.where(dy > yperiod/2., yperiod - dy, dy)
+        dz = np.where(dz > zperiod/2., zperiod - dz, dz)
+        dxy = np.sqrt(dx**2 + dy**2)
+
+        if np.any((dxy < rp_max) & (dz < pi_max)):
+            is_isolated[i] = False
+        else:
+            is_isolated[i] = True
+    return is_isolated

--- a/halotools/mock_observables/isolation_functions/tests/pure_python_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/pure_python_isolation.py
@@ -1,0 +1,25 @@
+"""
+"""
+import numpy as np
+
+
+def naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        rmax, xperiod, yperiod, zperiod):
+    """
+    """
+    npts1 = len(x1arr)
+    is_isolated = np.zeros(npts1, dtype=bool)
+    for i, x1, y1, z1 in zip(range(npts1), x1arr, y1arr, z1arr):
+        dx = np.abs(x2arr - x1)
+        dy = np.abs(y2arr - y1)
+        dz = np.abs(z2arr - z1)
+        dx = np.where(dx > xperiod/2., xperiod - dx, dx)
+        dy = np.where(dy > yperiod/2., yperiod - dy, dy)
+        dz = np.where(dz > zperiod/2., zperiod - dz, dz)
+        d = np.sqrt(dx**2 + dy**2 + dz**2)
+        if np.any(d < rmax):
+            is_isolated[i] = False
+        else:
+            is_isolated[i] = True
+    return is_isolated
+

--- a/halotools/mock_observables/isolation_functions/tests/test_brute_force_comparisons.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_brute_force_comparisons.py
@@ -1,0 +1,61 @@
+""" Module providing testing of isolation functions by comparing to naive serial algorithms
+implemented in pure python
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from astropy.utils.misc import NumpyRNGContext
+
+from .pure_python_isolation import naive_spherical_isolation
+
+from ..spherical_isolation import spherical_isolation
+
+
+__all__ = ('test_spherical_isolation1', )
+fixed_seed = 43
+
+
+def test_spherical_isolation1():
+    """
+    """
+    npts1, npts2 = 100, 103
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
+
+    r_max = 0.2
+    iso1 = spherical_isolation(sample1, sample2, r_max, period=1)
+
+    x1arr, y1arr, z1arr = sample1[:, 0], sample1[:, 1], sample1[:, 2]
+    x2arr, y2arr, z2arr = sample2[:, 0], sample2[:, 1], sample2[:, 2]
+    xperiod, yperiod, zperiod = 1, 1, 1
+    iso2 = naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        r_max, xperiod, yperiod, zperiod)
+
+    assert np.all(iso1 == iso2)
+    #  ensure the test is non-trivial
+    assert np.any(iso1)
+    assert not np.all(iso1)
+
+
+def test_spherical_isolation2():
+    """
+    """
+    npts1, npts2 = 100, 103
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
+
+    r_max = 0.2
+    iso1 = spherical_isolation(sample1, sample2, r_max, period=None)
+
+    x1arr, y1arr, z1arr = sample1[:, 0], sample1[:, 1], sample1[:, 2]
+    x2arr, y2arr, z2arr = sample2[:, 0], sample2[:, 1], sample2[:, 2]
+    xperiod, yperiod, zperiod = np.inf, np.inf, np.inf
+    iso2 = naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        r_max, xperiod, yperiod, zperiod)
+
+    assert np.all(iso1 == iso2)
+    #  ensure the test is non-trivial
+    assert np.any(iso1)
+    assert not np.all(iso1)

--- a/halotools/mock_observables/isolation_functions/tests/test_brute_force_comparisons.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_brute_force_comparisons.py
@@ -6,9 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
-from .pure_python_isolation import naive_spherical_isolation
+from .pure_python_isolation import naive_spherical_isolation, naive_cylindrical_isolation
 
 from ..spherical_isolation import spherical_isolation
+from ..cylindrical_isolation import cylindrical_isolation
 
 
 __all__ = ('test_spherical_isolation1', )
@@ -59,3 +60,50 @@ def test_spherical_isolation2():
     #  ensure the test is non-trivial
     assert np.any(iso1)
     assert not np.all(iso1)
+
+
+def test_cylindrical_isolation1():
+    """
+    """
+    npts1, npts2 = 100, 103
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
+
+    rp_max, pi_max = 0.2, 0.2
+    iso1 = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=1)
+
+    x1arr, y1arr, z1arr = sample1[:, 0], sample1[:, 1], sample1[:, 2]
+    x2arr, y2arr, z2arr = sample2[:, 0], sample2[:, 1], sample2[:, 2]
+    xperiod, yperiod, zperiod = 1, 1, 1
+    iso2 = naive_cylindrical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        rp_max, pi_max, xperiod, yperiod, zperiod)
+
+    assert np.all(iso1 == iso2)
+    #  ensure the test is non-trivial
+    assert np.any(iso1)
+    assert not np.all(iso1)
+
+
+def test_cylindrical_isolation2():
+    """
+    """
+    npts1, npts2 = 100, 103
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((npts1, 3))
+        sample2 = np.random.random((npts2, 3))
+
+    rp_max, pi_max = 0.2, 0.2
+    iso1 = cylindrical_isolation(sample1, sample2, rp_max, pi_max, period=None)
+
+    x1arr, y1arr, z1arr = sample1[:, 0], sample1[:, 1], sample1[:, 2]
+    x2arr, y2arr, z2arr = sample2[:, 0], sample2[:, 1], sample2[:, 2]
+    xperiod, yperiod, zperiod = np.inf, np.inf, np.inf
+    iso2 = naive_cylindrical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        rp_max, pi_max, xperiod, yperiod, zperiod)
+
+    assert np.all(iso1 == iso2)
+    #  ensure the test is non-trivial
+    assert np.any(iso1)
+    assert not np.all(iso1)
+

--- a/halotools/mock_observables/isolation_functions/tests/test_pure_python_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_pure_python_isolation.py
@@ -1,0 +1,30 @@
+""" Module providing testing for the brute force isolation functions
+"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from astropy.utils.misc import NumpyRNGContext
+
+from .pure_python_isolation import naive_spherical_isolation
+
+from ...tests.cf_helpers import generate_locus_of_3d_points, generate_3d_regular_mesh
+
+__all__ = ('test_naive_spherical_isolation1', )
+
+fixed_seed = 43
+
+
+def test_naive_spherical_isolation1():
+    npts1, npts2 = 50, 45
+    with NumpyRNGContext(fixed_seed):
+        x1arr = np.random.rand(npts1)
+        y1arr = np.random.rand(npts1)
+        z1arr = np.random.rand(npts1)
+        x2arr = np.random.rand(npts2)
+        y2arr = np.random.rand(npts2)
+        z2arr = np.random.rand(npts2)
+
+    rmax = 0.25
+    xperiod, yperiod, zperiod = 1, 1, 1
+    result = naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        rmax, xperiod, yperiod, zperiod)

--- a/halotools/mock_observables/isolation_functions/tests/test_pure_python_isolation.py
+++ b/halotools/mock_observables/isolation_functions/tests/test_pure_python_isolation.py
@@ -15,16 +15,33 @@ fixed_seed = 43
 
 
 def test_naive_spherical_isolation1():
-    npts1, npts2 = 50, 45
-    with NumpyRNGContext(fixed_seed):
-        x1arr = np.random.rand(npts1)
-        y1arr = np.random.rand(npts1)
-        z1arr = np.random.rand(npts1)
-        x2arr = np.random.rand(npts2)
-        y2arr = np.random.rand(npts2)
-        z2arr = np.random.rand(npts2)
+    npts2 = 45
+    sample1 = generate_3d_regular_mesh(5)  #  0.1, 0.3, 0.5, 0.7, 0.9
+    npts1 = sample1.shape[0]
+    sample2 = generate_locus_of_3d_points(npts2, xc=0.101, yc=0.3, zc=0.3)
+    x1arr, y1arr, z1arr = sample1[:, 0], sample1[:, 1], sample1[:, 2]
+    x2arr, y2arr, z2arr = sample2[:, 0], sample2[:, 1], sample2[:, 2]
 
-    rmax = 0.25
+    rmax = 0.02
     xperiod, yperiod, zperiod = 1, 1, 1
     result = naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
         rmax, xperiod, yperiod, zperiod)
+    assert result.sum() == npts1 - 1
+
+
+def test_naive_spherical_isolation2():
+    npts2 = 45
+    sample1 = generate_3d_regular_mesh(5)  #  0.1, 0.3, 0.5, 0.7, 0.9
+    npts1 = sample1.shape[0]
+    sample2a = generate_locus_of_3d_points(npts2, xc=0.101, yc=0.3, zc=0.3)
+    sample2b = generate_locus_of_3d_points(npts2, xc=0.301, yc=0.3, zc=0.3)
+    sample2c = generate_locus_of_3d_points(npts2, xc=0.501, yc=0.3, zc=0.3)
+    sample2 = np.concatenate((sample2a, sample2b, sample2c))
+    x1arr, y1arr, z1arr = sample1[:, 0], sample1[:, 1], sample1[:, 2]
+    x2arr, y2arr, z2arr = sample2[:, 0], sample2[:, 1], sample2[:, 2]
+
+    rmax = 0.02
+    xperiod, yperiod, zperiod = 1, 1, 1
+    result = naive_spherical_isolation(x1arr, y1arr, z1arr, x2arr, y2arr, z2arr,
+        rmax, xperiod, yperiod, zperiod)
+    assert result.sum() == npts1 - 3


### PR DESCRIPTION
Fixed bug raised in #776. 

Error was very simple, and only relevant to users calculating isolation criteria without periodic boundary conditions. In the initial argument processing of both `spherical_isolation` and `cylindrical_isolation` functions:

`
x1, y2, z1 = sample1[:, 0], sample1[:, 2], sample1[:, 2]
`
has now been corrected to 
`
x1, y2, z1 = sample1[:, 0], sample1[:, 1], sample1[:, 2]
`

This bug was not revealed by the test suite prior to now because there was no brute force testing on a random set of points comparing to a pure python implementation of a naive isolation algorithm for non-PBC case. This PR also adds this brute force testing, for both periodic and non-periodic cases. These newly-introduced tests failed when the old code was run against them; now they pass. So these will serve as regression tests. 