### PR TITLE
Added assume_x_is_sorted keyword argument to sliding_conditional_percentile

### DIFF
--- a/halotools/utils/conditional_percentile.py
+++ b/halotools/utils/conditional_percentile.py
@@ -51,7 +51,8 @@ def sliding_conditional_percentile(x, y, window_length, assume_x_is_sorted=False
     >>> window_length = 5
     >>> result = sliding_conditional_percentile(x, y, window_length)
     """
-    rank_orders = cython_sliding_rank(x, y, window_length)
+    rank_orders = cython_sliding_rank(x, y, window_length,
+                assume_x_is_sorted=assume_x_is_sorted)
     rank_order_percentiles = (1. + rank_orders)/float(window_length+1)
     return rank_order_percentiles
 
@@ -76,7 +77,7 @@ def rank_order_function(x):
     return unsorting_indices(np.argsort(x))
 
 
-def cython_sliding_rank(x, y, window_length):
+def cython_sliding_rank(x, y, window_length, assume_x_is_sorted=False):
     r"""
     Return an array storing the rank-order of each element element in y
     computed over a fixed window length at each x
@@ -94,6 +95,10 @@ def cython_sliding_rank(x, y, window_length):
     window_length : int
         Integer must be odd and less than ``npts``
 
+    assume_x_is_sorted : bool, optional
+        Performance enhancement flag that can be used for cases where input `x`
+        has already been sorted. Default is False.
+
     Returns
     -------
     sliding_rank_orders : ndarray
@@ -109,9 +114,12 @@ def cython_sliding_rank(x, y, window_length):
     x, y, nwin = _check_xyn_bounds(x, y, window_length)
     nhalfwin = int(nwin/2)
 
-    indx_x_sorted = np.argsort(x)
-    indx_x_unsorted = unsorting_indices(indx_x_sorted)
-    y_sorted = y[indx_x_sorted]
+    if assume_x_is_sorted:
+        y_sorted = y
+    else:
+        indx_x_sorted = np.argsort(x)
+        indx_x_unsorted = unsorting_indices(indx_x_sorted)
+        y_sorted = y[indx_x_sorted]
 
     result = np.array(cython_conditional_rank_kernel(y_sorted, nwin))
 
@@ -121,7 +129,10 @@ def cython_sliding_rank(x, y, window_length):
     rightmost_window_ranks = rank_order_function(y_sorted[-nwin:])
     result[-nhalfwin-1:] = rightmost_window_ranks[-nhalfwin-1:]
 
-    return result[indx_x_unsorted].astype(int)
+    if assume_x_is_sorted:
+        return result.astype(int)
+    else:
+        return result[indx_x_unsorted].astype(int)
 
 
 def _check_xyn_bounds(x, y, n):

--- a/halotools/utils/conditional_percentile.py
+++ b/halotools/utils/conditional_percentile.py
@@ -9,7 +9,7 @@ from .engines import cython_conditional_rank_kernel
 __all__ = ('sliding_conditional_percentile', )
 
 
-def sliding_conditional_percentile(x, y, window_length):
+def sliding_conditional_percentile(x, y, window_length, assume_x_is_sorted=False):
     r""" Estimate the conditional cumulative distribution function Prob(< y | x)
     using a sliding window of length ``window_length``.
 
@@ -23,6 +23,10 @@ def sliding_conditional_percentile(x, y, window_length):
 
     window_length : int
         Integer must be odd and less than ``npts``
+
+    assume_x_is_sorted : bool, optional
+        Performance enhancement flag that can be used for cases where input `x`
+        has already been sorted. Default is False.
 
     Returns
     -------

--- a/halotools/utils/tests/test_conditional_percentile.py
+++ b/halotools/utils/tests/test_conditional_percentile.py
@@ -4,7 +4,7 @@ import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 from copy import deepcopy
 
-from ..conditional_percentile import cython_sliding_rank
+from ..conditional_percentile import cython_sliding_rank, sliding_conditional_percentile
 from ..conditional_percentile import rank_order_function, _check_xyn_bounds
 from ..array_utils import unsorting_indices
 
@@ -91,3 +91,18 @@ def test_brute_force_python_rank_comparison():
 
     msg = "Failed brute force comparison on {0} of {1} random tests"
     assert num_failures == 0, msg.format(num_failures, num_tests)
+
+
+def test_assume_x_is_sorted():
+    npts = 1000
+    with NumpyRNGContext(fixed_seed):
+        x = np.random.random(npts)
+        y = np.random.random(npts)
+    window_length = 101
+    p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            assume_x_is_sorted=True)
+    p2 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            assume_x_is_sorted=False)
+    assert np.all(p1 != p2)
+
+

--- a/halotools/utils/tests/test_conditional_percentile.py
+++ b/halotools/utils/tests/test_conditional_percentile.py
@@ -93,7 +93,20 @@ def test_brute_force_python_rank_comparison():
     assert num_failures == 0, msg.format(num_failures, num_tests)
 
 
-def test_assume_x_is_sorted():
+def test1_assume_x_is_sorted():
+    npts = 1000
+    with NumpyRNGContext(fixed_seed):
+        x = np.sort(np.random.random(npts))
+        y = np.random.random(npts)
+    window_length = 101
+    p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            assume_x_is_sorted=True)
+    p2 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            assume_x_is_sorted=False)
+    assert np.allclose(p1, p2)
+
+
+def test2_assume_x_is_sorted():
     npts = 1000
     with NumpyRNGContext(fixed_seed):
         x = np.random.random(npts)
@@ -103,6 +116,24 @@ def test_assume_x_is_sorted():
             assume_x_is_sorted=True)
     p2 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
             assume_x_is_sorted=False)
-    assert np.all(p1 != p2)
+    assert not np.allclose(p1, p2)
 
 
+def test3_assume_x_is_sorted():
+    npts = 1000
+    with NumpyRNGContext(fixed_seed):
+        x = np.random.random(npts)
+        y = np.random.random(npts)
+    window_length = 101
+    p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            assume_x_is_sorted=False)
+
+    indx_x_sorted = np.argsort(x)
+    indx_x_unsorted = unsorting_indices(indx_x_sorted)
+    x_sorted = x[indx_x_sorted]
+    y_sorted = y[indx_x_sorted]
+    p2_sorted = sliding_conditional_percentile(x_sorted, y_sorted, window_length,
+            assume_x_is_sorted=True)
+    p2 = p2_sorted[indx_x_unsorted]
+
+    assert np.allclose(p1, p2)


### PR DESCRIPTION
For cases where galaxies/halos can be pre-sorted according to, e.g., stellar or halo mass, the __assume_x_is_sorted__ argument can now be used to improve performance of the calculation of Prob(< y | x). 