### PR TITLE
HOD mock preserving total number of galaxies (and relative deviation) when a seed is specified

### DIFF
--- a/halotools/empirical_models/assembias_models/__init__.py
+++ b/halotools/empirical_models/assembias_models/__init__.py
@@ -1,1 +1,1 @@
-from .heaviside_assembias import HeavisideAssembias
+from .heaviside_assembias import *

--- a/halotools/empirical_models/assembias_models/heaviside_assembias.py
+++ b/halotools/empirical_models/assembias_models/heaviside_assembias.py
@@ -519,7 +519,8 @@ class PreservingNgalHeavisideAssembias(HeavisideAssembias):
             with NumpyRNGContext(seed):
                 score = np.random.rand(total)
             score.sort()
-            x = first_occupation_moment.cumsum() / first_occupation_moment.sum()
+            x = first_occupation_moment.cumsum(dtype=np.float64)
+            x /= x[-1]
             result = np.ediff1d(np.insert(np.searchsorted(score, x), 0, 0))
         else:
             msg = ("\nYou have chosen to set ``_upper_occupation_bound`` to some value \n"

--- a/halotools/empirical_models/assembias_models/heaviside_assembias.py
+++ b/halotools/empirical_models/assembias_models/heaviside_assembias.py
@@ -7,6 +7,7 @@ any method of any component model, as in
 
 import numpy as np
 from warnings import warn
+from astropy.utils.misc import NumpyRNGContext
 
 from .. import model_defaults, model_helpers
 
@@ -15,7 +16,7 @@ from ...custom_exceptions import HalotoolsError
 from ...utils.table_utils import compute_conditional_percentiles
 import collections
 
-__all__ = ('HeavisideAssembias', )
+__all__ = ('HeavisideAssembias', 'PreservingNgalHeavisideAssembias')
 __author__ = ('Andrew Hearin', )
 
 
@@ -491,3 +492,47 @@ class HeavisideAssembias(object):
             return result
 
         return wrapper
+
+
+class PreservingNgalHeavisideAssembias(HeavisideAssembias):
+    def assembias_mc_occupation(self, seed=None, **kwargs):
+        first_occupation_moment_orig = self.mean_occupation_orig(**kwargs)
+        first_occupation_moment = self.mean_occupation(**kwargs)
+        if self._upper_occupation_bound == 1:
+            with NumpyRNGContext(seed):
+                score = np.random.rand(custom_len(first_occupation_moment_orig))
+            total = np.count_nonzero(first_occupation_moment_orig > score)
+            result = np.where(first_occupation_moment > score, 1, 0)
+            diff = result.sum() - total
+            if diff < 0:
+                x = (first_occupation_moment / score)
+                result.fill(0)
+                result[x.argsort()[-total:]] = 1
+            elif diff > 0:
+                x = (1.0-first_occupation_moment) / (1.0-score)
+                result.fill(0)
+                result[x.argsort()[:total]] = 1
+        elif self._upper_occupation_bound == float("inf"):
+            total = self._poisson_distribution(first_occupation_moment_orig.sum(), seed=seed)
+            if seed is not None:
+                seed += 1
+            with NumpyRNGContext(seed):
+                score = np.random.rand(total)
+            score.sort()
+            x = first_occupation_moment.cumsum() / first_occupation_moment.sum()
+            result = np.ediff1d(np.insert(np.searchsorted(score, x), 0, 0))
+        else:
+            msg = ("\nYou have chosen to set ``_upper_occupation_bound`` to some value \n"
+                "besides 1 or infinity. In such cases, you must also \n"
+                "write your own ``mc_occupation`` method that overrides the method in the \n"
+                "OccupationComponent super-class\n")
+            raise HalotoolsError(msg)
+
+        if 'table' in kwargs:
+            kwargs['table']['halo_num_'+self.gal_type] = result
+        return result
+
+    def _decorate_baseline_method(self):
+        self.mean_occupation_orig = self.mean_occupation
+        self.mc_occupation = self.assembias_mc_occupation
+        super(PreservingNgalHeavisideAssembias, self)._decorate_baseline_method()

--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -5,7 +5,7 @@ in all HOD-style models of the galaxy-halo connection.
 """
 
 import numpy as np
-from scipy.stats import poisson
+from scipy.special import pdtrik
 from astropy.extern import six
 from abc import ABCMeta
 from astropy.utils.misc import NumpyRNGContext
@@ -180,13 +180,11 @@ class OccupationComponent(object):
         mc_abundance : array
             Integer array giving the number of galaxies in each of the input table.
         """
-        # The scipy built-in Poisson number generator raises an exception
-        # if its input is zero, so here we impose a simple workaround
-        first_occupation_moment = np.where(first_occupation_moment <= 0,
-            model_defaults.default_tiny_poisson_fluctuation, first_occupation_moment)
-
+        # We don't use the built-in Poisson number generator so that when a seed
+        # is specified, it preserves the ranks among rvs even when mean is changed.
         with NumpyRNGContext(seed):
-            result = poisson.rvs(first_occupation_moment)
+            result = np.ceil(pdtrik(np.random.rand(*first_occupation_moment.shape),
+                                    first_occupation_moment)).astype(np.int)
         if 'table' in kwargs:
             kwargs['table']['halo_num_'+self.gal_type] = result
         return result

--- a/halotools/empirical_models/occupation_models/zheng07_components.py
+++ b/halotools/empirical_models/occupation_models/zheng07_components.py
@@ -9,12 +9,13 @@ import warnings
 from .occupation_model_template import OccupationComponent
 
 from .. import model_defaults
-from ..assembias_models import HeavisideAssembias
+from ..assembias_models import HeavisideAssembias, PreservingNgalHeavisideAssembias
 
 from ...custom_exceptions import HalotoolsError
 
 __all__ = ('Zheng07Cens', 'Zheng07Sats',
-           'AssembiasZheng07Cens', 'AssembiasZheng07Sats')
+           'AssembiasZheng07Cens', 'AssembiasZheng07Sats',
+           'PreservingNgalAssembiasZheng07Cens', 'PreservingNgalAssembiasZheng07Sats')
 
 
 class Zheng07Cens(OccupationComponent):
