### PR TITLE
improved testing of rp_pi_tpcf_jackknife()

### DIFF
--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf_jackknife.py
@@ -218,7 +218,7 @@ def rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins, Nsub=[5, 5, 5],
     >>> xran = np.random.uniform(0, Lbox, Nran)
     >>> yran = np.random.uniform(0, Lbox, Nran)
     >>> zran = np.random.uniform(0, Lbox, Nran)
-    >>> randoms = np.vstack((x,y,z)).T
+    >>> randoms = np.vstack((xran,yran,zran)).T
 
     Calculate the jackknife covariance matrix by dividing the simulation box
     into 3 samples per dimension (for a total of 3^3 total jackknife samples):

--- a/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
@@ -226,8 +226,8 @@ def test_parallel_serial_consistency_1():
     xi1, cov1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
         period=period, Nsub=3, num_threads=1)
     xi2, cov2 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
-        period=period, Nsub=3, num_threads=1)
-    
+        period=period, Nsub=3, num_threads=3)
+
     assert np.allclose(xi1, xi2), "tpcf between threaded and non-threaded results do no match"
     assert np.allclose(cov1, cov2), "cov matrix between threaded and non-threaded results do no match"
 
@@ -238,13 +238,13 @@ def test_parallel_serial_consistency_2():
         sample1 = np.random.random((Npts1, 3))
         sample2 = np.random.random((Npts2, 3))
         randoms = np.random.random((Nran, 3))
-    
+
     xi1, cov1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
         period=period, Nsub=3, num_threads=1, sample2=sample2, do_auto=False)
 
     xi2, cov2 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
-        period=period, Nsub=3, num_threads=1, sample2=sample2, do_auto=False)
-    
+        period=period, Nsub=3, num_threads=3, sample2=sample2, do_auto=False)
+
     assert np.allclose(xi1, xi2), "tpcf between threaded and non-threaded results do no match"
     assert np.allclose(cov1, cov2), "cov matrix between threaded and non-threaded results do no match"
 

--- a/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
@@ -216,17 +216,35 @@ def test_consistency_with_wp_jackknife_2():
             assert np.allclose(element_1, element_2), "covariance elements do no match"
 
 
-def test_parallel_serial_consistency():
+def test_parallel_serial_consistency_1():
     Npts1, Npts2, Nran = 300, 180, 1000
     with NumpyRNGContext(fixed_seed):
         sample1 = np.random.random((Npts1, 3))
         sample2 = np.random.random((Npts2, 3))
-        randoms = [Nran]
+        randoms = np.random.random((Nran, 3))
 
     xi1, cov1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
-        period=period, Nsub=3, num_threads=1, sample2=sample2, do_auto=False)
+        period=period, Nsub=3, num_threads=1)
     xi2, cov2 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
-        period=period, Nsub=3, num_threads=5, sample2=sample2, do_auto=False)
-    assert np.allclose(xi1, xi2)
-    assert np.allclose(cov1, cov2)
+        period=period, Nsub=3, num_threads=1)
+    
+    assert np.allclose(xi1, xi2), "tpcf between threaded and non-threaded results do no match"
+    assert np.allclose(cov1, cov2), "cov matrix between threaded and non-threaded results do no match"
+
+
+def test_parallel_serial_consistency_2():
+    Npts1, Npts2, Nran = 300, 180, 1000
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts1, 3))
+        sample2 = np.random.random((Npts2, 3))
+        randoms = np.random.random((Nran, 3))
+    
+    xi1, cov1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
+        period=period, Nsub=3, num_threads=1, sample2=sample2, do_auto=False)
+
+    xi2, cov2 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
+        period=period, Nsub=3, num_threads=1, sample2=sample2, do_auto=False)
+    
+    assert np.allclose(xi1, xi2), "tpcf between threaded and non-threaded results do no match"
+    assert np.allclose(cov1, cov2), "cov matrix between threaded and non-threaded results do no match"
 

--- a/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
@@ -9,6 +9,8 @@ from astropy.utils.misc import NumpyRNGContext
 from ..rp_pi_tpcf_jackknife import rp_pi_tpcf_jackknife
 from ..rp_pi_tpcf import rp_pi_tpcf
 
+from ..wp_jackknife import wp_jackknife
+
 slow = pytest.mark.slow
 
 __all__ = ('test_tpcf_jackknife_corr_func', )
