### PR TITLE
Sliding percentile feature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@
 
 - Added `~halotools.utils.fuzzy_digitize` function to `~halotools.utils` sub-package.
 
+- Added `~halotools.utils.sliding_conditional_percentile` function to `~halotools.utils` sub-package.
+
+
 0.6 (2017-12-15)
 ----------------
 

--- a/docs/whats_new_history/whats_new_0.7.rst
+++ b/docs/whats_new_history/whats_new_0.7.rst
@@ -27,6 +27,10 @@ Probabilistic binning
 The `~halotools.utils.fuzzy_digitize` function in `halotools.utils` allows you to discretize an
 array in a probabilistic fashion, which can be useful for applications of conditional abundance matching.
 
+Estimation of Conditional Probability Distributions
+-----------------------------------------------------
+The `~halotools.utils.sliding_conditional_percentile` function in `halotools.utils` calculates Prob(< y | x) for any arbitrary distribution of two-dimensional data. This function can be used to estimate, for example, quantiles of galaxy size as a function of stellar mass, and also should be useful in applications of conditional abundance matching.
+
 
 New Mock Observables
 ====================

--- a/halotools/utils/__init__.py
+++ b/halotools/utils/__init__.py
@@ -14,3 +14,4 @@ from .inverse_transformation_sampling import *
 from .distribution_matching import *
 from .matrix_operations_3d import *
 from .probabilistic_binning import fuzzy_digitize
+from .conditional_percentile import sliding_conditional_percentile

--- a/halotools/utils/conditional_percentile.py
+++ b/halotools/utils/conditional_percentile.py
@@ -1,3 +1,5 @@
+"""
+"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
@@ -8,7 +10,33 @@ __all__ = ('sliding_conditional_percentile', )
 
 
 def sliding_conditional_percentile(x, y, window_length):
-    """
+    """ Estimate the conditional cumulative distribution function Prob(< y | x)
+    using a sliding window of length ``window_length``.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array of shape (npts, )
+
+    y : ndarray
+        Array of shape (npts, )
+
+    window_length : int
+        Integer must be odd and less than ``npts``
+
+    Returns
+    -------
+    rank_order_percentiles : ndarray
+        Numpy array of shape (npts, ) storing values in the open interval (0, 1).
+        Larger values of the returned array correspond to values of ``y``
+        that are larger-than-average for the corresponding value of ``x``.
+
+    Notes
+    -----
+    The ``window_length`` argument controls the precision of the calculation,
+    and also the performance. For estimations of Prob(< y | x) with sub-percent accuracy,
+    values of ``window_length`` must exceed 100.
+
     Examples
     --------
     >>> x = np.random.rand(100)
@@ -32,7 +60,7 @@ def rank_order_function(x):
     Results
     -------
     rank_orders : ndarray
-        Integer array of shape (npts, ) storing values between 0 and npts-1
+        Integer array of shape (npts, ) storing values in the interval [0, npts-1]
     """
     x = np.atleast_1d(x)
     assert x.ndim == 1, "x must be a 1-d sequence"
@@ -43,6 +71,27 @@ def rank_order_function(x):
 
 def cython_sliding_rank(x, y, window_length):
     """
+    Return an array storing the rank-order of each element element in y
+    computed over a fixed window length at each x
+
+    This function is the kernel of calculation of Prob(< y | x).
+
+    Parameters
+    ----------
+    x : ndarray
+        Array of shape (npts, )
+
+    y : ndarray
+        Array of shape (npts, )
+
+    window_length : int
+        Integer must be odd and less than ``npts``
+
+    Returns
+    -------
+    sliding_rank_orders : ndarray
+        Integer array of shape (npts, ) storing values between 0 and window_length-1
+
     Examples
     --------
     >>> x = np.random.rand(100)
@@ -69,7 +118,8 @@ def cython_sliding_rank(x, y, window_length):
 
 
 def _check_xyn_bounds(x, y, n):
-    """ Enforce bounds checks on the inputs and return 1-d Numpy arrays
+    """ Enforce bounds checks on the inputs
+    and return 1-d Numpy arrays with appropriate dtype
     """
     x = np.atleast_1d(x).astype('f8')
     assert x.ndim == 1, "x must be a 1-d array"

