### PR TITLE
bug fix in velocity_marked_npairs functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,10 @@
 
 - Fixed bug in `radial_profile_3d` when called in parallel. See https://github.com/astropy/halotools/issues/854.
 
+- Fixed bug in `velocity_marked_npairs_3d` and `velocity_marked_npairs_xy_z` when called with default arguments. See https://github.com/astropy/halotools/issues/836.
+
+- Changed the `weight_func_id` numbers associated with weighting functions for `velocity_marked_npairs_3d` and `velocity_marked_npairs_xy_z` where e.g. 11 is now 1, etc.
+
 
 0.5 (2017-05-31)
 ----------------

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_3d_engine.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_3d_engine.pyx
@@ -229,13 +229,13 @@ cdef f_type return_velocity_weighting_function(weight_func_id):
     returns a pointer to the user-specified pairwise velocity weighting function.
     """
 
-    if weight_func_id==11:
+    if weight_func_id==1:
         return relative_radial_velocity_weights
-    if weight_func_id==12:
+    if weight_func_id==2:
         return radial_velocity_variance_counter_weights
-    if weight_func_id==13:
+    if weight_func_id==3:
         return relative_los_velocity_weights
-    if weight_func_id==14:
+    if weight_func_id==4:
         return los_velocity_variance_counter_weights
     else:
         raise ValueError('weighting function does not exist')

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_xy_z_engine.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_xy_z_engine.pyx
@@ -240,13 +240,13 @@ cdef f_type return_velocity_weighting_function(weight_func_id):
     returns a pointer to the user-specified pairwise velocity weighting function.
     """
 
-    if weight_func_id==11:
+    if weight_func_id==1:
         return relative_radial_velocity_weights
-    if weight_func_id==12:
+    if weight_func_id==2:
         return radial_velocity_variance_counter_weights
-    if weight_func_id==13:
+    if weight_func_id==3:
         return relative_los_velocity_weights
-    if weight_func_id==14:
+    if weight_func_id==4:
         return los_velocity_variance_counter_weights
     else:
         raise ValueError('weighting function does not exist')

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marking_functions.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marking_functions.pyx
@@ -24,6 +24,8 @@ cdef void relative_radial_velocity_weights(cnp.float64_t* w1,
                                            cnp.float64_t* result3):
     """
     Calculate the relative radial velocity between two points.
+
+    func ID=1
     
     Parameters
     ----------
@@ -93,6 +95,8 @@ cdef void radial_velocity_variance_counter_weights(cnp.float64_t* w1,
     Calculate the relative radial velocity between two points minus an offset, and the 
     squared quantity.  This function is used to calculate the variance using the 
     "shifted data" technique where a constant value is subtracted from the value.
+
+    func ID=2
     
     Parameters
     ----------
@@ -158,6 +162,8 @@ cdef void relative_los_velocity_weights(cnp.float64_t* w1,
                                         cnp.float64_t* result3):
     """
     Calculate the relative line-of-sight (LOS) velocity between two points.
+
+    func ID=3
     
     Parameters
     ----------
