### PR TITLE
fix for numpy 1.15 indexing changes

### DIFF
--- a/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py
@@ -202,7 +202,7 @@ class MonteCarloGalProf(object):
         # To do this, we first determine the index in the profile function table
         # where the relevant function object is stored:
         rad_prof_func_table_indices = (
-            self.rad_prof_func_table_indices[digitized_param_list]
+            self.rad_prof_func_table_indices[np.array(digitized_param_list, dtype='intp')]
             )
         # Now we have an array of indices for our functions, and we need to evaluate
         # the i^th function on the i^th element of rho.
@@ -519,7 +519,7 @@ class MonteCarloGalProf(object):
         # To do this, we first determine the index in the profile function table
         # where the relevant function object is stored:
         vel_prof_func_table_indices = (
-            self.rad_prof_func_table_indices[digitized_param_list]
+            self.rad_prof_func_table_indices[np.array(digitized_param_list, dtype='intp')]
             )
         # Now we have an array of indices for our functions, and we need to evaluate
         # the i^th function on the i^th element of rho.


### PR DESCRIPTION
This PR is intended to fix the following warnings:
```
build/testenv/lib/python3.6/site-packages/nbodykit/source/catalog/tests/test_hod.py::test_hod_cm[1]
  /home/yfeng1/anaconda3/install/lib/python3.6/site-packages/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py:205: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
    self.rad_prof_func_table_indices[digitized_param_list]
  /home/yfeng1/anaconda3/install/lib/python3.6/site-packages/halotools/empirical_models/phase_space_models/analytic_models/monte_carlo_helpers.py:522: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
    self.rad_prof_func_table_indices[digitized_param_list]
```