--- a/halotools/utils/conditional_percentile.py
+++ b/halotools/utils/conditional_percentile.py
@@ -1,0 +1,90 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
+from .array_utils import unsorting_indices
+from .engines import cython_conditional_rank_kernel
+
+__all__ = ('sliding_conditional_percentile', )
+
+
+def sliding_conditional_percentile(x, y, window_length):
+    """
+    Examples
+    --------
+    >>> x = np.random.rand(100)
+    >>> y = np.random.rand(100)
+    >>> window_length = 5
+    >>> result = sliding_conditional_percentile(x, y, window_length)
+    """
+    rank_orders = cython_sliding_rank(x, y, window_length)
+    rank_order_percentiles = (1. + rank_orders)/float(window_length+1)
+    return rank_order_percentiles
+
+
+def rank_order_function(x):
+    """ Calculate the rank-order of each element in an input array.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array of shape (npts, )
+
+    Results
+    -------
+    rank_orders : ndarray
+        Integer array of shape (npts, ) storing values between 0 and npts-1
+    """
+    x = np.atleast_1d(x)
+    assert x.ndim == 1, "x must be a 1-d sequence"
+    assert len(x) > 1, "x must have more than one element"
+
+    return unsorting_indices(np.argsort(x))
+
+
+def cython_sliding_rank(x, y, window_length):
+    """
+    Examples
+    --------
+    >>> x = np.random.rand(100)
+    >>> y = np.random.rand(100)
+    >>> window_length = 5
+    >>> result = cython_sliding_rank(x, y, window_length)
+    """
+    x, y, nwin = _check_xyn_bounds(x, y, window_length)
+    nhalfwin = int(nwin/2)
+
+    indx_x_sorted = np.argsort(x)
+    indx_x_unsorted = unsorting_indices(indx_x_sorted)
+    y_sorted = y[indx_x_sorted]
+
+    result = np.array(cython_conditional_rank_kernel(y_sorted, nwin))
+
+    leftmost_window_ranks = rank_order_function(y_sorted[:nwin])
+    result[:nhalfwin+1] = leftmost_window_ranks[:nhalfwin+1]
+
+    rightmost_window_ranks = rank_order_function(y_sorted[-nwin:])
+    result[-nhalfwin-1:] = rightmost_window_ranks[-nhalfwin-1:]
+
+    return result[indx_x_unsorted].astype(int)
+
+
+def _check_xyn_bounds(x, y, n):
+    """ Enforce bounds checks on the inputs and return 1-d Numpy arrays
+    """
+    x = np.atleast_1d(x).astype('f8')
+    assert x.ndim == 1, "x must be a 1-d array"
+    y = np.atleast_1d(y).astype('f8')
+    assert y.ndim == 1, "y must be a 1-d array"
+
+    assert len(x) == len(y), "x and y must have the same length"
+
+    msg = "Window length = {0} must be an odd integer"
+    try:
+        assert n % 2 == 1, msg.format(n)
+    except AssertionError:
+        raise ValueError(msg.format(n))
+
+    msg2 = "Window length = {0} must satisfy 1 < n < len(x)"
+    assert 1 < n < len(x), msg2.format(n)
+
+    return x, y, int(n)

--- a/halotools/utils/conditional_percentile.py
+++ b/halotools/utils/conditional_percentile.py
@@ -10,7 +10,7 @@ __all__ = ('sliding_conditional_percentile', )
 
 
 def sliding_conditional_percentile(x, y, window_length):
-    """ Estimate the conditional cumulative distribution function Prob(< y | x)
+    r""" Estimate the conditional cumulative distribution function Prob(< y | x)
     using a sliding window of length ``window_length``.
 
     Parameters
@@ -50,7 +50,7 @@ def sliding_conditional_percentile(x, y, window_length):
 
 
 def rank_order_function(x):
-    """ Calculate the rank-order of each element in an input array.
+    r""" Calculate the rank-order of each element in an input array.
 
     Parameters
     ----------
@@ -70,7 +70,7 @@ def rank_order_function(x):
 
 
 def cython_sliding_rank(x, y, window_length):
-    """
+    r"""
     Return an array storing the rank-order of each element element in y
     computed over a fixed window length at each x
 
@@ -118,7 +118,7 @@ def cython_sliding_rank(x, y, window_length):
 
 
 def _check_xyn_bounds(x, y, n):
