### PR TITLE
Estimating CDF using kernel density estimation

### DIFF
--- a/halotools/empirical_models/abunmatch/kde_utils.py
+++ b/halotools/empirical_models/abunmatch/kde_utils.py
@@ -1,0 +1,35 @@
+"""
+"""
+from __future__ import division, print_function, absolute_import, unicode_literals
+
+import numpy as np
+from scipy.stats import gaussian_kde
+
+
+__all__ = ('kde_cdf', )
+
+
+def kde_cdf(data, x):
+    """ Estimate the cumulative distribution function P(> x) defined by an input data sample.
+
+    Parameters
+    ----------
+    data : ndarray
+        Numpy array of shape (num_sample, )
+
+    x : ndarray
+        Numpy array of shape (num_pts, )
+
+    Returns
+    -------
+    cdf : ndarray
+        Numpy array of shape (num_pts, )
+
+    Examples
+    --------
+    >>> data = np.random.normal(loc=0, scale=1, size=int(1e4))
+    >>> x = np.linspace(-4, 4, 100)
+    >>> cdf = kde_cdf(data, x)
+    """
+    kde = gaussian_kde(data)
+    return np.fromiter((kde.integrate_box_1d(-np.inf, high) for high in np.atleast_1d(x)), dtype='f4')

--- a/halotools/empirical_models/abunmatch/kde_utils.py
+++ b/halotools/empirical_models/abunmatch/kde_utils.py
@@ -9,15 +9,15 @@ from scipy.stats import gaussian_kde
 __all__ = ('kde_cdf', )
 
 
-def kde_cdf(data, x):
-    """ Estimate the cumulative distribution function P(> x) defined by an input data sample.
+def kde_cdf(data, y):
+    """ Estimate the cumulative distribution function P(> y) defined by an input data sample.
 
     Parameters
     ----------
     data : ndarray
         Numpy array of shape (num_sample, )
 
-    x : ndarray
+    y : ndarray
         Numpy array of shape (num_pts, )
 
     Returns
@@ -25,18 +25,18 @@ def kde_cdf(data, x):
     cdf : ndarray
         Numpy array of shape (num_pts, )
 
-    Examples
+    Eyamples
     --------
     >>> data = np.random.normal(loc=0, scale=1, size=int(1e4))
-    >>> x = np.linspace(-4, 4, 100)
-    >>> cdf = kde_cdf(data, x)
+    >>> y = np.linspace(-4, 4, 100)
+    >>> cdf = kde_cdf(data, y)
     """
     kde = gaussian_kde(data)
-    return np.fromiter((kde.integrate_box_1d(-np.inf, high) for high in np.atleast_1d(x)), dtype='f4')
+    return np.fromiter((kde.integrate_box_1d(-np.inf, high) for high in np.atleast_1d(y)), dtype='f4')
 
 
-def kde_cdf_interpol(data, x, npts_interpol=None, npts_sample=None, weights_sample=None):
-    """ Estimate the cumulative distribution function P(> x) defined by an input data sample,
+def kde_cdf_interpol(data, y, npts_interpol=None, npts_sample=None):
+    """ Estimate the cumulative distribution function P(> y) defined by an input data sample,
     optionally interpolating from a downsampling of the data
     to improve performance at the cost of precision.
 
@@ -45,46 +45,90 @@ def kde_cdf_interpol(data, x, npts_interpol=None, npts_sample=None, weights_samp
     data : ndarray
         Numpy array of shape (num_sample, )
 
-    x : ndarray
+    y : ndarray
         Numpy array of shape (num_pts, )
 
     npts_interpol : int, optional
         Number of points used to build a lookup table in lieu of evaluating the CDF
-        at every point in x. Should be smaller than the number of points in x.
-        Default behavior is to evaluate the CDF exactly at each value of x.
+        at every point in y. Should be smaller than the number of points in y.
+        Default behavior is to evaluate the CDF eyactly at each value of y.
 
     npts_sample : int, optional
         Size of downsampled data to use for construction of the KDE.
         Default behavior is not to downsample at all.
         Should be smaller than the number of points in the input data sample.
 
-    weights_sample : ndarray, optional
-        Numpy array of shape (num_sample, ) to use when downsampling the input data.
-        This keyword is only operative when used in conjunction with the ``npts_sample`` argument.
-        Default downsampling is random (without replacement).
-
     Returns
     -------
     cdf : ndarray
         Numpy array of shape (num_pts, )
 
-    Examples
+    Eyamples
     --------
     >>> data = np.random.normal(loc=0, scale=1, size=int(1e4))
-    >>> x = np.linspace(-4, 4, 100)
-    >>> cdf = kde_cdf_interpol(data, x)
-    >>> cdf = kde_cdf_interpol(data, x, npts_interpol=500)
-    >>> cdf = kde_cdf_interpol(data, x, npts_sample=1000)
+    >>> y = np.linspace(-4, 4, 100)
+    >>> cdf = kde_cdf_interpol(data, y)
+    >>> cdf = kde_cdf_interpol(data, y, npts_interpol=500)
+    >>> cdf = kde_cdf_interpol(data, y, npts_sample=1000)
     """
     if npts_sample is not None:
