### PR TITLE
Run --coverage test on Travis using py3.6 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ env:
 
 matrix:
     include:
-        # Do a coverage test in Python 2.
-        - python: 2.7
+        # Do a coverage test in Python 3
+        - python: 3.6
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it


### PR DESCRIPTION
Changed the `.travis` config file so that the `--coverage` option is run in python 3.6 instead of 2.7. For some reason this *decreases* coverage by 0.6%, but it resolves the weird test failures that showed up in #796. 

CC @bsipocz @astrofrog @eteq - I never did get to the bottom of why this happened, but I figured I'd point it out in case this is happening elsewhere. If the `--coverage` option runs on travis in a 2.7 environment, for some reason there is a mysterious failure with very little information available from googling:

`DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead`