### PR TITLE
Numpy10 bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        - PYTEST_VERSION=3.1
+        - PYTEST_VERSION=3.1.0
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        - PYTEST_VERSION=3.1.0
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
@@ -100,7 +99,7 @@ install:
     # in how to install a package, in which case you can have additional
     # commands in the install: section below.
 
-    - git clone git://github.com/astropy/ci-helpers.git
+    - git clone -b uninstall_hypothesis git://github.com/bsipocz/ci-helpers
     - source ci-helpers/travis/setup_conda.sh
 
     # As described above, using ci-helpers, you should be able to set up an

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        - PYTEST_VERSION<3.2
+        - PYTEST_VERSION=3.1.0
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
@@ -65,7 +65,7 @@ matrix:
 
         # Try Astropy development version
         - python: 3.6
-          env: ASTROPY_VERSION=development ASTROPY_USE_SYSTEM_PYTEST=1
+          env: ASTROPY_VERSION=development
 
         # Try older numpy version, 1.9 is tested above with py3.3 and 1.11 with py3.4
         - python: 3.5
@@ -74,7 +74,7 @@ matrix:
         # Try numpy pre-release version, this runs only when a pre-release
         # is available on pypi.
         - python: 3.6
-          env: NUMPY_VERSION=prerelease SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
+          env: NUMPY_VERSION=prerelease SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - PYTEST_VERSION=3.1
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        - PYTEST_VERSION=3.1.0
+        - PYTEST_VERSION<3.2
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/tests/test_mc_generate_nfw_radial_positions.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/tests/test_mc_generate_nfw_radial_positions.py
@@ -1,5 +1,6 @@
 """
 """
+import numpy as np
 import pytest
 
 from ..mc_generate_nfw_radial_positions import mc_generate_nfw_radial_positions
@@ -19,7 +20,7 @@ def test_mc_generate_nfw_radial_positions1():
 def test_mc_generate_nfw_radial_positions2():
 
     with pytest.raises(HalotoolsError) as err:
-        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_mass=(10**12, 10**13))
+        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_mass=np.logspace(12, 13, 5))
     substr = ("Input ``halo_mass`` must be a float")
     assert substr in err.value.args[0]
 
@@ -27,7 +28,7 @@ def test_mc_generate_nfw_radial_positions2():
 def test_mc_generate_nfw_radial_positions3():
 
     with pytest.raises(HalotoolsError) as err:
-        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_radius=(2, 3))
+        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_radius=np.linspace(2, 3, 5))
     substr = ("Input ``halo_radius`` must be a float")
     assert substr in err.value.args[0]
 
@@ -35,6 +36,6 @@ def test_mc_generate_nfw_radial_positions3():
 def test_mc_generate_nfw_radial_positions4():
 
     with pytest.raises(HalotoolsError) as err:
-        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_radius=0.5, conc=(2, 3))
+        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_radius=0.5, conc=np.linspace(2, 3, 5))
     substr = ("Input ``conc`` must be a float")
     assert substr in err.value.args[0]

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/tests/test_mc_generate_nfw_radial_positions.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/tests/test_mc_generate_nfw_radial_positions.py
@@ -12,30 +12,21 @@ __all__ = ('test_mc_generate_nfw_radial_positions1', )
 def test_mc_generate_nfw_radial_positions1():
     with pytest.raises(HalotoolsError) as err:
         __ = mc_generate_nfw_radial_positions(num_pts=10)
-    substr = ("If keyword argument ``halo_radius`` is unspecified, "
-        "argument ``halo_mass`` must be specified.")
-    assert substr in err.value.args[0]
 
 
 def test_mc_generate_nfw_radial_positions2():
 
     with pytest.raises(HalotoolsError) as err:
         __ = mc_generate_nfw_radial_positions(num_pts=10, halo_mass=np.logspace(12, 13, 5))
-    substr = ("Input ``halo_mass`` must be a float")
-    assert substr in err.value.args[0]
 
 
 def test_mc_generate_nfw_radial_positions3():
 
     with pytest.raises(HalotoolsError) as err:
         __ = mc_generate_nfw_radial_positions(num_pts=10, halo_radius=np.linspace(2, 3, 5))
-    substr = ("Input ``halo_radius`` must be a float")
-    assert substr in err.value.args[0]
 
 
 def test_mc_generate_nfw_radial_positions4():
 
     with pytest.raises(HalotoolsError) as err:
         __ = mc_generate_nfw_radial_positions(num_pts=10, halo_radius=0.5, conc=np.linspace(2, 3, 5))
-    substr = ("Input ``conc`` must be a float")
-    assert substr in err.value.args[0]

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/tests/test_mc_generate_nfw_radial_positions.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/tests/test_mc_generate_nfw_radial_positions.py
@@ -19,7 +19,7 @@ def test_mc_generate_nfw_radial_positions1():
 def test_mc_generate_nfw_radial_positions2():
 
     with pytest.raises(HalotoolsError) as err:
-        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_mass=(2, 3))
+        __ = mc_generate_nfw_radial_positions(num_pts=10, halo_mass=(10**12, 10**13))
     substr = ("Input ``halo_mass`` must be a float")
     assert substr in err.value.args[0]
 

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_biased_nfw/test_conc_gal_bias_behavior.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_biased_nfw/test_conc_gal_bias_behavior.py
@@ -22,7 +22,7 @@ gal_bias_bins = np.insert(gal_bias_bins, np.searchsorted(gal_bias_bins, 1), 1)
 
 
 def test_conc_gal_bias1():
-    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-18)
+    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-21)
     model_dict = zheng07_model.model_dictionary
 
     log_lowmass_value, log_highmass_value = 14, 16
@@ -45,7 +45,7 @@ def test_conc_gal_bias1():
 
 
 def test_sfr_biased_nfw_phase_space_conc_gal_bias():
-    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-18)
+    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-21)
     model_dict = zheng07_model.model_dictionary
 
     log_lowmass_value, log_highmass_value = 14, 16
@@ -93,7 +93,7 @@ def test_sfr_biased_nfw_phase_space_conc_gal_bias():
 
 
 def test_sfr_biased_nfw_phase_space_mockpop():
-    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-18)
+    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-21)
     model_dict = zheng07_model.model_dictionary
 
     log_lowmass_value, log_highmass_value = 14, 16


### PR DESCRIPTION
Recent PRs #843, #842, and #840 all have a Travis failure, limited to the environmental configuration **(python: 3.5, NUMPY_VERSION=1.10)**. These failures were intermittent at first, going away after a rebuild or two, but now they are persistent. At first there were Travis log complaints for failure of one of the test functions modified by commit 2b6e20fda9a9222bf066481945318d28e40f3b73, and now there are failures limited to the `.rst` doctests. 

1. The **test_conc_gal_bias_behavior.py** testing module was populating fake mocks with needlessly high number densities to accomplish the unit-testing. 
2. The **test_mc_generate_nfw_radial_positions2** function was passing in a _halo_mass_=(2, 3) argument that resulted in numerically tiny halo radii. 