### PR TITLE
Renamed conditional_abunmatch function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@
 
 - Added new `resample_x_to_match_y` function to `halotools.utils`.
 
+- Renamed old implementation of `conditional_abunmatch` to `conditional_abunmatch_bin_based`
+
 
 0.6 (2017-12-15)
 ----------------

--- a/docs/function_usage/abundance_matching.rst
+++ b/docs/function_usage/abundance_matching.rst
@@ -7,4 +7,4 @@ Abundance Matching and Age Matching
 
 .. autosummary::
 
-    conditional_abunmatch
+    conditional_abunmatch_bin_based

--- a/halotools/empirical_models/abunmatch/__init__.py
+++ b/halotools/empirical_models/abunmatch/__init__.py
@@ -1,2 +1,2 @@
-from .conditional_abunmatch import *
+from .conditional_abunmatch_bin_based import *
 from .noisy_percentile import *

--- a/halotools/empirical_models/abunmatch/conditional_abunmatch_bin_based.py
+++ b/halotools/empirical_models/abunmatch/conditional_abunmatch_bin_based.py
@@ -7,10 +7,10 @@ from ...utils import unsorting_indices
 
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
-__all__ = ('conditional_abunmatch', 'randomly_resort')
+__all__ = ('conditional_abunmatch_bin_based', 'randomly_resort')
 
 
-def conditional_abunmatch(haloprop, galprop, sigma=0., npts_lookup_table=1000, seed=None):
+def conditional_abunmatch_bin_based(haloprop, galprop, sigma=0., npts_lookup_table=1000, seed=None):
     """ Function used to model a correlation between two variables,
     ``haloprop`` and ``galprop``, using conditional abundance matching (CAM).
 
@@ -64,7 +64,7 @@ def conditional_abunmatch(haloprop, galprop, sigma=0., npts_lookup_table=1000, s
     --------
     Suppose we would like to do some CAM-style modeling of a correlation between some
     halo property ``haloprop`` and some galaxy property ``galprop``.
-    The `conditional_abunmatch` function
+    The `conditional_abunmatch_bin_based` function
     can be used to map values of the galaxy property onto the halos in such a way that the
     PDF of ``galprop`` is preserved and a correlation (of variable strength)
     between ``haloprop`` and ``galprop`` is introduced.
@@ -74,11 +74,11 @@ def conditional_abunmatch(haloprop, galprop, sigma=0., npts_lookup_table=1000, s
     >>> spin_at_fixed_mpeak = 10**np.random.normal(loc=mean, size=size, scale=std)
     >>> num_gals_in_mstar_bin = int(1e3)
     >>> some_galprop_at_fixed_mstar = np.random.power(2.5, size=num_gals_in_mstar_bin)
-    >>> modeled_galprop = conditional_abunmatch(spin_at_fixed_mpeak, some_galprop_at_fixed_mstar)
+    >>> modeled_galprop = conditional_abunmatch_bin_based(spin_at_fixed_mpeak, some_galprop_at_fixed_mstar)
 
     Notes
     -----
-    To approximate the input ``galprop`` distribution, the implementation of `conditional_abunmatch`
+    To approximate the input ``galprop`` distribution, the implementation of `conditional_abunmatch_bin_based`
     builds a lookup table for the CDF of the input ``galprop`` using a simple call to `numpy.interp`,
     which can result in undesired edge case behavior if
     a large fraction of model galaxies lie outside the range of the data.

--- a/halotools/empirical_models/abunmatch/tests/test_conditional_abunmatch.py
+++ b/halotools/empirical_models/abunmatch/tests/test_conditional_abunmatch.py
@@ -3,23 +3,23 @@
 import numpy as np
 from astropy.utils import NumpyRNGContext
 
-from ..conditional_abunmatch import conditional_abunmatch
+from ..conditional_abunmatch_bin_based import conditional_abunmatch_bin_based
 
 
-def test_conditional_abunmatch1():
+def test_conditional_abunmatch_bin_based1():
     with NumpyRNGContext(43):
         x = np.random.normal(loc=0, scale=0.1, size=100)
     y = np.linspace(10, 20, 100)
-    model_y = conditional_abunmatch(x, y, seed=43)
+    model_y = conditional_abunmatch_bin_based(x, y, seed=43)
     msg = "monotonic cam does not preserve mean"
     assert np.allclose(model_y.mean(), y.mean(), rtol=0.1), msg
 
 
-def test_conditional_abunmatch2():
+def test_conditional_abunmatch_bin_based2():
     with NumpyRNGContext(43):
         x = np.random.normal(loc=0, scale=0.1, size=100)
     y = np.linspace(10, 20, 100)
-    model_y = conditional_abunmatch(x, y, seed=43)
+    model_y = conditional_abunmatch_bin_based(x, y, seed=43)
     idx_x_sorted = np.argsort(x)
     msg = "monotonic cam does not preserve correlation"
     high = model_y[idx_x_sorted][-50:].mean()
@@ -29,11 +29,11 @@ def test_conditional_abunmatch2():
     assert high_low_fracdiff > 0.1
 
 
-def test_conditional_abunmatch3():
+def test_conditional_abunmatch_bin_based3():
     with NumpyRNGContext(43):
         x = np.random.normal(loc=0, scale=0.1, size=100)
     y = np.linspace(10, 20, 100)
-    model_y = conditional_abunmatch(x, y, sigma=0.01, seed=43)
+    model_y = conditional_abunmatch_bin_based(x, y, sigma=0.01, seed=43)
     idx_x_sorted = np.argsort(x)
     msg = "low-noise cam does not preserve correlation"
     high = model_y[idx_x_sorted][-50:].mean()

--- a/halotools/utils/inverse_transformation_sampling.py
+++ b/halotools/utils/inverse_transformation_sampling.py
@@ -95,7 +95,7 @@ def monte_carlo_from_cdf_lookup(x_table, y_table, mc_input='random',
     in some other array, ``x``. You can accomplish this by passing in the rank-order
     percentile values of ``x`` instead of uniform randoms.
     This is the basis of the conditional abundance matching technique
-    implemented by the `~halotools.empirical_models.conditional_abunmatch` function.
+    implemented by the `~halotools.empirical_models.conditional_abunmatch_bin_based` function.
 
     To see an example of how this works, let's create some fake data for some property *x*
     that we wish to model as being correlated with Monte Carlo realizations of *y* while


### PR DESCRIPTION
New function is named conditional_abunmatch_bin_based. The purpose of this PR is to clear the namespace for a soon-to-be-added new implementation of conditional abundance matching that is entirely bin-free. This will unfortunately break backwards compatibility.

CC @h-aung @manodeep @duncandc 