-    """ Enforce bounds checks on the inputs
+    r""" Enforce bounds checks on the inputs
     and return 1-d Numpy arrays with appropriate dtype
     """
     x = np.atleast_1d(x).astype('f8')

--- a/halotools/utils/engines/__init__.py
+++ b/halotools/utils/engines/__init__.py
@@ -1,0 +1,1 @@
+from .conditional_rank_kernel import cython_conditional_rank_kernel

--- a/halotools/utils/engines/conditional_rank_kernel.pyx
+++ b/halotools/utils/engines/conditional_rank_kernel.pyx
@@ -1,0 +1,121 @@
+"""
+"""
+import numpy as np
+cimport cython
+
+from ..array_utils import unsorting_indices
+
+__all__ = ('cython_conditional_rank_kernel', )
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cdef int _bisect_left_kernel(double[:] arr, double value):
+    """ Return the index where to insert ``value`` in list ``arr`` of length ``n``,
+    assuming ``arr`` is sorted.
+    """
+    cdef int n = arr.shape[0]
+    cdef int ifirst_subarr = 0
+    cdef int ilast_subarr = n
+    cdef int imid_subarr
+
+    while ilast_subarr-ifirst_subarr >= 2:
+        imid_subarr = (ifirst_subarr + ilast_subarr)/2
+        if value > arr[imid_subarr]:
+            ifirst_subarr = imid_subarr
+        else:
+            ilast_subarr = imid_subarr
+    if value > arr[ifirst_subarr]:
+        return ilast_subarr
+    else:
+        return ifirst_subarr
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cdef void _insert_first_pop_last_kernel(int* arr, int value_in, int n):
+    cdef int i
+    for i in range(n-2, -1, -1):
+        arr[i+1] = arr[i]
+    arr[0] = value_in
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cdef int _correspondence_indices_shift(int idx_in, int idx_out, int idx):
+    """
+    """
+    cdef int shift = 0
+    if idx_in < idx_out:
+        if idx_in <= idx < idx_out:
+            shift = 1
+    elif idx_in > idx_out:
+        if idx_out < idx <= idx_in:
+            shift = -1
+    return shift
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cdef void _insert_pop_kernel(double* arr, int idx_in, int idx_out, double value_in):
+    """ Pop out the value stored in index ``idx_out`` of array ``arr``,
+    and insert ``value_in`` at index ``idx_in`` of the final array.
+    """
+    cdef int i
+
+    if idx_in <= idx_out:
+        for i in range(idx_out-1, idx_in-1, -1):
+            arr[i+1] = arr[i]
+    else:
+        for i in range(idx_out, idx_in):
+            arr[i] = arr[i+1]
+    arr[idx_in] = value_in
+
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+def cython_conditional_rank_kernel(double[:] y_sorted, int nwin):
+    """
+    """
+    cdef int nhalfwin = int(nwin/2)
+    cdef int iy, idx_in, idx_out, idx_temp, i
+    cdef double value_in, value_out
+    cdef int npts = y_sorted.shape[0]
+    cdef double[:] result = np.zeros(npts, dtype='f8')
+
+    cdef int ifirst_subarr, ilast_subarr, imid_subarr, shift
+
+    cdf_value_table = np.copy(y_sorted[:nwin])
+    idx_sorted_cdf_values = np.argsort(cdf_value_table)
+    _sorted_cdf_value_table = np.copy(cdf_value_table[idx_sorted_cdf_values])
+    _correspondence_indices = np.copy(unsorting_indices(idx_sorted_cdf_values)[::-1])
+
+    cdef double[:] sorted_cdf_value_table = np.array(_sorted_cdf_value_table, dtype='f8')
+    cdef int[:] correspondence_indices = np.array(_correspondence_indices, dtype='i4')
+
+    for iy in range(nhalfwin, npts-nhalfwin-1):
+        result[iy] = correspondence_indices[nhalfwin]
+        value_in = y_sorted[iy + nhalfwin + 1]
+
+        idx_out = correspondence_indices[nwin-1]
+        value_out = sorted_cdf_value_table[idx_out]
+
+        if value_in <= value_out:
+            idx_in = _bisect_left_kernel(sorted_cdf_value_table, value_in)
+        else:
+            idx_in = _bisect_left_kernel(sorted_cdf_value_table, value_in) - 1
+
+        _insert_first_pop_last_kernel(&correspondence_indices[0], idx_in, nwin)
+
+        for i in range(1, nwin):
+            idx = correspondence_indices[i]
+            correspondence_indices[i] += _correspondence_indices_shift(idx_in, idx_out, idx)
+
+        _insert_pop_kernel(&sorted_cdf_value_table[0], idx_in, idx_out, value_in)
+
+    return result

--- a/halotools/utils/engines/conditional_rank_kernel.pyx
+++ b/halotools/utils/engines/conditional_rank_kernel.pyx
@@ -14,6 +14,9 @@ __all__ = ('cython_conditional_rank_kernel', )
 cdef int _bisect_left_kernel(double[:] arr, double value):
     """ Return the index where to insert ``value`` in list ``arr`` of length ``n``,
     assuming ``arr`` is sorted.
