### PR TITLE
Added support for `x==Lbox` points for SubhaloPhaseSpace model

### DIFF
--- a/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_phase_space.py
+++ b/halotools/empirical_models/phase_space_models/subhalo_based_models/subhalo_phase_space.py
@@ -351,8 +351,8 @@ def _sign_pbc(x1, x2, period=None, equality_fill_val=0., return_pbc_correction=F
         try:
             assert np.all(x1 >= 0)
             assert np.all(x2 >= 0)
-            assert np.all(x1 < period)
-            assert np.all(x2 < period)
+            assert np.all(x1 <= period)
+            assert np.all(x2 <= period)
         except AssertionError:
             msg = "If period is not None, all values of x and y must be between [0, period)"
             raise ValueError(msg)


### PR DESCRIPTION
Thanks to @johannesulf for pointing this out in #900 . 

It might be a good idea if the behavior of a few other Halotools functions such as `enforce_periodicity_of_box` were modified to automatically wrap `x == Lbox` points to `x == 0.` Any thoughts on this @johannesulf? 