### PR TITLE
Fixed bug in rotate_vector_collection

### DIFF
--- a/halotools/utils/matrix_operations_3d.py
+++ b/halotools/utils/matrix_operations_3d.py
@@ -296,6 +296,6 @@ def rotate_vector_collection(rotation_matrices, vectors, optimize=False):
     >>> assert np.allclose(v1, v2)
     """
     try:
-        np.einsum('ijk,ik->ij', rotation_matrices, vectors, optimize=optimize)
+        return np.einsum('ijk,ik->ij', rotation_matrices, vectors, optimize=optimize)
     except TypeError:
         return np.einsum('ijk,ik->ij', rotation_matrices, vectors)


### PR DESCRIPTION
The `rotate_vector_collection` function in `matrix_operations_3d` omitted a return statement for one of its logical branches, so `void` was being returned. This PR resolves bug #874. 