+
+    This function is equivalent to the bisect_left function implemented in the
+    python standard libary bisect.
     """
     cdef int n = arr.shape[0]
     cdef int ifirst_subarr = 0
@@ -36,6 +39,8 @@ cdef int _bisect_left_kernel(double[:] arr, double value):
 @cython.nonecheck(False)
 @cython.wraparound(False)
 cdef void _insert_first_pop_last_kernel(int* arr, int value_in, int n):
+    """ Insert the element ``value_in`` into the input array and pop out the last element
+    """
     cdef int i
     for i in range(n-2, -1, -1):
         arr[i+1] = arr[i]
@@ -46,7 +51,7 @@ cdef void _insert_first_pop_last_kernel(int* arr, int value_in, int n):
 @cython.nonecheck(False)
 @cython.wraparound(False)
 cdef int _correspondence_indices_shift(int idx_in, int idx_out, int idx):
-    """
+    """ Update the correspondence indices array
     """
     cdef int shift = 0
     if idx_in < idx_out:
@@ -83,7 +88,7 @@ def cython_conditional_rank_kernel(double[:] y_sorted, int nwin):
     """
     """
     cdef int nhalfwin = int(nwin/2)
-    cdef int iy, idx_in, idx_out, idx_temp, i
+    cdef int iy, idx_in, idx_out, idx_temp, i, idx
     cdef double value_in, value_out
     cdef int npts = y_sorted.shape[0]
     cdef double[:] result = np.zeros(npts, dtype='f8')

--- a/halotools/utils/engines/setup_package.py
+++ b/halotools/utils/engines/setup_package.py
@@ -1,0 +1,27 @@
+from distutils.extension import Extension
+import os
+
+PATH_TO_PKG = os.path.relpath(os.path.dirname(__file__))
+SOURCES = ("conditional_rank_kernel.pyx", )
+THIS_PKG_NAME = '.'.join(__name__.split('.')[:-1])
+
+
+def get_extensions():
+
+    names = [THIS_PKG_NAME + "." + src.replace('.pyx', '') for src in SOURCES]
+    sources = [os.path.join(PATH_TO_PKG, srcfn) for srcfn in SOURCES]
+    include_dirs = ['numpy']
+    libraries = []
+    language = 'c++'
+    extra_compile_args = ['-Ofast']
+
+    extensions = []
+    for name, source in zip(names, sources):
+        extensions.append(Extension(name=name,
+            sources=[source],
+            include_dirs=include_dirs,
+            libraries=libraries,
+            language=language,
+            extra_compile_args=extra_compile_args))
+
+    return extensions

