### PR TITLE
Add option to return indexes in conditional abundance matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@ MANIFEST
 */cython_version.py
 htmlcov
 .coverage
-v/*
-.pytest_cache/*
 
 # Sphinx
 docs/api
@@ -45,11 +43,12 @@ distribute-*.tar.gz
 # Other
 .*.swp
 *~
-temporary_testing_script.py 
+temporary_testing_script.py
 *.ipynb
 .ipynb_checkpoints/*
 */.ipynb_checkpoints/*
 */*/.ipynb_checkpoints/*
+.pytest_cache/*
 
 # Mac OSX
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ MANIFEST
 */cython_version.py
 htmlcov
 .coverage
+v/*
+.pytest_cache/*
 
 # Sphinx
 docs/api

--- a/halotools/empirical_models/abunmatch/bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/bin_free_cam.py
@@ -143,11 +143,12 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
         iw += 1
 
 
-    if assume_x_is_sorted:
-        return result
-
     if return_indexes:
-        # I don't think that this is right...
+        # The result indexes point to the location in y2_sorted. Undo that if required
+        result = result if assume_x2_is_sorted else idx_x2_sorted[result]
+        # The result indexes are ordered like y_sorted. Undo that if required
+        result = result if assume_x_is_sorted else result[unsorting_indices(idx_x_sorted)]
         return result
     else:
-        return result[unsorting_indices(idx_x_sorted)]
+        # The result values are ordered like y_sorted, Undo that if required
+        return result if assume_x_is_sorted else result[unsorting_indices(idx_x_sorted)]

--- a/halotools/empirical_models/abunmatch/bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/bin_free_cam.py
@@ -78,6 +78,8 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
     `~halotools.empirical_models.conditional_abunmatch_bin_based`.
 
     """
+    # add_subgrid_noise = False
+    # return_indexes = True
     if (return_indexes and add_subgrid_noise):
         raise ValueError("Can't add subgrid noise when returning indexes")
 
@@ -140,7 +142,12 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
             result[ix1] = get_value_at_rank(rightmost_sorted_window_y2, rightmost_window_ranks[iw], nwin, int(add_subgrid_noise))
         iw += 1
 
+
     if assume_x_is_sorted:
+        return result
+
+    if return_indexes:
+        # I don't think that this is right...
         return result
     else:
         return result[unsorting_indices(idx_x_sorted)]

--- a/halotools/empirical_models/abunmatch/bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/bin_free_cam.py
@@ -3,7 +3,7 @@
 import numpy as np
 from ...utils import unsorting_indices
 from ...utils.conditional_percentile import _check_xyn_bounds, rank_order_function
-from .engines import cython_bin_free_cam_kernel
+from .engines import cython_bin_free_cam_kernel, get_value
 from .tests.naive_python_cam import sample2_window_indices
 
 
@@ -138,7 +138,7 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
             ]
         else:
             leftmost_sorted_window_y2 = np.sort(y2_sorted[iy2_low:iy2_high])
-            result[ix1] = leftmost_sorted_window_y2[leftmost_window_ranks[iw]]
+            result[ix1] = get_value(leftmost_window_ranks[iw], nwin, leftmost_sorted_window_y2, int(add_subgrid_noise))
 
         iw += 1
 
@@ -155,7 +155,7 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
             ]
         else:
             rightmost_sorted_window_y2 = np.sort(y2_sorted[iy2_low:iy2_high])
-            result[ix1] = rightmost_sorted_window_y2[rightmost_window_ranks[iw]]
+            result[ix1] = get_value(rightmost_window_ranks[iw], nwin, rightmost_sorted_window_y2, int(add_subgrid_noise))
         iw += 1
 
     if not assume_x_is_sorted:

--- a/halotools/empirical_models/abunmatch/bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/bin_free_cam.py
@@ -78,8 +78,6 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
     `~halotools.empirical_models.conditional_abunmatch_bin_based`.
 
     """
-    # add_subgrid_noise = False
-    # return_indexes = True
     if (return_indexes and add_subgrid_noise):
         raise ValueError("Can't add subgrid noise when returning indexes")
 

--- a/halotools/empirical_models/abunmatch/bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/bin_free_cam.py
@@ -47,10 +47,15 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
         Performance enhancement flag that can be used for cases where input `x2` and `y2`
         have been pre-sorted so that `x2` is monotonically increasing. Default is False.
 
+    return_indexes : bool, optional
+        Return the indexes in y2 of where to find the new values, rather than the values.
+        `add_subgrid_noise` must be set to False is this is set.
+        Default is False.
+
     Returns
     -------
     ynew : ndarray
-        Numpy array of shape (n1, ) storing the new values of
+        Numpy array of shape (n1, ) storing the new values (or indexes if return_indexes is True) of
         the secondary property for the input points.
 
     Examples

--- a/halotools/empirical_models/abunmatch/engines/__init__.py
+++ b/halotools/empirical_models/abunmatch/engines/__init__.py
@@ -1,1 +1,1 @@
-from .bin_free_cam_kernel import cython_bin_free_cam_kernel, get_value
+from .bin_free_cam_kernel import cython_bin_free_cam_kernel, get_value_at_rank

--- a/halotools/empirical_models/abunmatch/engines/__init__.py
+++ b/halotools/empirical_models/abunmatch/engines/__init__.py
@@ -1,1 +1,1 @@
-from .bin_free_cam_kernel import cython_bin_free_cam_kernel
+from .bin_free_cam_kernel import cython_bin_free_cam_kernel, get_value

--- a/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
+++ b/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
@@ -128,7 +128,7 @@ def get_value_at_rank(double[:] sorted_values, int rank1, int nwin, int add_subg
         return sorted_values[rank1]
     else:
         low_rank = max(rank1 - 1, 0)
-        high_rank = min(rank1 + 1, nwin)
+        high_rank = min(rank1 + 1, nwin - 1)
         low_cdf = sorted_values[low_rank]
         high_cdf = sorted_values[high_rank]
         return low_cdf + (high_cdf-low_cdf)*random_uniform()

--- a/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
+++ b/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
@@ -117,7 +117,7 @@ cdef int _find_index(int[:] arr, int val):
     for i in range(len(arr)):
         if arr[i] == val:
             return i
-    raise Exception("not found")
+    return -1
 
 
 @cython.boundscheck(False)
@@ -262,7 +262,10 @@ def cython_bin_free_cam_kernel(double[:] y1, double[:] y2, int[:] i2_match, int 
         #  or alternatively we randomly draw a value between
         #  sorted_cdf_values2[rank1-1] and sorted_cdf_values2[rank1+1]
         if return_indexes == 1:
-            y1_new_indexes[iy1] = iy2 + nhalfwin - _find_index(correspondence_indx2, rank1)
+            index = _find_index(correspondence_indx2, rank1)
+            if index == -1:
+                raise Exception("Index {} not found in correspondence_indx2".format(rank1))
+            y1_new_indexes[iy1] = iy2 + nhalfwin - index
         else:
             y1_new_values[iy1] = get_value_at_rank(sorted_cdf_values2, rank1, nwin, add_subgrid_noise)
 

--- a/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
+++ b/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
@@ -120,10 +120,17 @@ cdef int _find_index(int[:] arr, int val):
     return -1
 
 
+# Public version of _get_value_at_rank as we need to call this from python.
 @cython.boundscheck(False)
 @cython.nonecheck(False)
 @cython.wraparound(False)
 def get_value_at_rank(double[:] sorted_values, int rank1, int nwin, int add_subgrid_noise):
+    return _get_value_at_rank(sorted_values, rank1, nwin, add_subgrid_noise)
+
+@cython.boundscheck(False)
+@cython.nonecheck(False)
+@cython.wraparound(False)
+cdef double _get_value_at_rank(double[:] sorted_values, int rank1, int nwin, int add_subgrid_noise):
     if add_subgrid_noise == 0:
         return sorted_values[rank1]
     else:
@@ -204,6 +211,7 @@ def cython_bin_free_cam_kernel(double[:] y1, double[:] y2, int[:] i2_match, int 
     cdef int iy2_max = npts2 - nhalfwin - 1
 
     cdef int low_rank, high_rank
+    cdef int index
     cdef double low_cdf, high_cdf
 
     #  Ensure that any bookkeeping error in setting up the window
@@ -267,7 +275,7 @@ def cython_bin_free_cam_kernel(double[:] y1, double[:] y2, int[:] i2_match, int 
                 raise Exception("Index {} not found in correspondence_indx2".format(rank1))
             y1_new_indexes[iy1] = iy2 + nhalfwin - index
         else:
-            y1_new_values[iy1] = get_value_at_rank(sorted_cdf_values2, rank1, nwin, add_subgrid_noise)
+            y1_new_values[iy1] = _get_value_at_rank(sorted_cdf_values2, rank1, nwin, add_subgrid_noise)
 
         #  Move on to the next value in y1
 

--- a/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
+++ b/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
@@ -127,12 +127,8 @@ def get_value_at_rank(double[:] sorted_values, int rank1, int nwin, int add_subg
     if add_subgrid_noise == 0:
         return sorted_values[rank1]
     else:
-        low_rank = rank1 - 1
-        high_rank = rank1 + 1
-        if low_rank < 0:
-            low_rank = 0
-        elif high_rank >= nwin:
-            high_rank = nwin - 1
+        low_rank = max(rank1 - 1, 0)
+        high_rank = min(rank1 + 1, nwin)
         low_cdf = sorted_values[low_rank]
         high_cdf = sorted_values[high_rank]
         return low_cdf + (high_cdf-low_cdf)*random_uniform()

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -505,3 +505,23 @@ def test_initial_sorting4():
         assume_x_is_sorted=True, assume_x2_is_sorted=True,
         add_subgrid_noise=False)
     assert np.allclose(result, result4[unsorting_indices(idx_x_sorted)])
+
+def test_return_indexes():
+    n1, n2 = int(1e2), int(1e2)
+
+    with NumpyRNGContext(fixed_seed):
+        x = np.random.uniform(0, 10, n1)
+        y = np.random.uniform(0, 1, n1)
+
+    with NumpyRNGContext(fixed_seed):
+        x2 = np.random.uniform(0, 10, n2)
+        y2 = np.random.uniform(-4, -3, n2)
+
+    print(y2[:10])
+    nwin = 5
+    values = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=False)
+    indexes = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
+    print(values)
+    print(y2[indexes])
+
+    assert np.all(y2[indexes] == values)

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -9,6 +9,7 @@ from ....utils import unsorting_indices
 
 
 fixed_seed = 43
+fixed_seed2 = 44
 
 
 def test1():
@@ -520,15 +521,23 @@ def test_return_indexes():
         x = np.random.uniform(0, 10, n1)
         y = np.random.uniform(0, 1, n1)
 
-    with NumpyRNGContext(fixed_seed):
+    with NumpyRNGContext(fixed_seed2):
         x2 = np.random.uniform(0, 10, n2)
         y2 = np.random.uniform(-4, -3, n2)
 
     nwin = 5
-    values = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=False)
-    indexes = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
-    print()
-    print(values)
-    print(y2[indexes])
+    for sorted_x in [False, True]:
+        for sorted_x2 in [False, True]:
+            x_, y_, x2_, y2_ = x, y, x2, y2
+            if sorted_x:
+                x_, y_ = np.sort(x_), np.sort(y_)
+            if sorted_x2:
+                x2_, y2_ = np.sort(x2_), np.sort(y2_)
 
-    assert np.all(y2[indexes] == values)
+
+            values = conditional_abunmatch(x_, y_, x2_, y2_, nwin, add_subgrid_noise=False,
+                    assume_x_is_sorted=sorted_x, assume_x2_is_sorted=sorted_x2, return_indexes=False)
+            indexes = conditional_abunmatch(x_, y_, x2_, y2_, nwin, add_subgrid_noise=False,
+                    assume_x_is_sorted=sorted_x, assume_x2_is_sorted=sorted_x2, return_indexes=True)
+
+            assert np.all(y2_[indexes] == values), "{}, {}".format(sorted_x, sorted_x2)

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -75,7 +75,8 @@ def test2():
         itest_rank = window_ranks[nhalfwin]
         itest_correct_result = sorted_window2[itest_rank]
         itest_result = result[itest]
-        assert itest_result == itest_correct_result
+        print(itest_result, itest_correct_result)
+        # assert itest_result == itest_correct_result
 
     #  Test left edge
     for itest in range(nhalfwin):
@@ -88,8 +89,9 @@ def test2():
         itest_correct_result = sorted_window2[itest_rank]
         itest_result = result[itest]
         msg = "itest_result = {0}, correct result = {1}"
-        assert itest_result == itest_correct_result, msg.format(
-            itest_result, itest_correct_result)
+        print(itest_result, itest_correct_result)
+        # assert itest_result == itest_correct_result, msg.format(
+        #     itest_result, itest_correct_result)
 
     #  Test right edge
     for iwin in range(nhalfwin+1, nwin):
@@ -103,8 +105,9 @@ def test2():
         itest_correct_result = sorted_window2[itest_rank]
         itest_result = result[itest]
         msg = "itest_result = {0}, correct result = {1}"
-        assert itest_result == itest_correct_result, msg.format(
-            itest_result, itest_correct_result)
+        print(itest_result, itest_correct_result)
+        # assert itest_result == itest_correct_result, msg.format(
+        #     itest_result, itest_correct_result)
 
 
 def test3():

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -60,7 +60,6 @@ def test2():
     print("ranks2  = {0}".format(cython_sliding_rank(x2, y2, nwin)))
 
     result = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False)
-    result2 = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
 
     print("\n\nynew  = {0}".format(np.abs(result)))
     print("y2    = {0}".format(y2))
@@ -366,10 +365,6 @@ def test_hard_coded_case6():
             x2, ranks_sample2, y2, nwin)
 
     result = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False)
-    result2 = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
-    print(result)
-    print(result2)
-    print(np.array(y2)[result2])
 
     assert np.allclose(result, pure_python_result)
 
@@ -388,8 +383,6 @@ def test_subgrid_noise1():
     nwin1 = 201
     result = conditional_abunmatch(x, y, x2, y2, nwin1, add_subgrid_noise=False)
     result2 = conditional_abunmatch(x, y, x2, y2, nwin1, add_subgrid_noise=True)
-
-    print(np.count_nonzero(np.abs(result - result2) > 0.1))
     assert np.allclose(result, result2, atol=0.1)
     assert not np.allclose(result, result2, atol=0.02)
     assert np.all(result - result2 != 0)
@@ -515,7 +508,7 @@ def test_initial_sorting4():
     assert np.allclose(result, result4[unsorting_indices(idx_x_sorted)])
 
 def test_return_indexes():
-    n1, n2 = int(1e1), int(1e1)
+    n1, n2 = int(1e2), int(1e2)
 
     with NumpyRNGContext(fixed_seed):
         x = np.random.uniform(0, 10, n1)
@@ -525,7 +518,7 @@ def test_return_indexes():
         x2 = np.random.uniform(0, 10, n2)
         y2 = np.random.uniform(-4, -3, n2)
 
-    nwin = 5
+    nwin = 9
     for sorted_x in [False, True]:
         for sorted_x2 in [False, True]:
             x_, y_, x2_, y2_ = x, y, x2, y2

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -75,8 +75,7 @@ def test2():
         itest_rank = window_ranks[nhalfwin]
         itest_correct_result = sorted_window2[itest_rank]
         itest_result = result[itest]
-        print(itest_result, itest_correct_result)
-        # assert itest_result == itest_correct_result
+        assert itest_result == itest_correct_result
 
     #  Test left edge
     for itest in range(nhalfwin):
@@ -89,9 +88,8 @@ def test2():
         itest_correct_result = sorted_window2[itest_rank]
         itest_result = result[itest]
         msg = "itest_result = {0}, correct result = {1}"
-        print(itest_result, itest_correct_result)
-        # assert itest_result == itest_correct_result, msg.format(
-        #     itest_result, itest_correct_result)
+        assert itest_result == itest_correct_result, msg.format(
+            itest_result, itest_correct_result)
 
     #  Test right edge
     for iwin in range(nhalfwin+1, nwin):
@@ -105,9 +103,8 @@ def test2():
         itest_correct_result = sorted_window2[itest_rank]
         itest_result = result[itest]
         msg = "itest_result = {0}, correct result = {1}"
-        print(itest_result, itest_correct_result)
-        # assert itest_result == itest_correct_result, msg.format(
-        #     itest_result, itest_correct_result)
+        assert itest_result == itest_correct_result, msg.format(
+            itest_result, itest_correct_result)
 
 
 def test3():
@@ -387,11 +384,13 @@ def test_subgrid_noise1():
     result2 = conditional_abunmatch(x, y, x2, y2, nwin1, add_subgrid_noise=True)
     assert np.allclose(result, result2, atol=0.1)
     assert not np.allclose(result, result2, atol=0.02)
+    assert np.all(result - result2 != 0)
 
     nwin2 = 1001
     result = conditional_abunmatch(x, y, x2, y2, nwin2, add_subgrid_noise=False)
     result2 = conditional_abunmatch(x, y, x2, y2, nwin2, add_subgrid_noise=True)
     assert np.allclose(result, result2, atol=0.02)
+    assert np.all(result - result2 != 0)
 
 
 def test_initial_sorting1():

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -2,6 +2,7 @@
 """
 import numpy as np
 from astropy.utils.misc import NumpyRNGContext
+import pytest
 from ..bin_free_cam import conditional_abunmatch
 from ....utils.conditional_percentile import cython_sliding_rank, rank_order_function
 from .naive_python_cam import pure_python_rank_matching
@@ -506,6 +507,15 @@ def test_initial_sorting4():
         assume_x_is_sorted=True, assume_x2_is_sorted=True,
         add_subgrid_noise=False)
     assert np.allclose(result, result4[unsorting_indices(idx_x_sorted)])
+
+def test_no_subgrid_noise_with_return_indexes():
+    x, y = np.arange(5), np.arange(5)
+    x2, y2 = np.arange(10), np.arange(10)
+    nwin = 3
+    with pytest.raises(ValueError) as err:
+        conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True, return_indexes=True)
+    assert str(err.value) == "Can't add subgrid noise when returning indexes"
+
 
 def test_return_indexes():
     n1, n2 = int(1e2), int(1e2)

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -59,6 +59,7 @@ def test2():
     print("ranks2  = {0}".format(cython_sliding_rank(x2, y2, nwin)))
 
     result = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False)
+    result2 = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
 
     print("\n\nynew  = {0}".format(np.abs(result)))
     print("y2    = {0}".format(y2))
@@ -364,6 +365,10 @@ def test_hard_coded_case6():
             x2, ranks_sample2, y2, nwin)
 
     result = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False)
+    result2 = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
+    print(result)
+    print(result2)
+    print(np.array(y2)[result2])
 
     assert np.allclose(result, pure_python_result)
 
@@ -382,6 +387,8 @@ def test_subgrid_noise1():
     nwin1 = 201
     result = conditional_abunmatch(x, y, x2, y2, nwin1, add_subgrid_noise=False)
     result2 = conditional_abunmatch(x, y, x2, y2, nwin1, add_subgrid_noise=True)
+
+    print(np.count_nonzero(np.abs(result - result2) > 0.1))
     assert np.allclose(result, result2, atol=0.1)
     assert not np.allclose(result, result2, atol=0.02)
     assert np.all(result - result2 != 0)
@@ -507,7 +514,7 @@ def test_initial_sorting4():
     assert np.allclose(result, result4[unsorting_indices(idx_x_sorted)])
 
 def test_return_indexes():
-    n1, n2 = int(1e2), int(1e2)
+    n1, n2 = int(1e1), int(1e1)
 
     with NumpyRNGContext(fixed_seed):
         x = np.random.uniform(0, 10, n1)
@@ -517,10 +524,10 @@ def test_return_indexes():
         x2 = np.random.uniform(0, 10, n2)
         y2 = np.random.uniform(-4, -3, n2)
 
-    print(y2[:10])
     nwin = 5
     values = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=False)
     indexes = conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=False, return_indexes=True)
+    print()
     print(values)
     print(y2[indexes])
 


### PR DESCRIPTION
As discussed in person + slack the primary goal of this is to:
* Add an option to return the index of y2 that was matched (rather than the value in y2) to the CAM code

I made one other minor change - previously, subgrid noise was not being added to the left and right edges. Now it should be.

I've put a number of comments on the PR where I have done something I am not sure about. Let me know what you think!