### PR TITLE
Added new `resample_x_to_match_y` function to `halotools.utils`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@
 
 - Added `~halotools.utils.sliding_conditional_percentile` function to `~halotools.utils` sub-package.
 
+- Added new `resample_x_to_match_y` function to `halotools.utils`.
+
 
 0.6 (2017-12-15)
 ----------------

--- a/docs/function_usage/utility_functions.rst
+++ b/docs/function_usage/utility_functions.rst
@@ -38,7 +38,7 @@ Matching one distribution to another
 .. autosummary::
 
     distribution_matching_indices
-
+    resample_x_to_match_y
 
 Rotations, dot products, and other operations in 3d space
 ===============================================================

--- a/halotools/utils/distribution_matching.py
+++ b/halotools/utils/distribution_matching.py
@@ -80,7 +80,7 @@ def distribution_matching_indices(input_distribution, output_distribution,
 
 def resample_x_to_match_y(x, y, bins, seed=None):
     """ Return the indices that resample `x` (with replacement) so that the
-    resampled distribution matches the histogram of `y` tabulated in the input `bins`.
+    resampled distribution matches the histogram of `y`.
     The returned indexing array will be sorted so that
     the i^th element of x[idx] is as close as possible to the
     i^th value of x, subject to the the constraint that x[idx] matches y.
@@ -94,7 +94,8 @@ def resample_x_to_match_y(x, y, bins, seed=None):
         Numpy array of shape (ny, )
 
     bins : ndarray
-        Numpy array of shape (nbins, )
+        Numpy array of shape (nbins, ) defining how the distribution `y`
+        will be binned to evaluate its PDF.
 
     seed : int, optional
         Random number seed used to generate indices.

--- a/halotools/utils/distribution_matching.py
+++ b/halotools/utils/distribution_matching.py
@@ -5,7 +5,7 @@ import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
 
-__all__ = ('distribution_matching_indices', )
+__all__ = ('distribution_matching_indices', 'resample_x_to_match_y')
 
 
 def distribution_matching_indices(input_distribution, output_distribution,
@@ -32,7 +32,8 @@ def distribution_matching_indices(input_distribution, output_distribution,
         determined by `numpy.histogram`.
 
     seed : int, optional
-        Random number seed used to generate indices. Default is None for stochastic results.
+        Random number seed used to generate indices.
+        Default is None for stochastic results.
 
     Returns
     -------
@@ -74,4 +75,50 @@ def distribution_matching_indices(input_distribution, output_distribution,
     candidate_indices = np.arange(len(input_distribution))
     with NumpyRNGContext(seed):
         indices = np.random.choice(candidate_indices, size=nselect, replace=True, p=prob_select)
+    return indices
+
+
+def resample_x_to_match_y(x, y, bins, seed=None):
+    """ Return the indices that resample `x` (with replacement) so that the
+    resampled distribution matches the histogram of `y` tabulated in the input `bins`.
+    The returned indexing array will be sorted so that
+    the i^th element of x[idx] is as close as possible to the
+    i^th value of x, subject to the the constraint that x[idx] matches y.
+
+    Parameters
+    ----------
+    x : ndarray
+        Numpy array of shape (nx, )
+
+    y : ndarray
+        Numpy array of shape (ny, )
+
+    bins : ndarray
+        Numpy array of shape (nbins, )
+
+    seed : int, optional
+        Random number seed used to generate indices.
+        Default is None for stochastic results.
+
+    Returns
+    -------
+    indices : ndarray
+        Numpy array of shape (nx, )
+
+    Examples
+    --------
+    >>> nx, ny = int(1e5), int(1e4)
+    >>> x = np.random.normal(loc=0, size=nx, scale=1)
+    >>> y = np.random.normal(loc=1, size=ny, scale=0.5)
+    >>> bins = np.linspace(-5, 5, 100)
+    >>> indices = resample_x_to_match_y(x, y, bins)
+    >>> rescaled_x = x[indices]
+    """
+    nselect = len(x)
+    idx = distribution_matching_indices(x, y, nselect, bins, seed=seed)
+    xnew = x[idx]
+    idx_sorted_xnew = np.argsort(xnew)
+    idx_sorted_x = np.argsort(x)
+    indices = np.empty_like(x).astype(int)
+    indices[idx_sorted_x] = idx[idx_sorted_xnew]
     return indices

--- a/halotools/utils/tests/test_distribution_matching.py
+++ b/halotools/utils/tests/test_distribution_matching.py
@@ -3,7 +3,7 @@
 import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
-from ..distribution_matching import distribution_matching_indices
+from ..distribution_matching import distribution_matching_indices, resample_x_to_match_y
 
 __all__ = ('test_distribution_matching_indices1', )
 
@@ -28,3 +28,25 @@ def test_distribution_matching_indices1():
     result_percentiles = np.percentile(result, percentile_table)
     correct_percentiles = np.percentile(output_distribution, percentile_table)
     assert np.allclose(result_percentiles, correct_percentiles, rtol=0.1)
+
+
+def test_resample_x_to_match_y():
+    """
+    """
+    nx, ny = int(9.9999e5), int(1e6)
+    with NumpyRNGContext(fixed_seed):
+        x = np.random.normal(loc=0, size=nx, scale=1)
+        y = np.random.normal(loc=0.5, size=ny, scale=0.25)
+    bins = np.linspace(y.min(), y.max(), 100)
+    indices = resample_x_to_match_y(x, y, bins, seed=fixed_seed)
+    rescaled_x = x[indices]
+
+    idx_x_sorted = np.argsort(x)
+    assert np.all(np.diff(rescaled_x[idx_x_sorted]) >= 0)
+
+    try:
+        result, __ = np.histogram(rescaled_x, bins, density=True)
+        correct_result, __ = np.histogram(y, bins, density=True)
+        assert np.allclose(result, correct_result, atol=0.02)
+    except TypeError:
+        pass


### PR DESCRIPTION
The `resample_x_to_match_y` function is used in the cosmoDC2 pipeline to make mocks for LSST-DESC. 