### PR TITLE
Add stand-alone z-space distortion function

### DIFF
--- a/halotools/mock_observables/catalog_analysis_helpers.py
+++ b/halotools/mock_observables/catalog_analysis_helpers.py
@@ -11,7 +11,7 @@ from ..sim_manager.sim_defaults import default_cosmology, default_redshift
 from ..custom_exceptions import HalotoolsError
 
 __all__ = ('mean_y_vs_x', 'return_xyz_formatted_array', 'cuboid_subvolume_labels',
-    'relative_positions_and_velocities', 'sign_pbc')
+    'relative_positions_and_velocities', 'sign_pbc', 'apply_zspace_distortion')
 __author__ = ['Andrew Hearin']
 
 

--- a/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
+++ b/halotools/mock_observables/tests/test_catalog_analysis_helpers.py
@@ -288,6 +288,24 @@ def test_return_xyz_formatted_array3():
     assert not np.all(result_z0a == result_z0b)
 
 
+def test_return_xyz_formatted_array4():
+    """ Verify that the internals of return_xyz_formatted_array agree with the
+    results returned by the standalone implementation
+    """
+    npts = int(1e4)
+    x = np.linspace(0.001, 0.999, npts)
+    y = np.linspace(0.001, 0.999, npts)
+    z = np.linspace(0.001, 0.999, npts)
+    v = np.random.normal(loc=0, scale=0.5, size=npts)
+
+    from astropy.cosmology import WMAP5
+    result1 = cat_helpers.return_xyz_formatted_array(x, y, z,
+        velocity=v, velocity_distortion_dimension='x', redshift=0.5, cosmology=WMAP5, period=1)
+
+    result2 = cat_helpers.apply_zspace_distortion(x, v, 0.5, WMAP5, Lbox=1)
+    assert np.allclose(result1[:, 0], result2)
+
+
 class TestCatalogAnalysisHelpers(TestCase):
     """ Class providing tests of the `~halotools.mock_observables.catalog_analysis_helpers`.
     """


### PR DESCRIPTION
New function in `apply_zspace_distortion` is more portable since it works with simple ndarrays and astropy cosmology, instead of halotools-formatted catalogs