--- a/halotools/utils/tests/test_conditional_percentile.py
+++ b/halotools/utils/tests/test_conditional_percentile.py
@@ -1,0 +1,93 @@
+"""
+"""
+import numpy as np
+from astropy.utils.misc import NumpyRNGContext
+from copy import deepcopy
+
+from ..conditional_percentile import cython_sliding_rank
+from ..conditional_percentile import rank_order_function, _check_xyn_bounds
+from ..array_utils import unsorting_indices
+
+
+__all__ = ('test_brute_force_python_rank_comparison', )
+
+fixed_seed = 43
+
+
+def python_sliding_rank(x, y, window_length):
+    """ Return an array storing the rank-order of each element element in y
+    calculated over a sliding window, after first sorting the elements of y
+    according to the values of x.
+
+    This function is the kernel of calculation of P(y | x).
+
+    Parameters
+    ----------
+    x : ndarray
+        Array of shape (npts, )
+
+    y : ndarray
+        Array of shape (npts, )
+
+    window_length : int
+
+    Returns
+    -------
+    sliding_rank_orders : ndarray
+        Integer array of shape (npts, ) storing values between 0 and window_length-1
+
+    Examples
+    --------
+    >>> x = np.random.rand(100)
+    >>> y = np.random.rand(100)
+    >>> window_length = 5
+    >>> result = python_sliding_rank(x, y, window_length)
+    """
+    x, y, nwin = _check_xyn_bounds(x, y, window_length)
+    npts = len(x)
+
+    indx_x_sorted = np.argsort(x)
+    indx_x_unsorted = unsorting_indices(indx_x_sorted)
+
+    y_sorted = y[indx_x_sorted]
+
+    result = np.zeros(len(x), dtype='f4') + np.nan
+
+    nhalfwin = int(nwin/2)
+    for iy in range(nhalfwin, npts-nhalfwin):
+        ifirst = iy - nhalfwin
+        ilast = iy + nhalfwin + 1
+        window_ranks = rank_order_function(y_sorted[ifirst:ilast])
+        result[iy] = window_ranks[nhalfwin]
+
+    leftmost_window_ranks = rank_order_function(y_sorted[:nwin])
+    result[:nhalfwin+1] = leftmost_window_ranks[:nhalfwin+1]
+    rightmost_window_ranks = rank_order_function(y_sorted[-nwin:])
+    result[-nhalfwin-1:] = rightmost_window_ranks[-nhalfwin-1:]
+
+    return result[indx_x_unsorted].astype(int)
+
+
+def test_brute_force_python_rank_comparison():
+    """ Generate some longer datasets for brute force comparison.
+    """
+    npts = 300
+    window_length_options = (5, 35, 77, 101, 203)
+    num_tests = 20
+    num_failures = 0
+    for seed in range(num_tests):
+        with NumpyRNGContext(seed):
+            x = np.random.rand(npts)
+        with NumpyRNGContext(seed+1):
+            y = np.random.rand(npts)
+        with NumpyRNGContext(seed+2):
+            window_length = np.random.choice(window_length_options)
+
+        result = python_sliding_rank(deepcopy(x), deepcopy(y), window_length)
+        result2 = cython_sliding_rank(deepcopy(x), deepcopy(y), window_length)
+
+        if not np.all(result == result2):
+            num_failures += 1
+
+    msg = "Failed brute force comparison on {0} of {1} random tests"
+    assert num_failures == 0, msg.format(num_failures, num_tests)

--- a/halotools/utils/tests/test_conditional_percentile.py
+++ b/halotools/utils/tests/test_conditional_percentile.py
@@ -15,7 +15,7 @@ fixed_seed = 43
 
 
 def python_sliding_rank(x, y, window_length):
-    """
+    r"""
     Return an array storing the rank-order of each element element in y
     computed over a fixed window length at each x
 
@@ -69,7 +69,7 @@ def python_sliding_rank(x, y, window_length):
 
 
 def test_brute_force_python_rank_comparison():
-    """ Generate some longer datasets for brute force comparison.
+    r""" Generate some longer datasets for brute force comparison.
     """
     npts = 300
     window_length_options = (5, 35, 77, 101, 203)

--- a/halotools/utils/tests/test_conditional_percentile.py
+++ b/halotools/utils/tests/test_conditional_percentile.py
@@ -15,9 +15,9 @@ fixed_seed = 43
 
 
 def python_sliding_rank(x, y, window_length):
-    """ Return an array storing the rank-order of each element element in y
-    calculated over a sliding window, after first sorting the elements of y
-    according to the values of x.
+    """
+    Return an array storing the rank-order of each element element in y
+    computed over a fixed window length at each x
 
     This function is the kernel of calculation of P(y | x).
 


### PR DESCRIPTION
New function `sliding_conditional_percentile` calculates Prob(< y | x) by sliding a window along the distribution and computing the rank-order of each element in the window. The target application is conditional abundance matching and/or decorated HODs where the rank-order percentile of some secondary halo property needs to be calculated on-the-fly at each step in an MCMC (enabling the secondary variable itself to be a model parameter). The performance trick is to only sort the elements in the window once at the beginning, and then pop elements in and out while maintaining the sorted order. So this function enables the CAM-analog to what @yymao has done for 1-dimensional abundance for smooth variations between {Mvir, Vmax}. 

Tagging @mclaughlin6464, as he may find use for this function in his decorated HOD work. 
