### PR TITLE
Remove reference cycles between MockFactory and ModelFactory.

### DIFF
--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -14,6 +14,8 @@ __all__ = ('test_hearin15', )
 
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="does not run on windows")
 def test_memory_leak():
     model = PrebuiltHodModelFactory('hearin15')
     halocat = FakeSim()

--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -13,6 +13,23 @@ from ....utils.python_string_comparisons import compare_strings_py23_safe
 __all__ = ('test_hearin15', )
 
 
+
+def test_memory_leak():
+    model = PrebuiltHodModelFactory('hearin15')
+    halocat = FakeSim()
+    import resource
+
+    model.populate_mock(halocat)
+    maxrss = []
+    for i in range(9):
+        model.mock.populate()
+        maxrss.append(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+
+    import numpy
+    # memory usage shall not increase significantly per run.
+    assert (numpy.diff(maxrss) < 1024).all()
+
+
 def test_hearin15():
     """
     """

--- a/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
+++ b/halotools/empirical_models/composite_models/tests/test_preloaded_models.py
@@ -1,5 +1,6 @@
 """
 """
+import sys
 import pytest
 import numpy as np
 

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -14,6 +14,7 @@ from astropy.table import Table
 from .mock_helpers import three_dim_pos_bundle, infer_mask_from_kwargs
 
 from .. import model_helpers, model_defaults
+import weakref
 
 try:
     from ... import mock_observables
@@ -76,6 +77,7 @@ class MockFactory(object):
         except:
             pass
 
+
         # Create a list of halo properties that will be inherited by the mock galaxies
         self.additional_haloprops = copy(model_defaults.default_haloprop_list_inherited_by_mock)
 
@@ -85,6 +87,15 @@ class MockFactory(object):
         self.additional_haloprops = list(set(self.additional_haloprops))
 
         self.galaxy_table = Table()
+
+    @property
+    def model(self):
+        """ model, a weak reference to the model because mock is always a member of model """
+        return self._model()
+
+    @model.setter
+    def model(self, value):
+        self._model = weakref.ref(value)
 
     @abstractmethod
     def populate(self, **kwargs):

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -276,7 +276,9 @@ class ModelFactory(object):
         :ref:`param_dict_mechanism`
         """
 
-        def decorated_func(*args, __param_dict__=self.param_dict, **kwargs):
+        # do not pass self into the scope
+        __param_dict__ = self.param_dict
+        def decorated_func(*args, **kwargs):
 
             # Update the param_dict as necessary
             for key in list(__param_dict__.keys()):

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -276,12 +276,12 @@ class ModelFactory(object):
         :ref:`param_dict_mechanism`
         """
 
-        def decorated_func(*args, **kwargs):
+        def decorated_func(*args, __param_dict__=self.param_dict, **kwargs):
 
             # Update the param_dict as necessary
-            for key in list(self.param_dict.keys()):
+            for key in list(__param_dict__.keys()):
                 if key in component_model.param_dict:
-                    component_model.param_dict[key] = self.param_dict[key]
+                    component_model.param_dict[key] = __param_dict__[key]
 
             func = getattr(component_model, func_name)
             return func(*args, **kwargs)

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -276,7 +276,10 @@ class ModelFactory(object):
         :ref:`param_dict_mechanism`
         """
 
-        # do not pass self into the scope
+        # do not pass self into the scope;
+        # assuming param_dict is not replaced during life cycle of self.
+        # passing `self` causes a cycle reference when
+        # the function is assigned as attributes of self.
         __param_dict__ = self.param_dict
         def decorated_func(*args, **kwargs):
 


### PR DESCRIPTION
This PR removes the reference cyels between MockFactory and ModelFactory.
I used objgraph to dump the back references in `halotools/empirical_models/composite_models/tests/test_preloaded_models.py::test_hearin15`

Before the PR:
![before](https://user-images.githubusercontent.com/138060/42246639-32c91f9a-7ed2-11e8-8a0f-5c421c85af3b.png)

After the PR:
![after](https://user-images.githubusercontent.com/138060/42246644-3749fa4e-7ed2-11e8-8775-225f71868b00.png)

Unfortunately this does not cure #917. Memory usage still increase after these cycles are cured. There must be other cycles that I haven't found yet.
