### PR TITLE
Satellite rotations pr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@
 
 - Added new utils function `bijective_distribution_matching`
 
+- Added new utils module `satellite_rotations` implementing functions that can be used to remap satellite orientations and positions within their halos
+
 
 0.6 (2017-12-15)
 ----------------

--- a/docs/function_usage/utility_functions.rst
+++ b/docs/function_usage/utility_functions.rst
@@ -21,6 +21,7 @@ Calculating quantities for objects grouped into a common halo
 .. autosummary::
 
 	group_member_generator
+    compute_richness
 
 
 Generating Monte Carlo realizations
@@ -67,3 +68,13 @@ Estimating two-dimensional PDFs
 .. autosummary::
 
     sliding_conditional_percentile
+
+
+Satellite orientations and intra-halo positions
+===============================================================
+
+.. autosummary::
+
+    rotate_satellite_vectors
+    calculate_satellite_radial_vector
+    reposition_satellites_from_radial_vectors

--- a/halotools/utils/__init__.py
+++ b/halotools/utils/__init__.py
@@ -1,4 +1,4 @@
-""" This module contains helper functions used throughout the Halotools package.
+r""" This module contains helper functions used throughout the Halotools package.
 """
 from __future__ import division, print_function, absolute_import, unicode_literals
 
@@ -8,10 +8,11 @@ from .io_utils import *
 from .table_utils import *
 from .value_added_halo_table_functions import *
 from .group_member_generator import group_member_generator
-from .crossmatch import crossmatch
+from .crossmatch import *
 from .array_indexing_manipulations import *
 from .inverse_transformation_sampling import *
 from .distribution_matching import *
 from .matrix_operations_3d import *
 from .probabilistic_binning import fuzzy_digitize
 from .conditional_percentile import sliding_conditional_percentile
+from .satellite_rotations import *

--- a/halotools/utils/crossmatch.py
+++ b/halotools/utils/crossmatch.py
@@ -1,12 +1,15 @@
-""" Module containing the `~halotools.utils.crossmatch` function used to
+r""" Module containing the `~halotools.utils.crossmatch` function used to
 calculate indices providing the correspondence between two data tables
 sharing a common objectID.
 """
 import numpy as np
 
 
+__all__ = ('crossmatch', 'compute_richness')
+
+
 def crossmatch(x, y, skip_bounds_checking=False):
-    """
+    r"""
     Finds where the elements of ``x`` appear in the array ``y``, including repeats.
 
     The elements in x may be repeated, but the elements in y must be unique.
@@ -57,8 +60,8 @@ def crossmatch(x, y, skip_bounds_checking=False):
 
     Notes
     -----
-    The matching between ``x`` and ``y`` is done on the sorted arrays.  A consequence of 
-    this is that x[idx_x] and y[idx_y] will generally be a subset of ``x`` and ``y`` in 
+    The matching between ``x`` and ``y`` is done on the sorted arrays.  A consequence of
+    this is that x[idx_x] and y[idx_y] will generally be a subset of ``x`` and ``y`` in
     sorted order.
 
     Examples
@@ -172,3 +175,38 @@ def crossmatch(x, y, skip_bounds_checking=False):
 
     # Undo the original sorting and return the result
     return idx_x_sorted[idx_x], idx_y_sorted[idx_y]
+
+
+def compute_richness(unique_halo_ids, halo_id_of_galaxies):
+    r""" For every ID in unique_halo_ids,
+    calculate the number of times the ID appears in halo_id_of_galaxies.
+
+    Parameters
+    ----------
+    unique_halo_ids : ndarray
+        Numpy array of shape (num_halos, ) storing unique integers
+
+    halo_id_of_galaxies : ndarray
+        Numpy integer array of shape (num_halos, ) storing the host ID of each galaxy
+
+    Returns
+    -------
+    richness : ndarray
+        Numpy integer array of shape (num_halos, ) storing halo richness
+
+    Examples
+    --------
+    >>> num_hosts = 100
+    >>> num_sats = int(1e5)
+    >>> unique_halo_ids = np.arange(5, num_hosts + 5)
+    >>> halo_id_of_galaxies = np.random.randint(0, 5000, num_sats)
+    >>> richness = compute_richness(unique_halo_ids, halo_id_of_galaxies)
+    """
+    unique_halo_ids = np.atleast_1d(unique_halo_ids).astype(int)
+    halo_id_of_galaxies = np.atleast_1d(halo_id_of_galaxies).astype(int)
+    richness_result = np.zeros_like(unique_halo_ids).astype(int)
+
+    vals, counts = np.unique(halo_id_of_galaxies, return_counts=True)
+    idxA, idxB = crossmatch(vals, unique_halo_ids)
+    richness_result[idxB] = counts[idxA]
+    return richness_result

