### PR TITLE
Added add_subgrid_noise feature to sliding_conditional_percentile

### DIFF
--- a/halotools/utils/tests/test_conditional_percentile.py
+++ b/halotools/utils/tests/test_conditional_percentile.py
@@ -100,9 +100,9 @@ def test1_assume_x_is_sorted():
         y = np.random.random(npts)
     window_length = 101
     p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
-            assume_x_is_sorted=True)
+            assume_x_is_sorted=True, add_subgrid_noise=False)
     p2 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
-            assume_x_is_sorted=False)
+            assume_x_is_sorted=False, add_subgrid_noise=False)
     assert np.allclose(p1, p2)
 
 
@@ -113,9 +113,9 @@ def test2_assume_x_is_sorted():
         y = np.random.random(npts)
     window_length = 101
     p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
-            assume_x_is_sorted=True)
+            assume_x_is_sorted=True, add_subgrid_noise=False)
     p2 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
-            assume_x_is_sorted=False)
+            assume_x_is_sorted=False, add_subgrid_noise=False)
     assert not np.allclose(p1, p2)
 
 
@@ -126,14 +126,28 @@ def test3_assume_x_is_sorted():
         y = np.random.random(npts)
     window_length = 101
     p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
-            assume_x_is_sorted=False)
+            assume_x_is_sorted=False, add_subgrid_noise=False)
 
     indx_x_sorted = np.argsort(x)
     indx_x_unsorted = unsorting_indices(indx_x_sorted)
     x_sorted = x[indx_x_sorted]
     y_sorted = y[indx_x_sorted]
     p2_sorted = sliding_conditional_percentile(x_sorted, y_sorted, window_length,
-            assume_x_is_sorted=True)
+            assume_x_is_sorted=True, add_subgrid_noise=False)
     p2 = p2_sorted[indx_x_unsorted]
 
     assert np.allclose(p1, p2)
+
+
+def test_subgrid_noise():
+    npts = 1000
+    with NumpyRNGContext(fixed_seed):
+        x = np.random.random(npts)
+        y = np.random.random(npts)
+    window_length = 51
+    p1 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            add_subgrid_noise=True)
+    p2 = sliding_conditional_percentile(deepcopy(x), deepcopy(y), window_length,
+            add_subgrid_noise=False)
+    assert not np.allclose(p1, p2, atol=0.01)
+    assert np.allclose(p1, p2, atol=0.05)


### PR DESCRIPTION
Using this keyword minimizes the impact of discreteness effects caused by the finite window size over which Prob(<y | x) is estimated by the `sliding_conditional_percentile` function. This bug was discovered when using the `sliding_conditional_percentile` function to generate mock catalogs for LSST-DESC; the bug becomes more apparent when modeling very large galaxy samples. This PR fixes the bug. 