### PR TITLE
Allocate memory before reading chunks

### DIFF
--- a/halotools/sim_manager/tabular_ascii_reader.py
+++ b/halotools/sim_manager/tabular_ascii_reader.py
@@ -574,7 +574,7 @@ class TabularAsciiReader(object):
         header_length = int(self.header_len())
         print(("Number of rows in detected header = %i \n" % header_length))
 
-        chunklist = []
+        full_array = np.zeros(num_data_rows, dtype=self.dt)
         with self._compression_safe_file_opener(self.input_fname, 'r') as f:
 
             for skip_header_row in range(header_length):
@@ -587,15 +587,13 @@ class TabularAsciiReader(object):
                 chunk_array = np.array(list(
                     self.data_chunk_generator(num_rows_in_chunk, f)), dtype=self.dt)
                 cut_chunk = self.apply_row_cut(chunk_array)
-                chunklist.append(cut_chunk)
+                full_array[_i*num_rows_in_chunk:(_i+1)*num_rows_in_chunk] = cut_chunk
 
             # Now for the remainder chunk
             chunk_array = np.array(list(
                 self.data_chunk_generator(num_rows_in_chunk_remainder, f)), dtype=self.dt)
             cut_chunk = self.apply_row_cut(chunk_array)
-            chunklist.append(cut_chunk)
-
-        full_array = np.concatenate(chunklist)
+            full_array[num_full_chunks*num_rows_in_chunk:] = cut_chunk
 
         end = time()
         runtime = (end-start)


### PR DESCRIPTION
At the moment, if this is going to fail because of a memory error it will fail right at the end during the concatenate which I think doubles memory (because it assigns a new array and then copies things into it).

With this, we avoid the doubling and if we are going to get an OOM failure we get it much earlier.

I wasn't able to get tests running locally tonight so there is a decent chance I have missed something silly. I can fix up any issues tomorrow, but please let me know if I have missed something and this doesn't make sense.