--- a/halotools/utils/satellite_rotations.py
+++ b/halotools/utils/satellite_rotations.py
@@ -1,0 +1,396 @@
+r"""
+"""
+import numpy as np
+from .crossmatch import crossmatch
+from .matrix_operations_3d import rotation_matrices_from_angles, rotate_vector_collection
+
+
+__all__ = ('rotate_satellite_vectors', 'calculate_satellite_radial_vector',
+        'reposition_satellites_from_radial_vectors')
+
+
+def rotate_satellite_vectors(satellite_vectors, satellite_hostid, satellite_rotation_angles,
+            host_halo_id, host_halo_axis, return_has_match=False):
+    r""" Rotate an input set of `satellite_vectors` by the input `satellite_rotation_angles`
+    about the axis associated with each satellite's host halo.
+
+    Parameters
+    ----------
+    satellite_vectors : ndarray
+        Numpy array of shape (num_sats, 3) storing a 3d vector associated with each satellite.
+
+    satellite_hostid : ndarray
+        Numpy integer array of shape (num_sats, ) storing the ID of the associated host halo.
+        Entries of `satellite_hostid` without a matching entry in `host_halo_id` will not be rotated
+
+    satellite_rotation_angles : ndarray
+        Numpy array of shape (num_sats, ) storing the rotation angles in radians
+
+    host_halo_id : ndarray
+        Numpy integer array of shape (num_host_halos, ) storing
+        the unique IDs of candidate host halos.
+
+    host_halo_axis : ndarray
+        Numpy array of shape (num_host_halos, 3) storing the 3d vector about which
+        satellites of that host halo will be rotated.
+
+    return_has_match : bool, optional
+        Optionally return a boolean array storing whether the satellite has a matching host.
+        Default is False
+
+    Returns
+    -------
+    rotated_vectors : ndarray
+        Numpy array of shape (num_sats, 3) storing the rotated satellite vectors
+
+    has_match : ndarray, optional
+        Numpy boolean array of shape (num_sats, ) equals True only for those satellites
+        for which there is a matching host_halo_id
+
+    Examples
+    --------
+    >>> num_sats, num_host_halos = int(1e4), 100
+    >>> satellite_hostid = np.random.randint(0, num_host_halos, num_sats)
+    >>> satellite_rotation_angles = np.random.uniform(-np.pi/2., np.pi/2., num_sats)
+    >>> satellite_vectors = np.random.uniform(-1, 1, num_sats*3).reshape((num_sats, 3))
+    >>> host_halo_id = np.arange(num_host_halos)
+    >>> host_halo_axis = np.random.uniform(-1, 1, num_host_halos*3).reshape((num_host_halos, 3))
+    >>> rotated_vectors = rotate_satellite_vectors(satellite_vectors, satellite_hostid, satellite_rotation_angles, host_halo_id, host_halo_axis)
+    """
+    satellite_hostid = np.atleast_1d(satellite_hostid)
+    satellite_rotation_angles = np.atleast_1d(satellite_rotation_angles)
+    satellite_vectors = np.atleast_2d(satellite_vectors)
+    host_halo_id = np.atleast_1d(host_halo_id)
+    host_halo_axis = np.atleast_2d(host_halo_axis)
+
+    has_match = np.isin(satellite_hostid, host_halo_id)
+    satellite_rotation_angles[~has_match] = 0.
+
+    idxA, idxB = crossmatch(satellite_hostid, host_halo_id)
+    matched_host_halo_axes = host_halo_axis[idxB]
+    matched_satellite_vectors = satellite_vectors[idxA]
+    matched_rotation_angles = satellite_rotation_angles[idxA]
+
+    rotation_matrices = rotation_matrices_from_angles(matched_rotation_angles, matched_host_halo_axes)
+    result = rotate_vector_collection(rotation_matrices, matched_satellite_vectors)
+    new_vectors = np.zeros_like(result)
+    new_vectors[idxA] = result
+
+    if return_has_match:
+        return new_vectors, has_match
+    else:
+        return new_vectors
+
+
+def calculate_satellite_radial_vector(sat_hostid, sat_x, sat_y, sat_z,
+            host_halo_id, host_halo_x, host_halo_y, host_halo_z, Lbox):
+    r"""
+    For each satellite, calculate the radial vector pointing from the associated host halo
+    to the satellite, accounting for periodic boundary conditions.
+
+    Parameters
+    ----------
+    sat_hostid : ndarray
+        Numpy array of integers of shape (num_sats, )
+
+    sat_x : ndarray
+        Numpy array of shape (num_sats, )
+
+    sat_y : ndarray
+        Numpy array of shape (num_sats, )
+
+    sat_z : ndarray
+        Numpy array of shape (num_sats, )
+
+    host_halo_id : ndarray
+        Numpy array of unique integers of shape (num_hosts, )
+
+    host_halo_x : ndarray
+        Numpy array of shape (num_hosts, )
+
+    host_halo_y : ndarray
+        Numpy array of shape (num_hosts, )
+
+    host_halo_z : ndarray
+        Numpy array of shape (num_hosts, )
+
+    Lbox : scalar or 3-element tuple
+        periodic boundary conditions
+
+    Returns
+    -------
+    normalized_radial_vectors : ndarray
+        Numpy array of shape (num_sats, 3)
+
+        Sign convention is such that, for cases where PBCs are not operative,
+        positive values correspond to satellite coordinates being larger than central coordinates,
+        i.e., normalized_radial_vectors[i, 0] = xsat[i] - xcen[i], and so forth.
+
+        When PBCs are operative, and the host halo is at the left edge of the box,
+        with the satellite at the right edge, the sign of normalized_radial_vectors will be negative.
+
+    radial_distances : ndarray
+        Numpy array of shape (num_sats, )
+    """
+    has_match = np.isin(sat_hostid, host_halo_id)
+
+    sat_hostid = np.atleast_1d(sat_hostid)[has_match]
+    sat_x = np.atleast_1d(sat_x)[has_match]
+    sat_y = np.atleast_1d(sat_y)[has_match]
+    sat_z = np.atleast_1d(sat_z)[has_match]
+    assert sat_hostid.shape[0] == sat_x.shape[0] == sat_y.shape[0] == sat_z.shape[0]
+    num_sats = has_match.shape[0]
+
+    host_halo_id = np.atleast_1d(host_halo_id)
+    host_halo_x = np.atleast_1d(host_halo_x)
+    host_halo_y = np.atleast_1d(host_halo_y)
+    host_halo_z = np.atleast_1d(host_halo_z)
+    assert host_halo_id.shape[0] == host_halo_x.shape[0] == host_halo_y.shape[0] == host_halo_z.shape[0]
+
+    Lbox = np.atleast_1d(Lbox)
+    if len(Lbox) == 1:
+        Lbox = np.array((Lbox[0], Lbox[0], Lbox[0]))
+    elif len(Lbox) != 3:
+        raise ValueError("Input `Lbox` must be a scalar or 3-element sequence")
+
+    idxA, idxB = crossmatch(sat_hostid, host_halo_id)
+    matched_sat_x = sat_x[idxA]
+    matched_sat_y = sat_y[idxA]
+    matched_sat_z = sat_z[idxA]
+    matching_host_x = host_halo_x[idxB]
+    matching_host_y = host_halo_y[idxB]
+    matching_host_z = host_halo_z[idxB]
+
+    dx = _relative_positions_and_velocities(matched_sat_x, matching_host_x, period=Lbox[0])
+    dy = _relative_positions_and_velocities(matched_sat_y, matching_host_y, period=Lbox[1])
+    dz = _relative_positions_and_velocities(matched_sat_z, matching_host_z, period=Lbox[2])
+    dr = np.sqrt(dx**2 + dy**2 + dz**2)
+
+    xout = np.zeros(num_sats).astype(float)
+    yout = np.zeros(num_sats).astype(float)
+    zout = np.zeros(num_sats).astype(float)
+    xout[idxA] = dx/dr
+    yout[idxA] = dy/dr
+    zout[idxA] = dz/dr
+
+    normalized_radial_vectors = np.zeros((num_sats, 3))
+    normalized_radial_vectors[:, 0] = xout
+    normalized_radial_vectors[:, 1] = yout
+    normalized_radial_vectors[:, 2] = zout
+
+    radial_distances = np.zeros(num_sats)
+    radial_distances[idxA] = dr
+
+    return normalized_radial_vectors, radial_distances
+
+
+def reposition_satellites_from_radial_vectors(satellite_position,
+            orig_radial_vector, new_radial_vector, Lbox):
+    r""" Given original and new host-centric coordinates for satellites, reposition the satellites
+    to their new spatial coordinates, accounting for periodic boundary conditions.
+
+    Parameters
+    ----------
+    satellite_position : ndarray
+        Numpy array of shape (nsats, 3)
+
+    orig_radial_vector : ndarray
+        Numpy array of shape (nsats, 3)
+
+    new_radial_vector : ndarray
+        Numpy array of shape (nsats, 3)
+
+    Lbox : scalar or 3-element tuple
+        periodic boundary conditions
+
+    Returns
+    -------
+    new_satellite_position : ndarray
+        Numpy array of shape (nsats, 3)
+
+    Examples
+    --------
+    >>> nsats = int(1e3)
+    >>> Lbox = 1
+    >>> satellite_position = np.random.uniform(0, Lbox, nsats*3).reshape((nsats, 3))
+    >>> orig_radial_vector = np.random.uniform(-0.1, 0.1, nsats*3).reshape((nsats, 3))
+    >>> new_radial_vector = np.random.uniform(-0.1, 0.1, nsats*3).reshape((nsats, 3))
+    >>> new_satellite_position = reposition_satellites_from_radial_vectors(satellite_position, orig_radial_vector, new_radial_vector, Lbox)
+    """
+    xc = satellite_position[:, 0] - orig_radial_vector[:, 0]
+    yc = satellite_position[:, 1] - orig_radial_vector[:, 1]
+    zc = satellite_position[:, 2] - orig_radial_vector[:, 2]
+
+    xs_new = xc + new_radial_vector[:, 0]
+    ys_new = yc + new_radial_vector[:, 1]
+    zs_new = zc + new_radial_vector[:, 2]
+
+    Lbox = np.atleast_1d(Lbox)
+    if len(Lbox) == 1:
+        Lbox = np.array((Lbox[0], Lbox[0], Lbox[0]))
+    elif len(Lbox) != 3:
+        raise ValueError("Input `Lbox` must be a scalar or 3-element sequence")
+
+    xs_new = xs_new % Lbox[0]
+    ys_new = ys_new % Lbox[1]
+    zs_new = zs_new % Lbox[2]
+
+    new_satellite_position = np.vstack((xs_new, ys_new, zs_new)).T
+    return new_satellite_position
+
+
+def _sign_pbc(x1, x2, period=None, equality_fill_val=0., return_pbc_correction=False):
+    r""" Return the sign of the unit vector pointing from x2 towards x1,
+    that is, the sign of (x1 - x2), accounting for periodic boundary conditions.
+
+    If x1 > x2, returns 1. If x1 < x2, returns -1. If x1 == x2, returns equality_fill_val.
+
+    Parameters
+    ----------
+    x1 : array
+        1-d array of length *Npts*.
+        If period is not None, all values must be contained in [0, Lbox)
+
+    x2 : array
+        1-d array of length *Npts*.
+        If period is not None, all values must be contained in [0, Lbox)
+
+    period : float, optional
+        Size of the periodic box. Default is None for non-periodic case.
+
+    equality_fill_val : float, optional
+        Value to return for cases where x1 == x2. Default is 0.
+
+    return_pbc_correction : bool, optional
+        If True, the `sign_pbc` function will additionally return a
+        length *Npts* boolean array storing whether or not the input
+        points had a PBC correction applied. Default is False.
+
+    Returns
+    -------
+    sgn : array
+        1-d array of length *Npts*.
+
+    Examples
+    --------
+    >>> Lbox = 250.0
+    >>> x1 = 1.
+    >>> x2 = 249.
+    >>> result = _sign_pbc(x1, x2, period=Lbox)
+    >>> assert result == 1
+
+    >>> result = _sign_pbc(x1, x2, period=None)
+    >>> assert result == -1
+
+    >>> npts = 100
+    >>> x1 = np.random.uniform(0, Lbox, npts)
+    >>> x2 = np.random.uniform(0, Lbox, npts)
+    >>> result = _sign_pbc(x1, x2, period=Lbox)
+    """
+    x1 = np.atleast_1d(x1)
+    x2 = np.atleast_1d(x2)
+    result = np.sign(x1 - x2)
+
+    if period is not None:
+        try:
+            assert np.all(x1 >= 0)
+            assert np.all(x2 >= 0)
+            assert np.all(x1 < period)
+            assert np.all(x2 < period)
+        except AssertionError:
+            msg = "If period is not None, all values of x and y must be between [0, period)"
+            raise ValueError(msg)
+
+        d = np.abs(x1-x2)
+        pbc_correction = np.sign(period/2. - d)
+        result = pbc_correction*result
+
+    if equality_fill_val != 0:
+        result = np.where(result == 0, equality_fill_val, result)
+
+    if return_pbc_correction:
+        return result, pbc_correction
+    else:
+        return result
+
+
+def _relative_positions_and_velocities(x1, x2, period=None, **kwargs):
+    r""" Return the vector pointing from x2 towards x1,
+    that is, x1 - x2, accounting for periodic boundary conditions.
+
+    If keyword arguments ``v1`` and ``v2`` are passed in,
+    additionally return the velocity ``v1`` with respect to ``v2``, with sign convention
+    such that positive (negative) values correspond to receding (approaching) points.
+
+    Parameters
+    -----------
+    x1 : array
+        1-d array of length *Npts*.
+        If period is not None, all values must be contained in [0, Lbox)
+
+    x2 : array
+        1-d array of length *Npts*.
+        If period is not None, all values must be contained in [0, Lbox)
+
+    period : float, optional
+        Size of the periodic box. Default is None for non-periodic case.
+
+    Returns
+    --------
+    xrel : array
+        1-d array of length *Npts* storing x1 - x2.
+        If *x1 > x2* and abs(*x1* - *x2*) > period/2, the sign of *d* will be negative.
+
+    vrel : array, optional
+        1-d array of length *Npts* storing v1 relative to v2.
+        Only returned if ``v1`` and ``v2`` are passed in.
+
+    Examples
+    --------
+    >>> Lbox = 250.0
+    >>> x1 = 1.
+    >>> x2 = 249.
+    >>> result = _relative_positions_and_velocities(x1, x2, period=Lbox)
+    >>> assert np.isclose(result, 2)
+
+    >>> result = _relative_positions_and_velocities(x1, x2, period=None)
+    >>> assert np.isclose(result, -248)
+
+    >>> npts = 100
+    >>> x1 = np.random.uniform(0, Lbox, npts)
+    >>> x2 = np.random.uniform(0, Lbox, npts)
+    >>> result = _relative_positions_and_velocities(x1, x2, period=Lbox)
+
+    Now let's frame this result in terms of a physically motivated example.
+    Suppose we have a central galaxy with position *xc* and velocity *vc*,
+    and a satellite galaxy with position *xs* and velocity *vs*.
+    We can calculate the vector pointing from the central to the satellite,
+    as well as the satellites's host-centric velocity:
+
+    >>> xcen, vcen = 249.9, 100
+    >>> xsat, vsat = 0.1, -300
+    >>> xrel, vrel = _relative_positions_and_velocities(xsat, xcen, v1=vsat, v2=vcen, period=Lbox)
+    >>> assert np.isclose(xrel, +0.2)
+    >>> assert np.isclose(vrel, -400)
+
+    >>> xcen, vcen = 0.1, 100
+    >>> xsat, vsat = 249.9, -300
+    >>> xrel, vrel = _relative_positions_and_velocities(xsat, xcen, v1=vsat, v2=vcen, period=Lbox)
+    >>> assert np.isclose(xrel, -0.2)
+    >>> assert np.isclose(vrel, +400)
+
+    """
+    s = _sign_pbc(x1, x2, period=period, equality_fill_val=1.)
+    absd = np.abs(x1 - x2)
+    if period is None:
+        xrel = s*absd
+    else:
+        xrel = s*np.where(absd > period/2., period - absd, absd)
+
+    try:
+        v1 = kwargs['v1']
+        v2 = kwargs['v2']
+        return xrel, s*(v1-v2)
+    except KeyError:
+        return xrel
+