-        msg = "npts_sample ={0} cannot exceed number of len(sample) = {1}"
+        msg = "npts_sample ={0} cannot eyceed number of len(sample) = {1}"
         assert npts_sample <= len(data), msg.format(npts_sample, len(data))
-        data = np.random.choice(data, npts_sample, replace=False, p=weights_sample)
+        data = np.random.choice(data, npts_sample, replace=False)
 
-    x = np.atleast_1d(x)
+    y = np.atleast_1d(y)
     if npts_interpol is not None:
-        x_table = np.linspace(x.min(), x.max(), npts_interpol)
-        cdf_table = kde_cdf(data, x_table)
-        return np.interp(x, x_table, cdf_table)
+        y_table = np.linspace(y.min(), y.max(), npts_interpol)
+        cdf_table = kde_cdf(data, y_table)
+        return np.interp(y, y_table, cdf_table)
     else:
-        return kde_cdf(data, x)
+        return kde_cdf(data, y)
+
+
+def kde_conditional_percentile(y, x, x_bins, npts_interpol=1000, npts_sample=5000):
+    """ Estimate P(> y | x) for each input point (x, y) by using Gaussian kernel density
+    estimation within each bin defined by x_bins.
+
+    Points outside the bounds of x_bins
+    will be treated as if they are members of the outer bins.
+
+    Parameters
+    ----------
+    y : ndarray
+        Numpy array of shape (num_sample, )
+
+    x : ndarray
+        Numpy array of shape (num_sample, )
+
+    x_bins : ndarray
+        Numpy array of shape (num_bins, )
+
+    Examples
+    --------
+    >>> npts = int(1e4)
+    >>> x = np.linspace(0, 10, npts)
+    >>> y = np.random.normal(loc=x)
+    >>> nbins = 15
+    >>> x_bins = np.linspace(0, 10, nbins)
+    >>> conditional_percentile = kde_conditional_percentile(y, x, x_bins)
+    """
+    result = np.zeros_like(y) + np.nan
+
+    #  Overwrite values of x that lie outside the outermost bins
+    x = np.where(x < x_bins[0], x_bins[0], x)
+    dx = (x_bins[-1] - x_bins[-2])/2.
+    x = np.where(x >= x_bins[-1], x_bins[-1]-dx, x)
+
+    for low, high in zip(x_bins[:-1], x_bins[1:]):
+        mask = (x >= low) & (x < high)
+        npts_bin = np.count_nonzero(mask)
+        if npts_bin > 0:
+            data = y[mask]
+            result[mask] = kde_cdf_interpol(data, data,
+                npts_interpol=min(npts_interpol, npts_bin), npts_sample=min(npts_sample, npts_bin))
+
+    return result
+
+
+
+

