### PR TITLE
bug fix for tpcf_jackknife

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@
 
 - Added `wp_jackknife` function. See https://github.com/astropy/halotools/pull/814.
 
+- Fixed bug in the normalization of the covariance matrices in the `tpcf_jackknife` function.  See https://github.com/astropy/halotools/issues/815.
+
 
 0.5 (2017-05-31)
 ----------------

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -289,9 +289,9 @@ def tpcf_jackknife(sample1, randoms, rbins, Nsub=[5, 5, 5],
     xi_22_sub = _TP_estimator(D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator)
 
     # calculate the covariance matrix
-    xi_11_cov = np.matrix(np.cov(xi_11_sub.T))
-    xi_12_cov = np.matrix(np.cov(xi_12_sub.T))
-    xi_22_cov = np.matrix(np.cov(xi_22_sub.T))
+    xi_11_cov = np.matrix(np.cov(xi_11_sub.T, bias=True))*(N_sub_vol-1.0)
+    xi_12_cov = np.matrix(np.cov(xi_12_sub.T, bias=True))*(N_sub_vol-1.0)
+    xi_22_cov = np.matrix(np.cov(xi_22_sub.T, bias=True))*(N_sub_vol-1.0)
 
     if _sample1_is_sample2:
         return xi_11_full, xi_11_cov


### PR DESCRIPTION
This PR addresses #815 and fixes a normalization error to the covariance matrices returned by the function.  This can easily result in a factor of ~10 difference in the resulting covariance.  

This issue has already been addressed in the wp_jackknife function.   