@@ -137,4 +139,38 @@ def test_do_auto_false():
     result1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
         period=period, Nsub=3, num_threads=1, sample2=sample2,
         do_auto=False)
+
+@pytest.mark.slow
+def test_consitency_with_wp_jackknife():
+    """
+    Verify the result and covariance matrix is consistent with wp_jackknife
+    """
+    Npts = 300
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts, 3))
+        randoms = np.random.random((Npts*3, 3))
+
+    
+    #use one large pi_bin
+    pi_max=0.1
+    pi_min=0.0
+    pi_bins_this_test = np.array([pi_min,pi_max])
+
+    result_1, err_1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins_this_test,
+        Nsub=3, period=period, num_threads=1)
+
+    result_2, err_2 = wp_jackknife(sample1, randoms, rp_bins, pi_max=pi_max,
+        Nsub=3, period=period, num_threads=1)
+    
+    #account for wp integration
+    result_1 = result_1.flatten()*2.0*np.diff(pi_bins_this_test)
+
+    assert np.all(result_1 == result_2), "tpcf is not consistent between rp_pi_tpcf and wp"
+    
+    #account for wp integration
+    factor = (2.0*np.diff(pi_bins_this_test))**2.0
+    err_1 = err_1*factor[0]
+
+    assert np.allclose(err_1,err_2), "cov matrix is not consoistent with wp_jackknife"
+
 

--- a/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_rp_pi_tpcf_jackknife.py
@@ -151,7 +151,7 @@ def test_consistency_with_wp_jackknife():
     with NumpyRNGContext(fixed_seed):
         sample1 = np.random.random((Npts, 3))
         randoms = np.random.random((Npts*3, 3))
-    
+
     #use one large pi_bin
     pi_max=0.1
     pi_min=0.0
@@ -162,12 +162,12 @@ def test_consistency_with_wp_jackknife():
 
     result_2, err_2 = wp_jackknife(sample1, randoms, rp_bins, pi_max=pi_max,
         Nsub=3, period=period, num_threads=1)
-    
+
     #account for wp integration
     result_1 = result_1.flatten()*2.0*np.diff(pi_bins_this_test)
 
     assert np.all(result_1 == result_2), "tpcf is not consistent between rp_pi_tpcf and wp"
-    
+
     #account for wp integration
     factor = (2.0*np.diff(pi_bins_this_test))**2.0
     err_1 = err_1*factor[0]
@@ -185,7 +185,7 @@ def test_consistency_with_wp_jackknife_2():
     with NumpyRNGContext(fixed_seed):
         sample1 = np.random.random((Npts, 3))
         randoms = np.random.random((Npts*3, 3))
-    
+
     #use one large pi_bin
     pi_max=0.15
     pi_min=0.0
@@ -201,7 +201,7 @@ def test_consistency_with_wp_jackknife_2():
 
     __, cov2 = wp_jackknife(sample1, randoms, rp_bins, pi_max=pi_bins_this_test[1],
         Nsub=3, period=period, num_threads=1)
-    
+
     #account for wp integration in comparison
     factor = (2.0*np.diff(pi_bins_this_test[0:2]))**2.0
     cov1 = cov1*factor[0]
@@ -216,5 +216,17 @@ def test_consistency_with_wp_jackknife_2():
             assert np.allclose(element_1, element_2), "covariance elements do no match"
 
 
+def test_parallel_serial_consistency():
+    Npts1, Npts2, Nran = 300, 180, 1000
+    with NumpyRNGContext(fixed_seed):
+        sample1 = np.random.random((Npts1, 3))
+        sample2 = np.random.random((Npts2, 3))
+        randoms = [Nran]
 
+    xi1, cov1 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
+        period=period, Nsub=3, num_threads=1, sample2=sample2, do_auto=False)
+    xi2, cov2 = rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins,
+        period=period, Nsub=3, num_threads=5, sample2=sample2, do_auto=False)
+    assert np.allclose(xi1, xi2)
+    assert np.allclose(cov1, cov2)
 


### PR DESCRIPTION
This pull requests improves the testing of `rp_pi_tpcf_jackknife` to include a consistency test between itself and `wp_jackknife` including the covariance matrices.  This should address issue #830.  