@@ -599,6 +600,120 @@ class AssembiasZheng07Cens(Zheng07Cens, HeavisideAssembias):
         """
         Zheng07Cens.__init__(self, **kwargs)
         HeavisideAssembias.__init__(self,
+            lower_assembias_bound=self._lower_occupation_bound,
+            upper_assembias_bound=self._upper_occupation_bound,
+            method_name_to_decorate='mean_occupation', **kwargs)
+
+
+
+class PreservingNgalAssembiasZheng07Sats(Zheng07Sats, PreservingNgalHeavisideAssembias):
+    r""" Assembly-biased modulation of `Zheng07Sats` that preserves N_gals.
+    """
+
+    def __init__(self, **kwargs):
+        r"""
+        Parameters
+        ----------
+        threshold : float, optional
+            Luminosity threshold of the mock galaxy sample. If specified,
+            input value must agree with one of the thresholds used in Zheng07 to fit HODs:
+            [-18, -18.5, -19, -19.5, -20, -20.5, -21, -21.5, -22].
+            Default value is specified in the `~halotools.empirical_models.model_defaults` module.
+
+        prim_haloprop_key : string, optional
+            String giving the column name of the primary halo property governing
+            the occupation statistics of gal_type galaxies.
+            Default value is specified in the `~halotools.empirical_models.model_defaults` module.
+
+        sec_haloprop_key : string, optional
+            String giving the column name of the secondary halo property
+            governing the assembly bias. Must be a key in the table
+            passed to the methods of `HeavisideAssembiasComponent`.
+            Default value is specified in the `~halotools.empirical_models.model_defaults` module.
+
+        split : float or list, optional
+            Fraction or list of fractions between 0 and 1 defining how
+            we split halos into two groupings based on
+            their conditional secondary percentiles.
+            Default is 0.5 for a constant 50/50 split.
+
+        split_abscissa : list, optional
+            Values of the primary halo property at which the halos are split as described above in
+            the ``split`` argument. If ``loginterp`` is set to True (the default behavior),
+            the interpolation will be done in the logarithm of the primary halo property.
+            Default is to assume a constant 50/50 split.
+
+        assembias_strength : float or list, optional
+            Fraction or sequence of fractions between -1 and 1
+            defining the assembly bias correlation strength.
+            Default is 0.5.
+
+        assembias_strength_abscissa : list, optional
+            Values of the primary halo property at which the assembly bias strength is specified.
+            Default is to assume a constant strength of 0.5. If passing a list, the strength
+            will interpreted at the input ``assembias_strength_abscissa``.
+            Default is to assume a constant strength of 0.5.
+
+        """
+        Zheng07Sats.__init__(self, **kwargs)
+        PreservingNgalHeavisideAssembias.__init__(self,
+            method_name_to_decorate='mean_occupation',
+            lower_assembias_bound=self._lower_occupation_bound,
+            upper_assembias_bound=self._upper_occupation_bound,
+            **kwargs)
+
+
+class PreservingNgalAssembiasZheng07Cens(Zheng07Cens, PreservingNgalHeavisideAssembias):
+    r""" Assembly-biased modulation of `Zheng07Cens` that preserves N_gals.
+    """
+
+    def __init__(self, **kwargs):
+        r"""
+        Parameters
+        ----------
+        threshold : float, optional
+            Luminosity threshold of the mock galaxy sample. If specified,
+            input value must agree with one of the thresholds used in Zheng07 to fit HODs:
+            [-18, -18.5, -19, -19.5, -20, -20.5, -21, -21.5, -22].
+            Default value is specified in the `~halotools.empirical_models.model_defaults` module.
+
+        prim_haloprop_key : string, optional
+            String giving the column name of the primary halo property governing
+            the occupation statistics of gal_type galaxies.
+            Default value is specified in the `~halotools.empirical_models.model_defaults` module.
+
+        sec_haloprop_key : string, optional
+            String giving the column name of the secondary halo property
+            governing the assembly bias. Must be a key in the table
+            passed to the methods of `HeavisideAssembiasComponent`.
+            Default value is specified in the `~halotools.empirical_models.model_defaults` module.
+
+        split : float or list, optional
+            Fraction or list of fractions between 0 and 1 defining how
+            we split halos into two groupings based on
+            their conditional secondary percentiles.
+            Default is 0.5 for a constant 50/50 split.
+
+        split_abscissa : list, optional
+            Values of the primary halo property at which the halos are split as described above in
+            the ``split`` argument. If ``loginterp`` is set to True (the default behavior),
+            the interpolation will be done in the logarithm of the primary halo property.
+            Default is to assume a constant 50/50 split.
+
+        assembias_strength : float or list, optional
+            Fraction or sequence of fractions between -1 and 1
+            defining the assembly bias correlation strength.
+            Default is 0.5.
+
+        assembias_strength_abscissa : list, optional
+            Values of the primary halo property at which the assembly bias strength is specified.
+            Default is to assume a constant strength of 0.5. If passing a list, the strength
+            will interpreted at the input ``assembias_strength_abscissa``.
+            Default is to assume a constant strength of 0.5.
+
+        """
+        Zheng07Cens.__init__(self, **kwargs)
+        PreservingNgalHeavisideAssembias.__init__(self,
             lower_assembias_bound=self._lower_occupation_bound,
             upper_assembias_bound=self._upper_occupation_bound,
             method_name_to_decorate='mean_occupation', **kwargs)


### PR DESCRIPTION
This PR is to ensure that:
1. When populating a Decorated HOD mock *with a specific seed*, the total number of galaxies will remain the same. 
2. When populating HOD mocks using *same specific seed* but different HOD parameters, for each mock, the relative deviation between the total number of galaxies and the mean occupation will be preserved. 

Here's an example of how the number of galaxies changes with `alpha` and `A_cen` in the `AssembiasZheng07` model *with a fixed seed*: 

![image](https://user-images.githubusercontent.com/3792659/39474534-6ef64dee-4d22-11e8-9d45-7688341a5ee1.png)

For analyses that require a smooth response to the change in parameters, the behavior in this PR when a seed is specified is very desirable. 

Thanks to @KuanWang-Astro for discovering this. (cc @andrew-zentner @mclaughlin6464)

(This PR was originally accidentally submitted to https://github.com/aphearin/halotools/pull/34, you can find some discussion there.)