### PR TITLE
Delete `max_sample_size` feature from `mock_observables`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Added new `mock_observables` functions `radial_distance` and `radial_distance_and_velocity` functions. See https://github.com/astropy/halotools/pull/782
 
+- Removed `max_sample_size` keyword argument from all `mock_observables` functions.
+
 
 0.5 (2017-05-31)
 ----------------

--- a/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
@@ -21,7 +21,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 
 def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
         velocities2=None, period=None, do_auto=True, do_cross=True,
-        num_threads=1, max_sample_size=int(1e6),
+        num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None, seed=None):
     r"""
     Calculate the pairwise line-of-sight (LOS) velocity dispersion (PVD), :math:`\sigma_{z12}(r_p)`.
@@ -62,11 +62,6 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
     num_threads : int, optional
         number of threads to use in calculation. Default is 1. A string 'max' may be used
         to indicate that the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size, the sample will be randomly down-sampled
-        such that the subsample is equal to max_sample_size.
 
     seed : int, optional
         Random number seed used to randomly downsample data, if applicable.
@@ -142,7 +137,7 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
 
     # process input arguments
     function_args = (sample1, velocities1, sample2, velocities2, period,
-        do_auto, do_cross, num_threads, max_sample_size,
+        do_auto, do_cross, num_threads,
         approx_cell1_size, approx_cell2_size, seed)
     sample1, velocities1, sample2, velocities2,\
         period, do_auto, do_cross,\

--- a/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
@@ -21,7 +21,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero
 def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
         sample2=None, velocities2=None,
         period=None, do_auto=True, do_cross=True,
-        num_threads=1, max_sample_size=int(1e6),
+        num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None, seed=None):
     r"""
     Calculate the mean pairwise line-of-sight (LOS) velocity
@@ -63,11 +63,6 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
     num_threads : int, optional
         number of threads to use in calculation. Default is 1. A string 'max' may be used
         to indicate that the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size, the sample will be randomly down-sampled
-        such that the subsample is equal to max_sample_size.
 
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
@@ -140,7 +135,7 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
     """
 
     function_args = (sample1, velocities1, sample2, velocities2, period,
-        do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size, seed)
+        do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size, seed)
 
     sample1, velocities1, sample2, velocities2, period, do_auto, do_cross,\
         num_threads, _sample1_is_sample2, PBCs = _pairwise_velocity_stats_process_args(*function_args)

--- a/halotools/mock_observables/pairwise_velocities/pairwise_velocities_helpers.py
+++ b/halotools/mock_observables/pairwise_velocities/pairwise_velocities_helpers.py
@@ -19,7 +19,7 @@ __author__ = ['Duncan Campbell']
 
 
 def _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size, seed):
+        period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.pairwise_velocity_stats`.
@@ -48,34 +48,6 @@ def _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocit
         sample2 = sample1
         velocities2 = velocities1
         _sample1_is_sample2 = True
-
-    # down sample if sample size exceeds max_sample_size.
-    if _sample1_is_sample2 is True:
-        if (len(sample1) > max_sample_size):
-            inds = np.arange(0, len(sample1))
-            with NumpyRNGContext(seed):
-                np.random.shuffle(inds)
-            inds = inds[0:max_sample_size]
-            sample1 = sample1[inds]
-            velocities1 = velocities1[inds]
-            print('\n downsampling `sample1`...')
-    else:
-        if len(sample1) > max_sample_size:
-            inds = np.arange(0, len(sample1))
-            with NumpyRNGContext(seed):
-                np.random.shuffle(inds)
-            inds = inds[0:max_sample_size]
-            sample1 = sample1[inds]
-            velocities1 = velocities1[inds]
-            print('\n downsampling `sample1`...')
-        if len(sample2) > max_sample_size:
-            inds = np.arange(0, len(sample2))
-            with NumpyRNGContext(seed):
-                np.random.shuffle(inds)
-            inds = inds[0:max_sample_size]
-            sample2 = sample2[inds]
-            velocities2 = velocities2[inds]
-            print('\n downsampling `sample2`...')
 
     period, PBCs = get_period(period)
 

--- a/halotools/mock_observables/pairwise_velocities/tests/test_pairwise_velocity_helpers.py
+++ b/halotools/mock_observables/pairwise_velocities/tests/test_pairwise_velocity_helpers.py
@@ -17,7 +17,6 @@ def test_pairwise_velocity_stats_process_args1():
     do_auto = False
     do_cross = False
     num_threads = 1
-    max_sample_size = int(1e5)
     approx_cell1_size = 0.1
     approx_cell2_size = 0.1
 
@@ -29,7 +28,7 @@ def test_pairwise_velocity_stats_process_args1():
 
     with pytest.raises(ValueError) as err:
         result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-            period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+            period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size,
             fixed_seed)
     substr = "Both ``do_auto`` and ``do_cross`` have been set to False"
     assert substr in err.value.args[0]
@@ -40,7 +39,6 @@ def test_pairwise_velocity_stats_process_args2():
     do_auto = True
     do_cross = False
     num_threads = 1
-    max_sample_size = int(1e5)
     approx_cell1_size = 0.1
     approx_cell2_size = 0.1
 
@@ -51,7 +49,7 @@ def test_pairwise_velocity_stats_process_args2():
         velocities2 = np.random.random((10, 3))
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, None, None,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size,
         fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
@@ -63,7 +61,6 @@ def test_pairwise_velocity_stats_process_args3():
     do_auto = True
     do_cross = False
     num_threads = 1
-    max_sample_size = int(1e5)
     approx_cell1_size = 0.1
     approx_cell2_size = 0.1
 
@@ -74,7 +71,7 @@ def test_pairwise_velocity_stats_process_args3():
         velocities2 = np.random.random((10, 3))
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size,
         fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
@@ -85,7 +82,6 @@ def test_pairwise_velocity_stats_process_args4():
     do_auto = True
     do_cross = False
     num_threads = 1
-    max_sample_size = int(1e5)
     approx_cell1_size = 0.1
     approx_cell2_size = 0.1
 
@@ -95,16 +91,12 @@ def test_pairwise_velocity_stats_process_args4():
         sample2 = np.random.random((10, 3))
         velocities2 = np.random.random((10, 3))
 
-    max_sample_size = 5
-
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample2, velocities2,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size,
         fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
     assert _sample1_is_sample2 is False
-    assert len(sample1) == max_sample_size
-    assert len(sample2) == max_sample_size
 
 
 def test_pairwise_velocity_stats_process_args5():
@@ -112,7 +104,6 @@ def test_pairwise_velocity_stats_process_args5():
     do_auto = True
     do_cross = False
     num_threads = 1
-    max_sample_size = int(1e5)
     approx_cell1_size = 0.1
     approx_cell2_size = 0.1
 
@@ -122,10 +113,8 @@ def test_pairwise_velocity_stats_process_args5():
         sample2 = np.random.random((10, 3))
         velocities2 = np.random.random((10, 3))
 
-    max_sample_size = 5
-
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, None, None,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size,
         fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result
@@ -136,7 +125,6 @@ def test_pairwise_velocity_stats_process_args6():
     do_auto = True
     do_cross = False
     num_threads = 1
-    max_sample_size = int(1e5)
     approx_cell1_size = 0.1
     approx_cell2_size = 0.1
 
@@ -145,7 +133,7 @@ def test_pairwise_velocity_stats_process_args6():
         velocities1 = np.random.random((10, 3))
 
     result = _pairwise_velocity_stats_process_args(sample1, velocities1, sample1, velocities1,
-        period, do_auto, do_cross, num_threads, max_sample_size, approx_cell1_size, approx_cell2_size,
+        period, do_auto, do_cross, num_threads, approx_cell1_size, approx_cell2_size,
         fixed_seed)
     sample1, velocities1, sample2, velocities2, period, do_auto,\
         do_cross, num_threads, _sample1_is_sample2, PBCs = result

--- a/halotools/mock_observables/two_point_clustering/angular_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/angular_tpcf.py
@@ -5,12 +5,9 @@ calculate galaxy clustering as a function of angular separation.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
-from warnings import warn
-from astropy.utils.misc import NumpyRNGContext
 
 from .tpcf_estimators import _TP_estimator_requirements, _TP_estimator
-from .clustering_helpers import (verify_tpcf_estimator,
-    downsample_inputs_exceeding_max_sample_size, process_optional_input_sample2)
+from .clustering_helpers import (verify_tpcf_estimator, process_optional_input_sample2)
 
 
 from ..pair_counters import npairs_3d
@@ -27,8 +24,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 
 def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
-        do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
-        max_sample_size=int(1e6), seed=None):
+        do_auto=True, do_cross=True, estimator='Natural', num_threads=1, seed=None):
     r"""
     Calculate the angular two-point correlation function, :math:`w(\theta)`.
 