--- a/halotools/utils/satellite_rotations.py
+++ b/halotools/utils/satellite_rotations.py
@@ -63,7 +63,10 @@ def rotate_satellite_vectors(satellite_vectors, satellite_hostid, satellite_rota
     host_halo_id = np.atleast_1d(host_halo_id)
     host_halo_axis = np.atleast_2d(host_halo_axis)
 
-    has_match = np.isin(satellite_hostid, host_halo_id)
+    try:
+        has_match = np.isin(satellite_hostid, host_halo_id)
+    except AttributeError:
+        has_match = np.in1d(satellite_hostid, host_halo_id)
     satellite_rotation_angles[~has_match] = 0.
 
     idxA, idxB = crossmatch(satellite_hostid, host_halo_id)
@@ -132,7 +135,10 @@ def calculate_satellite_radial_vector(sat_hostid, sat_x, sat_y, sat_z,
     radial_distances : ndarray
         Numpy array of shape (num_sats, )
     """
-    has_match = np.isin(sat_hostid, host_halo_id)
+    try:
+        has_match = np.isin(sat_hostid, host_halo_id)
+    except AttributeError:
+        has_match = np.in1d(sat_hostid, host_halo_id)
 
     sat_hostid = np.atleast_1d(sat_hostid)[has_match]
     sat_x = np.atleast_1d(sat_x)[has_match]

--- a/halotools/utils/tests/test_compute_richness.py
+++ b/halotools/utils/tests/test_compute_richness.py
@@ -1,0 +1,52 @@
+"""
+"""
+import numpy as np
+from ..crossmatch import compute_richness
+
+
+__all__ = ('test_compute_richness1', )
+
+
+def test_compute_richness1():
+    unique_halo_ids = [5, 2, 100]
+    halo_id_of_galaxies = [100, 2, 100, 3, 2, 100, 100, 3]
+    richness = compute_richness(unique_halo_ids, halo_id_of_galaxies)
+    assert np.all(richness == [0, 2, 4])
+
+
+def test_compute_richness2():
+    unique_halo_ids = [400, 100, 200, 300]
+    halo_id_of_galaxies = np.random.randint(0, 50, 200)
+    richness = compute_richness(unique_halo_ids, halo_id_of_galaxies)
+    assert np.all(richness == [0, 0, 0, 0])
+
+
+def test_compute_richness3():
+    unique_halo_ids = [400, 100, 200, 300]
+    halo_id_of_galaxies = [0, 999, 100, 200, 100, 200, 999, 300, 200]
+    richness = compute_richness(unique_halo_ids, halo_id_of_galaxies)
+    assert np.all(richness == [0, 2, 3, 1])
+
+
+def test_compute_richness4():
+    #  Set up a source halo catalog with 100 halos in each mass bin
+    log_mhost_min, log_mhost_max, dlog_mhost = 10.5, 15.5, 0.5
+    log_mhost_bins = np.arange(log_mhost_min, log_mhost_max+dlog_mhost, dlog_mhost)
+    log_mhost_mids = 0.5*(log_mhost_bins[:-1] + log_mhost_bins[1:])
+
+    num_source_halos_per_bin = 100
+    source_halo_log_mhost = np.tile(log_mhost_mids, num_source_halos_per_bin)
+    num_source_halos = len(source_halo_log_mhost)
+    source_halo_id = np.arange(num_source_halos).astype(int)
+
+    ngals_per_source_halo = 3
+    num_source_galaxies = num_source_halos*ngals_per_source_halo
+    source_galaxy_host_halo_id = np.repeat(source_halo_id, ngals_per_source_halo)
+
+    source_halos_richness = compute_richness(
+                source_halo_id, source_galaxy_host_halo_id)
+
+
+
+
+

--- a/halotools/utils/tests/test_satellite_rotations.py
+++ b/halotools/utils/tests/test_satellite_rotations.py
@@ -1,0 +1,204 @@
+r"""
+"""
+import numpy as np
+from ..matrix_operations_3d import elementwise_norm
+from ..satellite_rotations import rotate_satellite_vectors, calculate_satellite_radial_vector
+from ..satellite_rotations import reposition_satellites_from_radial_vectors
+
+
+def test1():
+    r""" Randomly generate vectors and rotations and ensure
+    the rotate_satellite_vectors function preserves norm.
+    """
+    nsats, nhosts = int(1e4), 100
+    satellite_hostid = np.random.randint(0, nhosts, nsats)
+    satellite_vectors = np.random.uniform(-1, 1, nsats*3).reshape((nsats, 3))
+    satellite_rotation_angles = np.random.uniform(-np.pi, np.pi, nsats)
+    host_halo_id = np.arange(nhosts)
+    host_halo_axis = np.random.uniform(-1, 1, nhosts*3).reshape((nhosts, 3))
+    new_vectors = rotate_satellite_vectors(
+            satellite_vectors, satellite_hostid, satellite_rotation_angles,
+            host_halo_id, host_halo_axis)
+    orig_norms = elementwise_norm(satellite_vectors)
+    new_norms = elementwise_norm(new_vectors)
+    assert np.allclose(orig_norms, new_norms)
+
+
+def test2():
+    r"""
+    All satellite vectors are normalized and point in x-direction.
+    All host vectors are normalized and point in z-direction.
+    Rotate the matched satellites by (pi, pi/2, -pi/2) and enforce that we get (-x, y, -y)
+    """
+    satellite_hostid = [1, 3, 0]
+    satellite_vectors = [[1, 0, 0], [1, 0, 0], [1, 0, 0]]
+    satellite_rotation_angles = [np.pi, np.pi/2., -np.pi/2.]
+    host_halo_id = [0, 1, 2, 3, 4]
+    host_halo_axis = [[0, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1], [0, 0, 1]]
+
+    new_vectors = rotate_satellite_vectors(
+            satellite_vectors, satellite_hostid, satellite_rotation_angles,
+            host_halo_id, host_halo_axis)
+
+    assert new_vectors.shape == (3, 3)
+    assert np.allclose(new_vectors[0, :], [-1, 0, 0])
+    assert np.allclose(new_vectors[1, :], [0, 1, 0])
+    assert np.allclose(new_vectors[2, :], [0, -1, 0])
+
+
+def test3():
+    r"""
+    All satellite vectors are normalized and point in y-direction.
+    All host vectors are normalized and point in x-direction.
+    Rotate the matched satellites by (pi, pi/2, -pi/2) and enforce that we get (-y, z, -z)
+    """
+    satellite_hostid = [1, 3, 0]
+    satellite_vectors = [[0, 1, 0], [0, 1, 0], [0, 1, 0]]
+    satellite_rotation_angles = [np.pi, np.pi/2., -np.pi/2.]
+    host_halo_id = [0, 1, 2, 3, 4]
+    host_halo_axis = [[1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0], [1, 0, 0]]
+
+    new_vectors = rotate_satellite_vectors(
+            satellite_vectors, satellite_hostid, satellite_rotation_angles,
+            host_halo_id, host_halo_axis)
+
+    assert new_vectors.shape == (3, 3)
+    assert np.allclose(new_vectors[0, :], [0, -1, 0])
+    assert np.allclose(new_vectors[1, :], [0, 0, 1])
+    assert np.allclose(new_vectors[2, :], [0, 0, -1])
+
+
+def test4():
+    r""" Concatenate four explicit cases and use nontrivial sequencing of
+    satellite_hostid to ensure all four hard-coded examples are explicitly correct
+    """
+    satellite_hostid = [1, 3, 0, 2]
+    satellite_vectors = [[1, 0, 0], [0, 1, 0], [1, 0, 0], [0, 1, 0]]
+    satellite_rotation_angles = [np.pi, np.pi/2., -np.pi/2., np.pi/2.]
+    host_halo_id = [0, 1, 2, 3, 4]
+    host_halo_axis = [[1, 0, 0], [0, 0, 1], [-1, 0, 0], [1, 0, 0], [1, 0, 0]]
+
+    new_vectors = rotate_satellite_vectors(
+            satellite_vectors, satellite_hostid, satellite_rotation_angles,
+            host_halo_id, host_halo_axis)
+
+    assert new_vectors.shape == (4, 3)
+    msg = ("This test4 intends to ensure that the passing test2 and test3\n"
+        "have results that propagate through to nontrivial usage of satellite_hostid")
+    assert np.allclose(new_vectors[0, :], [-1, 0, 0]), msg
+    assert np.allclose(new_vectors[1, :], [0, 0, 1]), msg
+    assert np.allclose(new_vectors[2, :], [1, 0, 0]), msg
+    assert np.allclose(new_vectors[3, :], [0, 0, -1]), msg
+
+
+def test_radial_vector1():
+    nsats = 100
+    nhosts = 10
+    Lbox = 1.
+
+    sat_x = np.random.uniform(0, Lbox, nsats)
+    sat_y = np.random.uniform(0, Lbox, nsats)
+    sat_z = np.random.uniform(0, Lbox, nsats)
+    sat_hostid = np.random.randint(0, nhosts, nsats)
+
+    host_halo_x = np.random.uniform(0, Lbox, nhosts)
+    host_halo_y = np.random.uniform(0, Lbox, nhosts)
+    host_halo_z = np.random.uniform(0, Lbox, nhosts)
+    host_halo_id = np.arange(0, nhosts)
+
+    normalized_radial_vectors, radial_distances = calculate_satellite_radial_vector(
+            sat_hostid, sat_x, sat_y, sat_z,
+            host_halo_id, host_halo_x, host_halo_y, host_halo_z, Lbox)
+    norms = elementwise_norm(normalized_radial_vectors)
+    assert np.allclose(norms, 1.)
+
+
+def test_radial_vector2():
+    Lbox = 1.
+
+    sat_x = [0.95, 0.95, 0.95]
+    sat_y = [0.95, 0.95, 0.95]
+    sat_z = [0.95, 0.95, 0.95]
+    sat_hostid = [1, 1, 1]
+
+    host_halo_x = [0.9, 0.9, 0.9]
+    host_halo_y = [0.9, 0.9, 0.9]
+    host_halo_z = [0.9, 0.9, 0.9]
+    host_halo_id = [0, 1, 2]
+
+    normalized_radial_vectors, radial_distances = calculate_satellite_radial_vector(
+            sat_hostid, sat_x, sat_y, sat_z,
+            host_halo_id, host_halo_x, host_halo_y, host_halo_z, Lbox)
+
+    correct_distance = np.sqrt(3*0.05**2)
+    assert np.allclose(radial_distances, correct_distance)
+
+    correct_vector = np.array((0.05, 0.05, 0.05))/correct_distance
+    assert np.allclose(correct_vector, normalized_radial_vectors[0, :])
+    assert np.allclose(correct_vector, normalized_radial_vectors[1, :])
+    assert np.allclose(correct_vector, normalized_radial_vectors[2, :])
+
+
+def test_radial_vector3():
+    Lbox = 1.
+
+    sat_x = [0.95, 0.95, 0.95]
+    sat_y = [0.05, 0.95, 0.95]
+    sat_z = [0.95, 0.95, 0.95]
+    sat_hostid = [1, 0, 2]
+
+    host_halo_x = [0.8, 0.05, 0.9]
+    host_halo_y = [0.8, 0.1, 0.9]
+    host_halo_z = [0.8, 0.85, 0.9]
+    host_halo_id = [1, 2, 0]
+
+    normalized_radial_vectors, radial_distances = calculate_satellite_radial_vector(
+            sat_hostid, sat_x, sat_y, sat_z,
+            host_halo_id, host_halo_x, host_halo_y, host_halo_z, Lbox)
+
+    correct_distance0 = np.sqrt(0.15**2 + 0.25**2 + 0.15**2)
+    assert np.allclose(radial_distances[0], correct_distance0)
+    correct_distance1 = np.sqrt(3*0.05**2)
+    assert np.allclose(radial_distances[1], correct_distance1)
+    correct_distance2 = np.sqrt(0.1**2 + 0.15**2 + 0.1**2)
+    assert np.allclose(radial_distances[2], correct_distance2)
+
+    correct_vector0 = np.array((0.15, 0.25, 0.15))/correct_distance0
+    assert np.allclose(correct_vector0, normalized_radial_vectors[0, :])
+    correct_vector1 = np.array((0.05, 0.05, 0.05))/correct_distance1
+    assert np.allclose(correct_vector1, normalized_radial_vectors[1, :])
+    correct_vector2 = np.array((-0.1, -0.15, 0.1))/correct_distance2
+    assert np.allclose(correct_vector2, normalized_radial_vectors[2, :])
+
+
+def test_reposition_satellites1():
+    r""" PBCs are irrelevant
+    """
+    nsats = int(1e3)
+    Lbox = 1
+
+    central_position = np.random.uniform(0.25, 0.75, nsats*3).reshape((nsats, 3))
+    orig_radial_vector = np.random.uniform(-0.1, 0.1, nsats*3).reshape((nsats, 3))
+    satellite_position = central_position + orig_radial_vector
+    new_radial_vector = np.random.uniform(-0.1, 0.1, nsats*3).reshape((nsats, 3))
+    new_satellite_position = reposition_satellites_from_radial_vectors(
+        satellite_position, orig_radial_vector, new_radial_vector, Lbox)
+    correct_satellite_position = central_position + new_radial_vector
+    assert np.allclose(new_satellite_position, correct_satellite_position)
+
+
+def test_reposition_satellites2():
+    r""" PBCs are operative
+    """
+    Lbox = 1
+
+    central_position = np.array((0.1, 0.1, 0.1)).reshape((1, 3))
+    orig_radial_vector = np.array((0.2, -0.2, 0.0)).reshape((1, 3))
+    satellite_position = np.array((0.3, 0.9, 0.1)).reshape((1, 3))
+    new_radial_vector = np.array((0.01, 0.01, 0.01)).reshape((1, 3))
+
+    new_satellite_position = reposition_satellites_from_radial_vectors(
+        satellite_position, orig_radial_vector, new_radial_vector, Lbox)
+
+    correct_satellite_position = central_position + new_radial_vector
+    assert np.allclose(new_satellite_position, correct_satellite_position)


### PR DESCRIPTION
This PR introduces a new `satellite_rotations` module to the `utils` sub-package. This module contains the following three user-facing functions, each of which accounts for periodic boundary conditions:

1. __rotate_satellite_vectors__ - Given a collection of satellites that each possess some vector (such the orientation of each satellite's shape, or the host-centric radial vector of each satellite), rotate each satellite's vector by an input angle about the axis associated with the satellite's host halo. The rotation angle is permitted to vary from satellite to satellite within the same host, but all satellites in the same halo will be rotated about the same rotation axis. 
2. __calculate_satellite_radial_vector__ - Given the 3d position of a collection of satellites, and given each satellite's hostID, and given the 3d position of a collection of candidate host halos, calculate each satellite's host-centric radial vector
3. __reposition_satellites_from_radial_vectors__ - Reposition a collection of satellites within their halos according to an input radial vector and a desired output radial vector

There is an additional __compute_richness__ function that uses __halotools.utils.crossmatch__ to modify the API of __np.unique__ to be more convenient for calculating satellite occupation statistics. 

@duncandc - Testing is pretty good and I'm reasonably confident in code-correctness, though as always the best testing comes from just doing science with the code. For now, just verify that the API of each function supports the most commonly encountered use-cases in the intrinsic alignment calculations we've been doing, and make sure that this PR addresses the points you raised in [this commit comment. ](https://github.com/aphearin/halotools/commit/1fdcdb4e5558f00f7dbb553c2e0d8994d4975359#commitcomment-28954231)

