### PR TITLE
Prim haloprop key propagation

### DIFF
--- a/halotools/empirical_models/composite_models/hod_models/zheng07.py
+++ b/halotools/empirical_models/composite_models/hod_models/zheng07.py
@@ -90,7 +90,7 @@ def zheng07_model_dictionary(
     ####################################
     # Build the `occupation` feature
     centrals_occupation = zheng07_components.Zheng07Cens(
-        threshold=threshold, redshift=redshift)
+        threshold=threshold, redshift=redshift, **kwargs)
 
     # Build the `profile` feature
     centrals_profile = TrivialPhaseSpace(redshift=redshift, **kwargs)

--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -1,15 +1,16 @@
 """
 """
 import pytest
+import numpy as np
 
 from ...factories import PrebuiltHodModelFactory
 
 from ....sim_manager import CachedHaloCatalog, FakeSim
 from ....custom_exceptions import HalotoolsError
+from ....utils.python_string_comparisons import compare_strings_py23_safe
 
 
-__all__ = ('test_hearin15', 'test_Leauthaud11', 'test_Leauthaud11b',
-    'test_Leauthaud11c', 'test_zu_mandelbaum15')
+__all__ = ('test_hearin15', )
 
 
 def test_hearin15():
@@ -58,3 +59,21 @@ def test_zu_mandelbaum15():
     halocat = FakeSim()
     model = PrebuiltHodModelFactory('zu_mandelbaum15', prim_haloprop_key='halo_mvir')
     model.populate_mock(halocat)
+
+
+def test_zheng07_alternate_haloprop1():
+    """ Regression test for Issue #827 - https://github.com/astropy/halotools/issues/827
+    """
+    model = PrebuiltHodModelFactory('zheng07', prim_haloprop_key='halo_custom_mass', mdef='200c')
+
+    centrals_occupation = model.model_dictionary['centrals_occupation']
+    assert compare_strings_py23_safe(centrals_occupation.prim_haloprop_key, 'halo_custom_mass')
+
+    satellites_occupation = model.model_dictionary['satellites_occupation']
+    assert compare_strings_py23_safe(satellites_occupation.prim_haloprop_key, 'halo_custom_mass')
+
+    centrals_profile = model.model_dictionary['centrals_profile']
+    assert compare_strings_py23_safe(centrals_profile.mdef, '200c')
+
+    satellites_profile = model.model_dictionary['satellites_profile']
+    assert compare_strings_py23_safe(satellites_profile.mdef, '200c')

--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -77,3 +77,15 @@ def test_zheng07_alternate_haloprop1():
 
     satellites_profile = model.model_dictionary['satellites_profile']
     assert compare_strings_py23_safe(satellites_profile.mdef, '200c')
+
+
+def test_zheng07_alternate_haloprop2():
+    """ Regression test for Issue #827 - https://github.com/astropy/halotools/issues/827
+    """
+    model = PrebuiltHodModelFactory('zheng07', prim_haloprop_key='halo_custom_mass', mdef='200c')
+    halocat = FakeSim(redshift=0.)
+    halocat.halo_table['halo_custom_mass'] = np.copy(halocat.halo_table['halo_mvir'])
+    halocat.halo_table['halo_m200c'] = np.copy(halocat.halo_table['halo_mvir'])
+    halocat.halo_table['halo_r200c'] = np.copy(halocat.halo_table['halo_rvir'])
+    model.populate_mock(halocat)
+

--- a/halotools/empirical_models/factories/hod_model_factory.py
+++ b/halotools/empirical_models/factories/hod_model_factory.py
@@ -803,6 +803,8 @@ class HodModelFactory(ModelFactory):
                 haloprop_list.append(component_model.prim_haloprop_key)
             if hasattr(component_model, 'sec_haloprop_key'):
                 haloprop_list.append(component_model.sec_haloprop_key)
+            if hasattr(component_model, 'halo_boundary_key'):
+                haloprop_list.append(component_model.halo_boundary_key)
             if hasattr(component_model, 'list_of_haloprops_needed'):
                 haloprop_list.extend(component_model.list_of_haloprops_needed)
 


### PR DESCRIPTION
This PR fixes two problems leading to bug report #827:

1. The **zheng07_model_dictionary** function accepts arbitrary kwargs but does not pass them on down to **Zheng07Cens**. No other pre-loaded composite model dictionaries appear to have missed this argument, so this problem appears to have been limited to the **zheng07_model_dictionary** composite model. 
2. The **HodModelFactory** builds a private list called __haloprop_list_ that is the union of each component model's requested properties. Phase space models all must define a quantity _halo_boundary_key_ that will be used to identify the corresponding column of a halo catalog. The _halo_boundary_key_ was not appended to __haloprop_list_. This results in KeyError exceptions when the **HodMockFactory** attempts to populate a halo catalog with a _halo_boundary_key_ column that is actually there. 

Both of these bugs have been fixed, with regression tests for each bug. 

@nickhand - could you report back whether these fixes solve your problem?