@@ -76,12 +72,6 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
 
     seed : int, optional
         Random number seed used to randomly downsample data, if applicable.
@@ -138,7 +128,7 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
 
     # check input arguments using clustering helper functions
     function_args = (sample1, theta_bins, sample2, randoms, do_auto, do_cross,
-        estimator, num_threads, max_sample_size, seed)
+        estimator, num_threads, seed)
 
     # pass arguments in, and get out processed arguments, plus some control flow variables
     sample1, theta_bins, sample2, randoms, do_auto, do_cross, num_threads,\
@@ -290,7 +280,7 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
 
 
 def _angular_tpcf_process_args(sample1, theta_bins, sample2, randoms,
-        do_auto, do_cross, estimator, num_threads, max_sample_size, seed):
+        do_auto, do_cross, estimator, num_threads, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.angular_tpcf`.
@@ -303,9 +293,6 @@ def _angular_tpcf_process_args(sample1, theta_bins, sample2, randoms,
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     theta_bins = np.atleast_1d(theta_bins)
     theta_max = np.max(theta_bins)

--- a/halotools/mock_observables/two_point_clustering/clustering_helpers.py
+++ b/halotools/mock_observables/two_point_clustering/clustering_helpers.py
@@ -6,12 +6,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from warnings import warn
-from astropy.utils.misc import NumpyRNGContext
 
 from ..mock_observables_helpers import enforce_sample_has_correct_shape
 
-__all__ = ('verify_tpcf_estimator', 'process_optional_input_sample2',
-    'downsample_inputs_exceeding_max_sample_size')
+__all__ = ('verify_tpcf_estimator', 'process_optional_input_sample2')
 
 __author__ = ['Duncan Campbell', 'Andrew Hearin']
 
@@ -38,7 +36,7 @@ def verify_tpcf_estimator(estimator):
     if estimator in available_estimators:
         return estimator
     else:
-        msg = ("Your estimator ``{0}`` \n"
+        msg = (u"Your estimator ``{0}`` \n"
             "is not in the list of available estimators:\n {1}".format(estimator, available_estimators))
         raise ValueError(msg)
 
@@ -86,7 +84,7 @@ def process_optional_input_sample2(sample1, sample2, do_cross, ndim=3):
         else:
             if np.all(sample1 == sample2):
                 _sample1_is_sample2 = True
-                msg = ("\n `sample1` and `sample2` are exactly the same, \n"
+                msg = (u"\n `sample1` and `sample2` are exactly the same, \n"
                        "only the auto-correlation will be returned.\n")
                 warn(msg)
                 do_cross = False
@@ -94,68 +92,3 @@ def process_optional_input_sample2(sample1, sample2, do_cross, ndim=3):
                 _sample1_is_sample2 = False
 
     return sample2, _sample1_is_sample2, do_cross
-
-
-def downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=None):
-    """ Function used to downsample sample1 and/or sample2
-    if either samples exceed max_sample_size
-
-    Parameters
-    ----------
-    sample1 : array_like
-
-    sample2 : array_like
-
-    _sample1_is_sample2 : boolean
-
-    max_sample_size : int
-
-    seed : int, optional
-        Random number seed used to randomly downsample data.
-        Default is None, in which case downsampling will be stochastic.
-
-    Returns
-    ---------
-    sample1 : array_like
-
-    sample2 : array_like
-    """
-
-    if _sample1_is_sample2 is True:
-        if (len(sample1) > max_sample_size):
-            inds = np.arange(0, len(sample1))
-            with NumpyRNGContext(seed):
-                np.random.shuffle(inds)
-            inds = inds[0:max_sample_size]
-            sample1 = sample1[inds]
-            msg = ("\n `sample1` exceeds `max_sample_size` \n"
-                   "downsampling `sample1`...")
-            warn(msg)
-        else:
-            pass
-    else:
-        if len(sample1) > max_sample_size:
-            inds = np.arange(0, len(sample1))
-            with NumpyRNGContext(seed):
-                np.random.shuffle(inds)
-            inds = inds[0:max_sample_size]
-            sample1 = sample1[inds]
-            msg = ("\n `sample1` exceeds `max_sample_size` \n"
-                   "downsampling `sample1`...")
-            warn(msg)
-        else:
-            pass
-        if len(sample2) > max_sample_size:
-            inds = np.arange(0, len(sample2))
-            with NumpyRNGContext(seed):
-                np.random.shuffle(inds)
-            inds = inds[0:max_sample_size]
-            sample2 = sample2[inds]
-            msg = ("\n `sample2` exceeds `max_sample_size` \n"
-                   "downsampling `sample2`...")
-            warn(msg)
-        else:
-            pass
-
-    return sample1, sample2

--- a/halotools/mock_observables/two_point_clustering/marked_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/marked_tpcf.py
@@ -8,8 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
-from .clustering_helpers import (process_optional_input_sample2,
-    downsample_inputs_exceeding_max_sample_size)
+from .clustering_helpers import process_optional_input_sample2
 
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
     get_separation_bins_array, get_period, get_num_threads)
@@ -28,7 +27,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 def marked_tpcf(sample1, rbins, sample2=None,
         marks1=None, marks2=None, period=None, do_auto=True, do_cross=True,
-        num_threads=1, max_sample_size=int(1e6), weight_func_id=1,
+        num_threads=1, weight_func_id=1,
         normalize_by='random_marks', iterations=1, randomize_marks=None, seed=None):
     r"""
     Calculate the real space marked two-point correlation function, :math:`\mathcal{M}(r)`.
@@ -90,12 +89,6 @@ def marked_tpcf(sample1, rbins, sample2=None,
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
 
     weight_func_id : int, optional
         Integer ID indicating which marking function should be used.
@@ -307,7 +300,7 @@ def marked_tpcf(sample1, rbins, sample2=None,
 
     # process parameters
     function_args = (sample1, rbins, sample2, marks1, marks2,
-        period, do_auto, do_cross, num_threads, max_sample_size,
+        period, do_auto, do_cross, num_threads,
         weight_func_id, normalize_by, iterations, randomize_marks, seed)
     sample1, rbins, sample2, marks1, marks2, period, do_auto, do_cross, num_threads,\
         weight_func_id, normalize_by, _sample1_is_sample2, PBCs,\
@@ -492,7 +485,7 @@ def pair_counts(sample1, sample2, rbins, period, num_threads, do_auto, do_cross,
 
 
 def _marked_tpcf_process_args(sample1, rbins, sample2, marks1, marks2,
-        period, do_auto, do_cross, num_threads, max_sample_size,
+        period, do_auto, do_cross, num_threads,
         wfunc, normalize_by, iterations, randomize_marks, seed):
     """
     Private method to do bounds-checking on the arguments passed to
@@ -573,9 +566,6 @@ def _marked_tpcf_process_args(sample1, rbins, sample2, marks1, marks2,
     else:
         msg = ("\n `randomize_marks` must be one dimensional.")
         raise HalotoolsError(msg)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rbins = get_separation_bins_array(rbins)
     rmax = np.amax(rbins)

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
@@ -8,8 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from math import pi
 
-from .clustering_helpers import (process_optional_input_sample2,
-    downsample_inputs_exceeding_max_sample_size, verify_tpcf_estimator)
+from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
 
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
@@ -27,7 +26,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         period=None, do_auto=True, do_cross=True, estimator='Natural',
-        num_threads=1, max_sample_size=int(1e6), approx_cell1_size=None,
+        num_threads=1, approx_cell1_size=None,
         approx_cell2_size=None, approx_cellran_size=None, seed=None):
     r"""
     Calculate the redshift space correlation function, :math:`\xi(r_{p}, \pi)`
@@ -107,12 +106,6 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
 
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
-
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
         will be apportioned into subvolumes of the simulation box.
@@ -190,7 +183,7 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
     """
 
     function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
-        do_cross, estimator, num_threads, max_sample_size,
+        do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
 
     sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
@@ -350,7 +343,7 @@ def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
 
 
 def _rp_pi_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
-        period, do_auto, do_cross, estimator, num_threads, max_sample_size,
+        period, do_auto, do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
@@ -362,9 +355,6 @@ def _rp_pi_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rp_bins = get_separation_bins_array(rp_bins)
     rp_max = np.amax(rp_bins)

--- a/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
@@ -7,8 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 
 from .clustering_helpers import (process_optional_input_sample2,
-    downsample_inputs_exceeding_max_sample_size, verify_tpcf_estimator,
-    tpcf_estimator_dd_dr_rr_requirements)
+    verify_tpcf_estimator, tpcf_estimator_dd_dr_rr_requirements)
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
     get_separation_bins_array, get_line_of_sight_bins_array, get_period, get_num_threads)
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
@@ -24,7 +23,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         period=None, do_auto=True, do_cross=True, estimator='Natural',
-        num_threads=1, max_sample_size=int(1e6), approx_cell1_size=None,
+        num_threads=1, approx_cell1_size=None,
         approx_cell2_size=None, approx_cellran_size=None, seed=None):
     r"""
     Calculate the redshift space correlation function, :math:`\xi(s, \mu)`
@@ -101,12 +100,6 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
 
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
@@ -208,7 +201,7 @@ def s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None, randoms=None,
 
     # process arguments
     function_args = (sample1, s_bins, mu_bins, sample2, randoms, period,
-        do_auto, do_cross, estimator, num_threads, max_sample_size,
+        do_auto, do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
 
     sample1, s_bins, mu_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
@@ -265,7 +258,7 @@ def spherical_sector_volume(s, mu):
     Note that the extra factor of 2 is to get the reflection.
     """
     theta = np.arccos(mu)
-    
+
     vol = (2.0*np.pi/3.0) * np.outer((s**3.0), (1.0-np.cos(theta)))*2.0
     return vol
 
@@ -388,7 +381,7 @@ def pair_counts(sample1, sample2, s_bins, mu_bins, period,
 
 
 def _s_mu_tpcf_process_args(sample1, s_bins, mu_bins, sample2, randoms,
-        period, do_auto, do_cross, estimator, num_threads, max_sample_size,
+        period, do_auto, do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
@@ -402,9 +395,6 @@ def _s_mu_tpcf_process_args(sample1, s_bins, mu_bins, sample2, randoms,
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     # process radial bins
     s_bins = get_separation_bins_array(s_bins)

--- a/halotools/mock_observables/two_point_clustering/tests/test_clustering_helpers.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_clustering_helpers.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import numpy as np
 
-from ..clustering_helpers import verify_tpcf_estimator, downsample_inputs_exceeding_max_sample_size
+from ..clustering_helpers import verify_tpcf_estimator
 from ..clustering_helpers import process_optional_input_sample2
 
 __all__ = ('test_verify_tpcf_estimator', )
@@ -20,80 +20,6 @@ def test_verify_tpcf_estimator():
         _ = verify_tpcf_estimator('Cuba Gooding, Jr.')
     substr = "is not in the list of available estimators:"
     assert substr in err.value.args[0]
-
-
-def test_downsample_inputs_exceeding_max_sample_size_case1():
-
-    _sample1_is_sample2 = True
-
-    npts1, npts2, max_sample_size = 100, 100, 200
-    sample1_in = np.zeros((npts1, 3))
-
-    sample1_out, sample2_out = downsample_inputs_exceeding_max_sample_size(
-        sample1_in, sample1_in, _sample1_is_sample2, max_sample_size=max_sample_size)
-
-
-def test_downsample_inputs_exceeding_max_sample_size_case2():
-
-    _sample1_is_sample2 = True
-
-    npts1, npts2, max_sample_size = 100, 100, 20
-    sample1_in = np.zeros((npts1, 3))
-    sample1_out, sample2_out = downsample_inputs_exceeding_max_sample_size(
-        sample1_in, sample1_in, _sample1_is_sample2, max_sample_size=max_sample_size)
-    assert len(sample1_out) == 20
-    assert len(sample2_out) == npts2
-
-
-def test_downsample_inputs_exceeding_max_sample_size_case3():
-
-    _sample1_is_sample2 = False
-
-    npts1, npts2, max_sample_size = 100, 100, 200
-    sample1_in = np.zeros((npts1, 3))
-    sample2_in = np.zeros((npts2, 3))
-
-    sample1_out, sample2_out = downsample_inputs_exceeding_max_sample_size(
-        sample1_in, sample2_in, _sample1_is_sample2, max_sample_size=max_sample_size)
-
-
-def test_downsample_inputs_exceeding_max_sample_size_case4():
-
-    _sample1_is_sample2 = False
-
-    npts1, npts2, max_sample_size = 1000, 10, 100
-    sample1_in = np.zeros((npts1, 3))
-    sample2_in = np.zeros((npts2, 3))
-    sample1_out, sample2_out = downsample_inputs_exceeding_max_sample_size(
-        sample1_in, sample2_in, _sample1_is_sample2, max_sample_size=max_sample_size)
-    assert len(sample1_out) == max_sample_size
-    assert len(sample2_out) == npts2
-
-
-def test_downsample_inputs_exceeding_max_sample_size_case5():
-
-    _sample1_is_sample2 = False
-
-    npts1, npts2, max_sample_size = 10, 1000, 100
-    sample1_in = np.zeros((npts1, 3))
-    sample2_in = np.zeros((npts2, 3))
-    sample1_out, sample2_out = downsample_inputs_exceeding_max_sample_size(
-        sample1_in, sample2_in, _sample1_is_sample2, max_sample_size=max_sample_size)
-    assert len(sample1_out) == npts1
-    assert len(sample2_out) == max_sample_size
-
-
-def test_downsample_inputs_exceeding_max_sample_size_case6():
-
-    _sample1_is_sample2 = False
-
-    npts1, npts2, max_sample_size = 1000, 1000, 100
-    sample1_in = np.zeros((npts1, 3))
-    sample2_in = np.zeros((npts2, 3))
-    sample1_out, sample2_out = downsample_inputs_exceeding_max_sample_size(
-        sample1_in, sample2_in, _sample1_is_sample2, max_sample_size=max_sample_size)
-    assert len(sample1_out) == max_sample_size
-    assert len(sample2_out) == max_sample_size
 
 
 def test_process_optional_input_sample2_case1():

--- a/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf.py
@@ -28,8 +28,7 @@ def test_rp_pi_tpcf_auto_nonperiodic():
         randoms = np.random.random((Npts, 3))
 
     result = rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None,
-        randoms=randoms, period=None,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=randoms, period=None, estimator='Natural')
 
     assert result.ndim == 2, "More than one correlation function returned erroneously."
 
@@ -43,8 +42,7 @@ def test_rp_pi_tpcf_auto_periodic():
         sample1 = np.random.random((Npts, 3))
 
     result = rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None,
-        randoms=None, period=period,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=None, period=period, estimator='Natural')
 
     assert result.ndim == 2, "More than one correlation function returned erroneously."
 
@@ -59,8 +57,7 @@ def test_rp_pi_tpcf_cross_periodic():
         sample2 = np.random.random((Npts, 3))
 
     result = rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=sample2,
-        randoms=None, period=period,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=None, period=period, estimator='Natural')
 
     assert len(result) == 3, "wrong number of correlations returned"
     assert result[0].ndim == 2, "dimension of auto incorrect"
@@ -79,8 +76,7 @@ def test_rp_pi_tpcf_cross_nonperiodic():
         randoms = np.random.random((Npts, 3))
 
     result = rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=sample2,
-        randoms=randoms, period=None,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=randoms, period=None, estimator='Natural')
 
     assert len(result) == 3, "wrong number of correlations returned"
     assert result[0].ndim == 2, "dimension of auto incorrect"

--- a/halotools/mock_observables/two_point_clustering/tests/test_s_mu_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_s_mu_tpcf.py
@@ -25,8 +25,7 @@ def test_s_mu_tpcf_auto_nonperiodic():
     mu_bins = np.linspace(0, 1.0, 5)
 
     result_1 = s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None,
-        randoms=randoms, period=None,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=randoms, period=None, estimator='Natural')
 
     assert result_1.ndim == 2, "correlation function returned has wrong dimension."
 
@@ -43,8 +42,7 @@ def test_s_mu_tpcf_auto_periodic():
     mu_bins = np.linspace(0, 1.0, 10)
 
     result_1 = s_mu_tpcf(sample1, s_bins, mu_bins, sample2=None,
-        randoms=None, period=period,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=None, period=period, estimator='Natural')
 
     assert result_1.ndim == 2, "correlation function returned has wrong dimension."
 

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf.py
@@ -38,7 +38,7 @@ def test_tpcf_auto():
     # with randoms
     result = tpcf(sample1, rbins, sample2=None,
                   randoms=randoms, period=None,
-                  max_sample_size=int(1e4), estimator='Natural',
+                  estimator='Natural',
                   approx_cell1_size=[rmax, rmax, rmax],
                   approx_cellran_size=[rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
@@ -46,7 +46,7 @@ def test_tpcf_auto():
     # with out randoms
     result = tpcf(sample1, rbins, sample2=None,
                   randoms=None, period=period,
-                  max_sample_size=int(1e4), estimator='Natural',
+                  estimator='Natural',
                   approx_cell1_size=[rmax, rmax, rmax], num_threads=1)
     assert result.ndim == 1, "More than one correlation function returned erroneously."
 
@@ -67,14 +67,14 @@ def test_tpcf_cross():
     # with randoms
     result = tpcf(sample1, rbins, sample2=sample2,
                   randoms=randoms, period=None,
-                  max_sample_size=int(1e4), estimator='Natural', do_auto=False,
+                  estimator='Natural', do_auto=False,
                   approx_cell1_size=[rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
 
     # with out randoms
     result = tpcf(sample1, rbins, sample2=sample2,
                   randoms=None, period=period,
-                  max_sample_size=int(1e4), estimator='Natural', do_auto=False,
+                  estimator='Natural', do_auto=False,
                   approx_cell1_size=[rmax, rmax, rmax])
     assert result.ndim == 1, "More than one correlation function returned erroneously."
 
@@ -93,27 +93,27 @@ def test_tpcf_estimators():
 
     result_1 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=None,
-                    max_sample_size=int(1e4), estimator='Natural',
+                    estimator='Natural',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
     result_2 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=None,
-                    max_sample_size=int(1e4), estimator='Davis-Peebles',
+                    estimator='Davis-Peebles',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
     result_3 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=None,
-                    max_sample_size=int(1e4), estimator='Hewett',
+                    estimator='Hewett',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
     result_4 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=None,
-                    max_sample_size=int(1e4), estimator='Hamilton',
+                    estimator='Hamilton',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
     result_5 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=None,
-                    max_sample_size=int(1e4), estimator='Landy-Szalay',
+                    estimator='Landy-Szalay',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
 
@@ -122,26 +122,6 @@ def test_tpcf_estimators():
     assert len(result_3) == 3, "wrong number of correlation functions returned erroneously."
     assert len(result_4) == 3, "wrong number of correlation functions returned erroneously."
     assert len(result_5) == 3, "wrong number of correlation functions returned erroneously."
-
-
-@slow
-def test_tpcf_sample_size_limit():
-    """
-    test the tpcf sample size limit functionality functionality
-    """
-    with NumpyRNGContext(fixed_seed):
-        sample1 = np.random.random((1000, 3))
-        sample2 = np.random.random((1000, 3))
-        randoms = np.random.random((1000, 3))
-    rbins = np.linspace(0.001, 0.3, 5)
-    rmax = rbins.max()
-
-    result_1 = tpcf(sample1, rbins, sample2=sample2,
-                    randoms=randoms, period=None,
-                    max_sample_size=int(1e2), estimator='Natural',
-                    approx_cell1_size=[rmax, rmax, rmax])
-
-    assert len(result_1) == 3, "wrong number of correlation functions returned erroneously."
 
 
 @slow
@@ -160,19 +140,19 @@ def test_tpcf_randoms():
     # No PBCs w/ randoms
     result_1 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=None,
-                    max_sample_size=int(1e4), estimator='Natural',
+                    estimator='Natural',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
     # PBCs w/o randoms
     result_2 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=None, period=period,
-                    max_sample_size=int(1e4), estimator='Natural',
+                    estimator='Natural',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
     # PBCs w/ randoms
     result_3 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=period,
-                    max_sample_size=int(1e4), estimator='Natural',
+                    estimator='Natural',
                     approx_cell1_size=[rmax, rmax, rmax],
                     approx_cellran_size=[rmax, rmax, rmax])
 
@@ -180,7 +160,7 @@ def test_tpcf_randoms():
     with pytest.raises(ValueError) as err:
         tpcf(sample1, rbins, sample2=sample2,
              randoms=None, period=None,
-             max_sample_size=int(1e4), estimator='Natural',
+             estimator='Natural',
              approx_cell1_size=[rmax, rmax, rmax],
              approx_cellran_size=[rmax, rmax, rmax])
     substr = "If no PBCs are specified, randoms must be provided."
@@ -206,13 +186,13 @@ def test_tpcf_period_API():
 
     result_1 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=period,
-                    max_sample_size=int(1e4), estimator='Natural',
+                    estimator='Natural',
                     approx_cell1_size=[rmax, rmax, rmax])
 
     period = 1.0
     result_2 = tpcf(sample1, rbins, sample2=sample2,
                     randoms=randoms, period=period,
-                    max_sample_size=int(1e4), estimator='Natural',
+                    estimator='Natural',
                     approx_cell1_size=[rmax, rmax, rmax])
 
     # should throw an error.  period must be positive!
@@ -220,7 +200,7 @@ def test_tpcf_period_API():
     with pytest.raises(ValueError) as err:
         tpcf(sample1, rbins, sample2=sample2,
              randoms=randoms, period=period,
-             max_sample_size=int(1e4), estimator='Natural',
+             estimator='Natural',
              approx_cell1_size=[rmax, rmax, rmax])
     substr = "All values must bounded positive numbers."
     assert substr in err.value.args[0]
@@ -245,17 +225,16 @@ def test_tpcf_cross_consistency_w_auto():
     # with out randoms
     result1 = tpcf(sample1, rbins, sample2=None,
                    randoms=None, period=period,
-                   max_sample_size=int(1e4), estimator='Natural',
+                   estimator='Natural',
                    approx_cell1_size=[rmax, rmax, rmax])
 
     result2 = tpcf(sample2, rbins, sample2=None,
                    randoms=None, period=period,
-                   max_sample_size=int(1e4), estimator='Natural',
+                   estimator='Natural',
                    approx_cell1_size=[rmax, rmax, rmax])
 
     result1_p, result12, result2_p = tpcf(sample1, rbins, sample2=sample2,
                                           randoms=None, period=period,
-                                          max_sample_size=int(1e4),
                                           estimator='Natural',
                                           approx_cell1_size=[rmax, rmax, rmax])
 
@@ -265,17 +244,16 @@ def test_tpcf_cross_consistency_w_auto():
     # with randoms
     result1 = tpcf(sample1, rbins, sample2=None,
                    randoms=randoms, period=period,
-                   max_sample_size=int(1e4), estimator='Natural',
+                   estimator='Natural',
                    approx_cell1_size=[rmax, rmax, rmax])
 
     result2 = tpcf(sample2, rbins, sample2=None,
                    randoms=randoms, period=period,
-                   max_sample_size=int(1e4), estimator='Natural',
+                   estimator='Natural',
                    approx_cell1_size=[rmax, rmax, rmax])
 
     result1_p, result12, result2_p = tpcf(sample1, rbins, sample2=sample2,
                                           randoms=randoms, period=period,
-                                          max_sample_size=int(1e4),
                                           estimator='Natural',
                                           approx_cell1_size=[rmax, rmax, rmax])
 
@@ -296,7 +274,7 @@ def test_RR_precomputed_exception_handling1():
     with pytest.raises(HalotoolsError) as err:
         _ = tpcf(sample1, rbins, sample2=sample2,
             randoms=randoms, period=period,
-            max_sample_size=int(1e4), estimator='Natural',
+            estimator='Natural',
             approx_cell1_size=[rmax, rmax, rmax],
             RR_precomputed=RR_precomputed)
     substr = "``RR_precomputed`` and ``NR_precomputed`` arguments, or neither\n"
@@ -317,7 +295,7 @@ def test_RR_precomputed_exception_handling2():
     with pytest.raises(HalotoolsError) as err:
         _ = tpcf(sample1, rbins, sample2=sample2,
             randoms=randoms, period=period,
-            max_sample_size=int(1e4), estimator='Natural',
+            estimator='Natural',
             approx_cell1_size=[rmax, rmax, rmax],
             RR_precomputed=RR_precomputed, NR_precomputed=NR_precomputed)
     substr = "\nLength of ``RR_precomputed`` must match length of ``rbins``\n"
@@ -338,7 +316,7 @@ def test_RR_precomputed_exception_handling3():
     with pytest.raises(HalotoolsError) as err:
         _ = tpcf(sample1, rbins, sample2=sample2,
             randoms=randoms, period=period,
-            max_sample_size=int(1e4), estimator='Natural',
+            estimator='Natural',
             approx_cell1_size=[rmax, rmax, rmax],
             RR_precomputed=RR_precomputed, NR_precomputed=NR_precomputed)
     substr = "the value of NR_precomputed must agree with the number of randoms"
@@ -372,7 +350,7 @@ def test_RR_precomputed_natural_estimator_auto():
     normal_result = tpcf(
         sample1, rbins, sample2=sample2,
         randoms=randoms, period=period,
-        max_sample_size=int(1e4), estimator='Natural',
+        estimator='Natural',
         approx_cell1_size=approx_cell1_size,
         approx_cellran_size=approx_cellran_size)
 
@@ -419,7 +397,7 @@ def test_RR_precomputed_natural_estimator_auto():
     result_with_RR_precomputed = tpcf(
         sample1, rbins, sample2=sample2,
         randoms=randoms, period=period,
-        max_sample_size=int(1e4), estimator='Natural',
+        estimator='Natural',
         approx_cell1_size=approx_cell1_size,
         approx_cellran_size=approx_cellran_size,
         RR_precomputed=RR,
@@ -455,7 +433,7 @@ def test_RR_precomputed_Landy_Szalay_estimator_auto():
     normal_result = tpcf(
         sample1, rbins, sample2=sample2,
         randoms=randoms, period=period,
-        max_sample_size=int(1e4), estimator='Landy-Szalay',
+        estimator='Landy-Szalay',
         approx_cell1_size=approx_cell1_size,
         approx_cellran_size=approx_cellran_size)
 
@@ -505,25 +483,13 @@ def test_RR_precomputed_Landy_Szalay_estimator_auto():
     result_with_RR_precomputed = tpcf(
         sample1, rbins, sample2=sample2,
         randoms=randoms, period=period,
-        max_sample_size=int(1e4), estimator='Landy-Szalay',
+        estimator='Landy-Szalay',
         approx_cell1_size=approx_cell1_size,
         approx_cellran_size=approx_cellran_size,
         RR_precomputed=RR,
         NR_precomputed=NR1)
 
     assert np.all(result_with_RR_precomputed == normal_result)
-
-
-def test_tpcf_raises_warning_for_large_samples():
-    with NumpyRNGContext(fixed_seed):
-        sample1 = np.random.random((1000, 3))
-    period = np.array([1.0, 1.0, 1.0])
-    rbins = np.linspace(0.001, 0.3, 5)
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        normal_result = tpcf(sample1, rbins, period=period,
-            max_sample_size=int(1e2))
 
 
 def test_tpcf_raises_exception_for_non_monotonic_rbins():

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf_one_two_halo.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf_one_two_halo.py
@@ -32,8 +32,7 @@ def test_tpcf_one_two_halo_auto_periodic():
         sample1 = np.random.random((Npts, 3))
 
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=None,
-      randoms=None, period=period,
-      max_sample_size=int(1e4), estimator='Natural')
+      randoms=None, period=period, estimator='Natural')
 
     assert len(result) == 2, "wrong number of correlation functions returned."
 
@@ -52,7 +51,7 @@ def test_tpcf_one_two_halo_cross_periodic():
 
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=sample2,
       sample2_host_halo_id=IDs2, randoms=None,
-      period=period, max_sample_size=int(1e4),
+      period=period,
       estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
       approx_cell2_size=[rmax, rmax, rmax],
       approx_cellran_size=[rmax, rmax, rmax])
@@ -72,8 +71,7 @@ def test_tpcf_one_two_halo_auto_nonperiodic():
         randoms = np.random.random((Nran, 3))
 
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=None,
-        randoms=randoms, period=period,
-        max_sample_size=int(1e4), estimator='Natural')
+        randoms=randoms, period=period, estimator='Natural')
 
     assert len(result) == 2, "wrong number of correlation functions returned."
 
@@ -93,7 +91,7 @@ def test_tpcf_one_two_halo_cross_nonperiodic():
 
     result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=sample2,
       sample2_host_halo_id=IDs2, randoms=randoms,
-      period=period, max_sample_size=int(1e4),
+      period=period,
       estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
       approx_cell2_size=[rmax, rmax, rmax],
       approx_cellran_size=[rmax, rmax, rmax])
@@ -112,7 +110,7 @@ def test_tpcf_decomposition_process_args1():
     with pytest.raises(ValueError) as err:
         result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=sample2,
           sample2_host_halo_id=None, randoms=None,
-          period=period, max_sample_size=int(1e4),
+          period=period,
           estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
           approx_cell2_size=[rmax, rmax, rmax],
           approx_cellran_size=[rmax, rmax, rmax])
@@ -131,7 +129,7 @@ def test_tpcf_decomposition_process_args2():
     with pytest.raises(HalotoolsError) as err:
         result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=sample2,
           sample2_host_halo_id=IDs2, randoms=None,
-          period=period, max_sample_size=int(1e4),
+          period=period,
           estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
           approx_cell2_size=[rmax, rmax, rmax],
           approx_cellran_size=[rmax, rmax, rmax])
@@ -150,7 +148,7 @@ def test_tpcf_decomposition_process_args3():
     with pytest.raises(HalotoolsError) as err:
         result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=sample2,
           sample2_host_halo_id=IDs2, randoms=None,
-          period=period, max_sample_size=int(1e4),
+          period=period,
           estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
           approx_cell2_size=[rmax, rmax, rmax],
           approx_cellran_size=[rmax, rmax, rmax])
@@ -169,7 +167,7 @@ def test_tpcf_decomposition_process_args4():
     with pytest.raises(ValueError) as err:
         result = tpcf_one_two_halo_decomp(sample1, IDs1, rbins, sample2=sample2,
           sample2_host_halo_id=IDs2, randoms=None,
-          period=period, max_sample_size=int(1e4),
+          period=period,
           estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
           approx_cell2_size=[rmax, rmax, rmax],
           approx_cellran_size=[rmax, rmax, rmax], do_auto='yes')
@@ -188,7 +186,7 @@ def test_tpcf_decomposition_cross_consistency():
     result_a = tpcf_one_two_halo_decomp(
         sample1, IDs1, rbins, sample2=sample2,
         sample2_host_halo_id=IDs2, randoms=None,
-        period=period, max_sample_size=int(1e4),
+        period=period,
         estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
         approx_cell2_size=[rmax, rmax, rmax],
         approx_cellran_size=[rmax, rmax, rmax],
@@ -198,7 +196,7 @@ def test_tpcf_decomposition_cross_consistency():
     result_b = tpcf_one_two_halo_decomp(
         sample1, IDs1, rbins, sample2=sample2,
         sample2_host_halo_id=IDs2, randoms=None,
-        period=period, max_sample_size=int(1e4),
+        period=period,
         estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
         approx_cell2_size=[rmax, rmax, rmax],
         approx_cellran_size=[rmax, rmax, rmax],
@@ -220,7 +218,7 @@ def test_tpcf_decomposition_auto_consistency():
     result_a = tpcf_one_two_halo_decomp(
         sample1, IDs1, rbins, sample2=sample2,
         sample2_host_halo_id=IDs2, randoms=None,
-        period=period, max_sample_size=int(1e4),
+        period=period,
         estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
         approx_cell2_size=[rmax, rmax, rmax],
         approx_cellran_size=[rmax, rmax, rmax],
@@ -231,7 +229,7 @@ def test_tpcf_decomposition_auto_consistency():
     result_1h_11b, result_2h_11b, result_1h_22b, result_2h_22b = tpcf_one_two_halo_decomp(
         sample1, IDs1, rbins, sample2=sample2,
         sample2_host_halo_id=IDs2, randoms=None,
-        period=period, max_sample_size=int(1e4),
+        period=period,
         estimator='Natural', approx_cell1_size=[rmax, rmax, rmax],
         approx_cell2_size=[rmax, rmax, rmax],
         approx_cellran_size=[rmax, rmax, rmax],

--- a/halotools/mock_observables/two_point_clustering/tests/test_wp.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_wp.py
@@ -31,8 +31,7 @@ def test_wp_auto_nonperiodic():
         randoms = np.random.random((Npts, 3))
 
     result = wp(sample1, rp_bins, pi_max, sample2=None,
-                randoms=randoms, period=None,
-                max_sample_size=int(1e4), estimator='Natural')
+                randoms=randoms, period=None, estimator='Natural')
 
     print(result)
     assert result.ndim == 1, "More than one correlation function returned erroneously."
@@ -47,8 +46,7 @@ def test_wp_auto_periodic():
         sample1 = np.random.random((Npts, 3))
 
     result = wp(sample1, rp_bins, pi_max, sample2=None,
-                randoms=None, period=period,
-                max_sample_size=int(1e4), estimator='Natural')
+                randoms=None, period=period, estimator='Natural')
 
     assert result.ndim == 1, "More than one correlation function returned erroneously."
 
@@ -63,8 +61,7 @@ def test_wp_cross_periodic():
         sample2 = np.random.random((Npts, 3))
 
     result = wp(sample1, rp_bins, pi_max, sample2=sample2,
-                randoms=None, period=period,
-                max_sample_size=int(1e4), estimator='Natural')
+                randoms=None, period=period, estimator='Natural')
 
     assert len(result) == 3, "wrong number of correlations returned"
     assert result[0].ndim == 1, "dimension of auto incorrect"
@@ -83,8 +80,7 @@ def test_wp_cross_nonperiodic():
         randoms = np.random.random((Npts, 3))
 
     result = wp(sample1, rp_bins, pi_max, sample2=sample2,
-                randoms=randoms, period=None,
-                max_sample_size=int(1e4), estimator='Natural')
+                randoms=randoms, period=None, estimator='Natural')
 
     assert len(result) == 3, "wrong number of correlations returned"
     assert result[0].ndim == 1, "dimension of auto incorrect"

--- a/halotools/mock_observables/two_point_clustering/tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf.py
@@ -9,8 +9,7 @@ from math import gamma
 from warnings import warn
 
 from .clustering_helpers import (process_optional_input_sample2,
-    downsample_inputs_exceeding_max_sample_size, verify_tpcf_estimator,
-    tpcf_estimator_dd_dr_rr_requirements)
+    verify_tpcf_estimator, tpcf_estimator_dd_dr_rr_requirements)
 from .tpcf_estimators import _TP_estimator
 
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
@@ -152,8 +151,7 @@ def _pair_counts(sample1, sample2, rbins,
 
 def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
-        max_sample_size=int(1e6), approx_cell1_size=None,
-        approx_cell2_size=None, approx_cellran_size=None,
+        approx_cell1_size=None, approx_cell2_size=None, approx_cellran_size=None,
         RR_precomputed=None, NR_precomputed=None, seed=None):
     r"""
     Calculate the real space two-point correlation function, :math:`\xi(r)`.
@@ -221,12 +219,6 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6. Set to np.inf for no downsampling.
 
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
@@ -329,7 +321,7 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
 
     # check input arguments using clustering helper functions
     function_args = (sample1, rbins, sample2, randoms, period,
-        do_auto, do_cross, estimator, num_threads, max_sample_size,
+        do_auto, do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size,
         RR_precomputed, NR_precomputed, seed)
 
@@ -390,7 +382,7 @@ def tpcf(sample1, rbins, sample2=None, randoms=None, period=None,
 
 
 def _tpcf_process_args(sample1, rbins, sample2, randoms,
-        period, do_auto, do_cross, estimator, num_threads, max_sample_size,
+        period, do_auto, do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size,
         RR_precomputed, NR_precomputed, seed):
     """
@@ -404,9 +396,6 @@ def _tpcf_process_args(sample1, rbins, sample2, randoms,
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rbins = get_separation_bins_array(rbins)
     rmax = np.amax(rbins)

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -11,8 +11,7 @@ from astropy.utils.misc import NumpyRNGContext
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
 from ..pair_counters import npairs_jackknife_3d
 
-from .clustering_helpers import (process_optional_input_sample2,
-    downsample_inputs_exceeding_max_sample_size, verify_tpcf_estimator)
+from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
     get_separation_bins_array, get_period, get_num_threads)
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
@@ -28,7 +27,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
         sample2=None, period=None, do_auto=True, do_cross=True,
-        estimator='Natural', num_threads=1, max_sample_size=int(1e6), seed=None):
+        estimator='Natural', num_threads=1, seed=None):
     r"""
     Calculate the two-point correlation function, :math:`\xi(r)` and the covariance
     matrix, :math:`{C}_{ij}`, between ith and jth radial bin.
@@ -98,12 +97,6 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
 
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
@@ -212,7 +205,7 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
 
     # process input parameters
     function_args = (sample1, randoms, rbins, Nsub, sample2, period, do_auto,
-        do_cross, estimator, num_threads, max_sample_size, seed)
+        do_cross, estimator, num_threads, seed)
     sample1, rbins, Nsub, sample2, randoms, period, do_auto, do_cross, num_threads,\
         _sample1_is_sample2, PBCs = _tpcf_jackknife_process_args(*function_args)
 
@@ -425,7 +418,7 @@ def jrandom_counts(sample, randoms, j_index, j_index_randoms, N_sub_vol, rbins,
 
 def _tpcf_jackknife_process_args(sample1, randoms, rbins,
         Nsub, sample2, period, do_auto, do_cross,
-        estimator, num_threads, max_sample_size, seed):
+        estimator, num_threads, seed):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.jackknife_tpcf`.
@@ -449,9 +442,6 @@ def _tpcf_jackknife_process_args(sample1, randoms, rbins,
                    "the user must provide true randoms, and \n"
                    "not just the number of randoms desired.")
             raise HalotoolsError(msg)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rbins = get_separation_bins_array(rbins)
     rmax = np.amax(rbins)

