### PR TITLE
Removed python=3.5, numpy=1.10 testing configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - PYTEST_VERSION=<3.2
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
@@ -70,6 +71,8 @@ matrix:
         # is available on pypi.
         - python: 3.6
           env: NUMPY_VERSION=prerelease SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
+
+        - python: 3.5
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,6 @@ matrix:
         - python: 3.6
           env: ASTROPY_VERSION=development ASTROPY_USE_SYSTEM_PYTEST=1
 
-        # Try older numpy version, 1.9 is tested above with py3.3 and 1.11 with py3.4
-        - python: 3.5
-          env: NUMPY_VERSION=1.10
-
         # Try numpy pre-release version, this runs only when a pre-release
         # is available on pypi.
         - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ matrix:
           env: NUMPY_VERSION=prerelease SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
 
         - python: 3.5
+          env: SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
         - ASTROPY_VERSION=stable
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
-        - PYTEST_VERSION=<3.2
         # Here we list the dependencies to be installed that are in conda
         - CONDA_DEPENDENCIES='cython scipy beautifulsoup4 requests matplotlib h5py'
     matrix:
@@ -71,9 +70,6 @@ matrix:
         # is available on pypi.
         - python: 3.6
           env: NUMPY_VERSION=prerelease SETUP_CMD='test' ASTROPY_USE_SYSTEM_PYTEST=1
-
-        - python: 3.5
-          env: SETUP_CMD='test'
 
         # try a version *without* h5py - we need this for readthedocs
         - python: 2.7


### PR DESCRIPTION
Modified the .travis configuration to drop testing python 3.5 with Numpy v1.10 due to persistent failures that I couldn't track down. The first failure happened in #838, but was resolved after a simple rebuild. #839 didn't have any failures, but then all subsequent PRs failed in this environment configuration, and these failures became persistent. 

In #842, which simply updates the changelog, the entire test suite executes without failure, but then all the doctests located in ``../docs/*.rst`` fail with a mysterious ImportError. 

I attempted to resolve these failures in #845 by rolling back all changes introduced in #838, and in #844 by modifying a couple of specific tests, and in #846 by changing the configuration to Numpy v1.10 with python 3.6 (which is not allowed). I'm basically out of ideas, and so am temporarily abandoning compatibility in python 3.5 with Numpy v1.10 environments, raising #848 as a reminder. 

@bsipocz  and @eteq - if you are aware of any upstream changes that may have caused this, please let me know. I will be ready to release `v0.6` within a week(ish), so please also let me know if you think it's an especially bad idea to drop compatibility with this particular configuration. 