### PR TITLE
Improved numerical stability of monte_carlo_helpers mc_radial_velocity

### DIFF
--- a/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py
@@ -17,6 +17,7 @@ from ... import model_defaults
 
 from ....custom_exceptions import HalotoolsError
 
+_epsilon = 0.001
 
 __author__ = ['Andrew Hearin']
 __all__ = ['MonteCarloGalProf']
@@ -567,7 +568,7 @@ class MonteCarloGalProf(object):
 
         virial_velocities = self.virial_velocity(total_mass)
         radial_dispersions = virial_velocities*dimensionless_radial_dispersions
-        radial_dispersions = np.where(radial_dispersions < 0, 0, radial_dispersions)
+        radial_dispersions = np.where(radial_dispersions <= 0, _epsilon, radial_dispersions)
 
         seed = kwargs.get('seed', None)
         with NumpyRNGContext(seed):

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_biased_nfw/test_conc_gal_bias_behavior.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_biased_nfw/test_conc_gal_bias_behavior.py
@@ -93,7 +93,7 @@ def test_sfr_biased_nfw_phase_space_conc_gal_bias():
 
 
 def test_sfr_biased_nfw_phase_space_mockpop():
-    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-18)
+    zheng07_model = PrebuiltHodModelFactory('zheng07', threshold=-20)
     model_dict = zheng07_model.model_dictionary
 
     log_lowmass_value, log_highmass_value = 14, 16
@@ -113,6 +113,6 @@ def test_sfr_biased_nfw_phase_space_mockpop():
 
     model = HodModelFactory(**model_dict)
 
-    halocat = FakeSim()
+    halocat = FakeSim(seed=43)
     model.populate_mock(halocat)
 


### PR DESCRIPTION
Now doing the following before generating radial profiles:

radial_dispersions = np.where(radial_dispersions <= 0, _epsilon, radial_dispersions),

where _epsilon = 0.001
This protects against calling np.random.normal with `scale` values equal to zero, raising exceptions in older versions of numpy