@@ -212,6 +218,8 @@ cdef void los_velocity_variance_counter_weights(cnp.float64_t* w1,
     Calculate the relative LOS velocity between two points minus an offset, and the 
     squared quantity.  This function is used to calculate the variance using the 
     "shifted data" technique where a constant value is subtracted from the value.
+
+    func ID=4
     
     Parameters
     ----------

--- a/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/los_pvd_vs_rp.py
@@ -229,7 +229,7 @@ def los_pvd_vs_rp(sample1, velocities1, rp_bins, pi_max, sample2=None,
 
         return D1D1, D1D2, D2D2, S1S1, S1S2, S2S2, N1N1, N1N2, N2N2
 
-    weight_func_id = 14
+    weight_func_id = 4
     V1V1, V1V2, V2V2, S1S1, S1S2, S2S2, N1N1, N1N2, N2N2 = marked_pair_counts(
         sample1, sample2, rp_bins, pi_bins, period,
         num_threads, do_auto, do_cross,

--- a/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
+++ b/halotools/mock_observables/pairwise_velocities/mean_los_velocity_vs_rp.py
@@ -211,7 +211,7 @@ def mean_los_velocity_vs_rp(sample1, velocities1, rp_bins, pi_max,
         return D1D1, D1D2, D2D2, N1N1, N1N2, N2N2
 
     # count the sum of radial velocities and number of pairs
-    weight_func_id = 13
+    weight_func_id = 3
     V1V1, V1V2, V2V2, N1N1, N1N2, N2N2 =\
         marked_pair_counts(sample1, sample2, rp_bins, pi_bins, period,
             num_threads, do_auto, do_cross,

--- a/halotools/mock_observables/pairwise_velocities/tests/test_velocity_marked_npairs_3d.py
+++ b/halotools/mock_observables/pairwise_velocities/tests/test_velocity_marked_npairs_3d.py
@@ -21,7 +21,7 @@ def test_velocity_marked_npairs_3d_test1():
         sample1 = np.random.random((npts, 3))
         weights1 = np.random.random((npts, 6))
 
-    weight_func_id = 11
+    weight_func_id = 1
     __ = process_weights_3d(sample1, sample1, weights1, weights1, weight_func_id)
 
 
@@ -33,7 +33,7 @@ def test_velocity_marked_npairs_3d_test2():
         weights1 = np.random.random((npts, 6))
         weights2 = np.random.random((npts, 6))
 
-    weight_func_id = 11
+    weight_func_id = 1
     __ = process_weights_3d(sample1, sample2, weights1, weights2, weight_func_id)
 
 
@@ -45,7 +45,7 @@ def test_velocity_marked_npairs_3d_test3():
         weights1 = np.random.random((npts, 7))
         weights2 = np.random.random((npts, 7))
 
-    weight_func_id = 11
+    weight_func_id = 1
     with pytest.raises(ValueError) as err:
         __ = process_weights_3d(sample1, sample2, weights1, weights2, weight_func_id)
     substr = "For this value of `weight_func_id`, there should be"
@@ -60,7 +60,7 @@ def test_velocity_marked_npairs_3d_test4():
         weights1 = np.random.random(npts)
         weights2 = np.random.random(npts)
 
-    weight_func_id = 11
+    weight_func_id = 1
     with pytest.raises(ValueError) as err:
         __ = process_weights_3d(sample1, sample2, weights1, weights2, weight_func_id)
     substr = "does not have the correct length. "
@@ -75,7 +75,7 @@ def test_velocity_marked_npairs_3d_test5():
         weights1 = np.random.random((npts, 3))
         weights2 = np.random.random((npts, 3))
 
-    weight_func_id = 11
+    weight_func_id = 1
     with pytest.raises(ValueError) as err:
         __ = process_weights_3d(sample1, sample2, weights1, weights2, weight_func_id)
     substr = "For this value of `weight_func_id`, there should be "
@@ -90,7 +90,7 @@ def test_velocity_marked_npairs_3d_test6():
         weights1 = np.random.random((npts, 3, 4))
         weights2 = np.random.random((npts, 3, 4))
 
-    weight_func_id = 11
+    weight_func_id = 1
     with pytest.raises(ValueError) as err:
         __ = process_weights_3d(sample1, sample2, weights1, weights2, weight_func_id)
     substr = "You must either pass in a 1-D or 2-D array"

--- a/halotools/mock_observables/pairwise_velocities/velocity_marked_npairs_3d.py
+++ b/halotools/mock_observables/pairwise_velocities/velocity_marked_npairs_3d.py
@@ -19,7 +19,7 @@ __all__ = ('velocity_marked_npairs_3d', )
 
 def velocity_marked_npairs_3d(sample1, sample2, rbins, period=None,
         weights1=None, weights2=None,
-        weight_func_id=0, verbose=False, num_threads=1,
+        weight_func_id=1, verbose=False, num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None):
     """
     Calculate the number of velocity weighted pairs with separations greater than or equal to r, :math:`W(>r)`.
@@ -132,11 +132,11 @@ def velocity_marked_npairs_3d(sample1, sample2, rbins, period=None,
     >>> vx = halocat.halo_table['halo_vx']
     >>> vy = halocat.halo_table['halo_vy']
     >>> vz = halocat.halo_table['halo_vz']
-    >>> velocities = np.vstack((vx,vy,vz)).T
+    >>> velocities = np.vstack((x,y,z,vx,vy,vz)).T
 
     >>> rbins = np.logspace(-2,-1,10)
     >>> pi_max = 10
-    >>> result = velocity_marked_npairs_3d(sample1, velocities, rbins, period=halocat.Lbox)
+    >>> result = velocity_marked_npairs_3d(sample1, sample1, rbins, period=halocat.Lbox, weights1=velocities, weights2=velocities)
     """
 
     result = _npairs_3d_process_args(sample1, sample2, rbins, period,
@@ -292,13 +292,13 @@ def _func_signature_int_from_vel_weight_func_id(weight_func_id):
         msg = "\n weight_func_id parameter must be an integer ID of a weighting function."
         raise HalotoolsError(msg)
 
-    elif weight_func_id == 11:
+    elif weight_func_id == 1:
         return 6
-    elif weight_func_id == 12:
+    elif weight_func_id == 2:
         return 7
-    elif weight_func_id == 13:
+    elif weight_func_id == 3:
         return 6
-    elif weight_func_id == 14:
+    elif weight_func_id == 4:
         return 7
     else:
         msg = ("The value ``weight_func_id`` = %i is not recognized")

--- a/halotools/mock_observables/pairwise_velocities/velocity_marked_npairs_xy_z.py
+++ b/halotools/mock_observables/pairwise_velocities/velocity_marked_npairs_xy_z.py
@@ -18,7 +18,7 @@ __all__ = ('velocity_marked_npairs_xy_z', )
 
 def velocity_marked_npairs_xy_z(sample1, sample2, rp_bins, pi_bins, period=None,
         weights1=None, weights2=None,
-        weight_func_id=0, verbose=False, num_threads=1,
+        weight_func_id=1, verbose=False, num_threads=1,
         approx_cell1_size=None, approx_cell2_size=None):
     r"""
     Calculate the number of velocity weighted pairs
@@ -140,11 +140,11 @@ def velocity_marked_npairs_xy_z(sample1, sample2, rp_bins, pi_bins, period=None,
     >>> vx = halocat.halo_table['halo_vx']
     >>> vy = halocat.halo_table['halo_vy']
     >>> vz = halocat.halo_table['halo_vz']
-    >>> velocities = np.vstack((vx,vy,vz)).T
+    >>> velocities = np.vstack((x,y,z,vx,vy,vz)).T
 
     >>> rp_bins = np.logspace(-2,-1,10)
     >>> pi_bins = np.linspace(0, 10, 5)
-    >>> result = velocity_marked_npairs_xy_z(sample1, velocities, rp_bins, pi_bins, period=halocat.Lbox)
+    >>> result = velocity_marked_npairs_xy_z(sample1, sample1, rp_bins, pi_bins, period=halocat.Lbox, weights1=velocities, weights2=velocities,)
 
     """
     result = _npairs_xy_z_process_args(sample1, sample2, rp_bins, pi_bins, period,


### PR DESCRIPTION
This pull request addresses issue #836.  

There is no weight_func_id=0 for these velocity weighted functions.  In addition, each function was being called incorrectly within the doc string example section.  

I have corrected these bugs and modified the ``weight_func_id`` numbers of each weighting function to be more reasonable, e.g. 1,2,3,4.  This change required updating ``weight_func_id`` in a couple other locations with the `pairwise_velocities module`.  These changes have been noted CHANGES.rst