--- a/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
@@ -8,10 +8,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 from math import gamma
-from warnings import warn
 
-from .clustering_helpers import (process_optional_input_sample2,
-    downsample_inputs_exceeding_max_sample_size, verify_tpcf_estimator)
+from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
 
 from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
     get_separation_bins_array, get_period, get_num_threads)
@@ -33,8 +31,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
         sample2=None, sample2_host_halo_id=None,
         randoms=None, period=None,
-        do_auto=True, do_cross=True, estimator='Natural',
-        num_threads=1, max_sample_size=int(1e6),
+        do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None,
         approx_cellran_size=None, seed=None):
     r"""
@@ -111,12 +108,6 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
 
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
@@ -197,7 +188,7 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
     # check input arguments using clustering helper functions
     function_args = (sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id,
         randoms, period, do_auto, do_cross, estimator, num_threads,
-        max_sample_size, approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
+        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
 
     # pass arguments in, and get out processed arguments, plus some control flow variables
     sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id, randoms, period,\
@@ -387,7 +378,7 @@ def marked_pair_counts(sample1, sample2, rbins, period, num_threads,
 
 def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
         sample2, sample2_host_halo_id, randoms,
-        period, do_auto, do_cross, estimator, num_threads, max_sample_size,
+        period, do_auto, do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
     """
     Private method to do bounds-checking on the arguments passed to
