### PR TITLE
Filtering out scipy warnings

### DIFF
--- a/halotools/utils/inverse_transformation_sampling.py
+++ b/halotools/utils/inverse_transformation_sampling.py
@@ -3,11 +3,15 @@
 import numpy as np
 from astropy.utils import NumpyRNGContext
 from warnings import warn
+import warnings
 
 from .array_utils import unsorting_indices
 
 
 __all__ = ('monte_carlo_from_cdf_lookup', 'build_cdf_lookup', 'rank_order_percentile')
+
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
+warnings.filterwarnings("ignore", message="numpy.ufunc size changed")
 
 
 def monte_carlo_from_cdf_lookup(x_table, y_table, mc_input='random',


### PR DESCRIPTION
Warnings related to np.dtype changing size are now filtered out by the inverse_transformation_sampling module