### PR TITLE
Change default behavior of return_indexes feature of conditional_abunmatch

### DIFF
--- a/halotools/empirical_models/abunmatch/bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/bin_free_cam.py
@@ -83,8 +83,8 @@ def conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True,
     `~halotools.empirical_models.conditional_abunmatch_bin_based`.
 
     """
-    if (return_indexes and add_subgrid_noise):
-        raise ValueError("Can't add subgrid noise when returning indexes")
+    if return_indexes:
+        add_subgrid_noise = False
 
     x, y, nwin = _check_xyn_bounds(x, y, nwin)
     x2, y2, nwin = _check_xyn_bounds(x2, y2, nwin)

--- a/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
+++ b/halotools/empirical_models/abunmatch/tests/test_bin_free_cam.py
@@ -508,13 +508,15 @@ def test_initial_sorting4():
         add_subgrid_noise=False)
     assert np.allclose(result, result4[unsorting_indices(idx_x_sorted)])
 
+
 def test_no_subgrid_noise_with_return_indexes():
-    x, y = np.arange(5), np.arange(5)
-    x2, y2 = np.arange(10), np.arange(10)
-    nwin = 3
-    with pytest.raises(ValueError) as err:
-        conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True, return_indexes=True)
-    assert str(err.value) == "Can't add subgrid noise when returning indexes"
+    """ Enforce that add_subgrid_noise is automatically set to False when return_indexes is True
+    """
+    n1, n2 = int(1e3), int(1e4)
+    x, y = np.arange(n1), np.arange(n1)
+    x2, y2 = np.arange(n2), np.arange(n2)
+    nwin = 35
+    conditional_abunmatch(x, y, x2, y2, nwin, add_subgrid_noise=True, return_indexes=True)
 
 
 def test_return_indexes():


### PR DESCRIPTION
Changed default behavior of conditional_abunmatch so that add_subgrid_noise is automatically set to False when return_indexes is True