@@ -420,9 +411,6 @@ def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
         msg = ("\n `sample2_host_halo_id` must be a 1-D \n"
                "array the same length as `sample2`.")
         raise HalotoolsError(msg)
-
-    sample1, sample2 = downsample_inputs_exceeding_max_sample_size(
-        sample1, sample2, _sample1_is_sample2, max_sample_size, seed=seed)
 
     rbins = get_separation_bins_array(rbins)
     rmax = np.max(rbins)

--- a/halotools/mock_observables/two_point_clustering/wp.py
+++ b/halotools/mock_observables/two_point_clustering/wp.py
@@ -19,7 +19,7 @@ np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD
 
 def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
-        max_sample_size=int(1e6), approx_cell1_size=None, approx_cell2_size=None,
+        approx_cell1_size=None, approx_cell2_size=None,
         approx_cellran_size=None, seed=None):
     r"""
     Calculate the projected two point correlation function, :math:`w_{p}(r_p)`,
@@ -104,12 +104,6 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         calculation, in which case a multiprocessing Pool object will
         never be instantiated. A string 'max' may be used to indicate that
         the pair counters should use all available cores on the machine.
-
-    max_sample_size : int, optional
-        Defines maximum size of the sample that will be passed to the pair counter.
-        If sample size exeeds max_sample_size,
-        the sample will be randomly down-sampled such that the subsample
-        is equal to ``max_sample_size``. Default value is 1e6.
 
     approx_cell1_size : array_like, optional
         Length-3 array serving as a guess for the optimal manner by how points
@@ -203,7 +197,7 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
 
     # process input parameters
     function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
-        do_cross, estimator, num_threads, max_sample_size,
+        do_cross, estimator, num_threads,
         approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
     sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
         _sample1_is_sample2, PBCs = _rp_pi_tpcf_process_args(*function_args)
@@ -216,7 +210,6 @@ def wp(sample1, rp_bins, pi_max, sample2=None, randoms=None, period=None,
         sample2=sample2, randoms=randoms,
         period=period, do_auto=do_auto, do_cross=do_cross,
         estimator=estimator, num_threads=num_threads,
-        max_sample_size=max_sample_size,
         approx_cell1_size=approx_cell1_size,
         approx_cell2_size=approx_cell2_size,
         approx_cellran_size=approx_cellran_size)


### PR DESCRIPTION
As pointed out by @manodeep in #797, the `max_sample_size` argument creates a bookkeeping nuisance. I think this feature was originally included at a time when the code was just too slow to use this many points, but that is no longer the case. This PR removes this feature from all `mock_observables` functions. 

Will wait to hear from @duncandc before merging, in case I have forgotten an important reason this feature is here. 