### PR TITLE
weighted npairs s mu bugfix

### DIFF
--- a/halotools/mock_observables/pair_counters/test_pair_counters/test_weighted_npairs_s_mu.py
+++ b/halotools/mock_observables/pair_counters/test_pair_counters/test_weighted_npairs_s_mu.py
@@ -63,6 +63,31 @@ def test2():
     assert np.all(unweighted_counts1 == unweighted_counts2)
     assert np.all(unweighted_counts1 != weighted_counts)
 
+def test_weight_consistency():
+    """
+    """
+    Npts = 1000
+    with NumpyRNGContext(fixed_seed):
+        random_sample = np.random.random((Npts, 3))
+    period = np.array([1.0, 1.0, 1.0])
+    # define bins
+    s_bins = np.array([0.0, 0.1, 0.2, 0.3])
+    N_mu_bins = 100
+    mu_bins = np.linspace(0, 1.0, N_mu_bins)
+    Npts = len(random_sample)
+
+    weights1 = np.ones(Npts)
+    weights2 = np.ones(Npts)
+
+    unweighted_counts_serial, weighted_counts_serial = weighted_npairs_s_mu(random_sample, random_sample,
+            weights1, weights2, s_bins, mu_bins, period=period, num_threads=1)
+
+    unweighted_counts_parallel, weighted_counts_parallel = weighted_npairs_s_mu(random_sample, random_sample,
+            weights1, weights2, s_bins, mu_bins, period=period, num_threads=2)
+    
+    #since weights are all equal to 1, weighted and unweighted counts should be the same
+    assert np.all(unweighted_counts_serial == weighted_counts_serial)
+    assert np.all(unweighted_counts_parallel == weighted_counts_parallel)
 
 def test_parallel_serial_consistency():
     """
@@ -82,8 +107,10 @@ def test_parallel_serial_consistency():
 
     unweighted_counts_serial, weighted_counts_serial = weighted_npairs_s_mu(random_sample, random_sample,
             weights1, weights2, s_bins, mu_bins, period=period, num_threads=1)
+
     unweighted_counts_parallel, weighted_counts_parallel = weighted_npairs_s_mu(random_sample, random_sample,
             weights1, weights2, s_bins, mu_bins, period=period, num_threads=3)
-
+    
+    #parallel and serial approaches should return the same answer
     assert np.all(unweighted_counts_serial == unweighted_counts_parallel)
     assert np.all(weighted_counts_serial == weighted_counts_parallel)

--- a/halotools/mock_observables/pair_counters/weighted_npairs_s_mu.py
+++ b/halotools/mock_observables/pair_counters/weighted_npairs_s_mu.py
@@ -222,12 +222,15 @@ def weighted_npairs_s_mu(sample1, sample2, weights1, weights2, s_bins, mu_bins, 
     if num_threads > 1:
         pool = multiprocessing.Pool(num_threads)
         result = pool.map(engine, cell1_tuples)
-        counts, weighted_counts = result
+        result = np.array(result)
+        counts = result[:,0]
+        weighted_counts = result[:,1]
         counts = np.sum(np.array(counts), axis=0)
         weighted_counts = np.sum(np.array(weighted_counts), axis=0)
         pool.close()
     else:
         result = engine(cell1_tuples[0])
-        counts, weighted_counts = result
+        counts = result[0]
+        weighted_counts = result[1]
 
     return np.array(counts), np.array(weighted_counts)


### PR DESCRIPTION
This addresses issue #837

When num_threads > 1 the list returned by multiprocessing.map was not indexed properly.  This has now been resolved by turning it into an array before pulling out the weighted and unweighted counts.  