--- a/halotools/empirical_models/abunmatch/kde_utils.py
+++ b/halotools/empirical_models/abunmatch/kde_utils.py
@@ -33,3 +33,58 @@ def kde_cdf(data, x):
     """
     kde = gaussian_kde(data)
     return np.fromiter((kde.integrate_box_1d(-np.inf, high) for high in np.atleast_1d(x)), dtype='f4')
+
+
+def kde_cdf_interpol(data, x, npts_interpol=None, npts_sample=None, weights_sample=None):
+    """ Estimate the cumulative distribution function P(> x) defined by an input data sample,
+    optionally interpolating from a downsampling of the data
+    to improve performance at the cost of precision.
+
+    Parameters
+    ----------
+    data : ndarray
+        Numpy array of shape (num_sample, )
+
+    x : ndarray
+        Numpy array of shape (num_pts, )
+
+    npts_interpol : int, optional
+        Number of points used to build a lookup table in lieu of evaluating the CDF
+        at every point in x. Should be smaller than the number of points in x.
+        Default behavior is to evaluate the CDF exactly at each value of x.
+
+    npts_sample : int, optional
+        Size of downsampled data to use for construction of the KDE.
+        Default behavior is not to downsample at all.
+        Should be smaller than the number of points in the input data sample.
+
+    weights_sample : ndarray, optional
+        Numpy array of shape (num_sample, ) to use when downsampling the input data.
+        This keyword is only operative when used in conjunction with the ``npts_sample`` argument.
+        Default downsampling is random (without replacement).
+
+    Returns
+    -------
+    cdf : ndarray
+        Numpy array of shape (num_pts, )
+
+    Examples
+    --------
+    >>> data = np.random.normal(loc=0, scale=1, size=int(1e4))
+    >>> x = np.linspace(-4, 4, 100)
+    >>> cdf = kde_cdf_interpol(data, x)
+    >>> cdf = kde_cdf_interpol(data, x, npts_interpol=500)
+    >>> cdf = kde_cdf_interpol(data, x, npts_sample=1000)
+    """
+    if npts_sample is not None:
+        msg = "npts_sample ={0} cannot exceed number of len(sample) = {1}"
+        assert npts_sample <= len(data), msg.format(npts_sample, len(data))
+        data = np.random.choice(data, npts_sample, replace=False, p=weights_sample)
+
+    x = np.atleast_1d(x)
+    if npts_interpol is not None:
+        x_table = np.linspace(x.min(), x.max(), npts_interpol)
+        cdf_table = kde_cdf(data, x_table)
+        return np.interp(x, x_table, cdf_table)
+    else:
+        return kde_cdf(data, x)

--- a/halotools/empirical_models/abunmatch/kde_utils.py
+++ b/halotools/empirical_models/abunmatch/kde_utils.py
@@ -85,7 +85,7 @@ def kde_cdf_interpol(data, y, npts_interpol=None, npts_sample=None):
         return kde_cdf(data, y)
 
 
-def kde_conditional_percentile(y, x, x_bins, npts_interpol=1000, npts_sample=5000):
+def kde_conditional_percentile(y, x, x_bins, npts_interpol=2000, npts_sample=5000):
     """ Estimate P(> y | x) for each input point (x, y) by using Gaussian kernel density
     estimation within each bin defined by x_bins.
 
@@ -128,7 +128,3 @@ def kde_conditional_percentile(y, x, x_bins, npts_interpol=1000, npts_sample=500
                 npts_interpol=min(npts_interpol, npts_bin), npts_sample=min(npts_sample, npts_bin))
 
     return result
-
-
-
-


### PR DESCRIPTION
This PR introduces a few convenience functions commonly used in applications of conditional abundance matching, particularly `kde_conditional_percentile`. This method improves performance and robustness of bin-based methods (e.g., `halotools.utils.compute_conditional_percentiles` function). A subsequent PR will implement an end-to-end CAM implementation based on kernel density estimation that should also significantly improve upon current bin-based methods. 

The newly-added `percentile_curves` convenience function should also be useful for various data analyses where, for example, 95% confidence regions around a running median are desired, or where a mass-dependent percentile cut of halos is desired, as in common assembly bias calculations. 

CC @duncandc @mclaughlin6464 