### PR TITLE
Fix inconsistent return idx

### DIFF
--- a/halotools/mock_observables/counts_in_cells/counts_in_cylinders.py
+++ b/halotools/mock_observables/counts_in_cells/counts_in_cylinders.py
@@ -209,9 +209,9 @@ def _counts_in_cylinders_process_args(sample1, sample2, proj_search_radius, cyli
     y2 = sample2[:, 1]
     z2 = sample2[:, 2]
 
-    if return_indexes and ((len(x1) > 2e32) or (len(x2) > 2e32)):
+    if return_indexes and ((len(x1) > 2**32) or (len(x2) > 2**32)):
         msg = ("Return indexes uses a uint32 and so can only handle inputs shorter than " +
-            "2e32 (~4 Billion). If you are affected by this please raise an Issue on " +
+            "2^32 (~4 Billion). If you are affected by this please raise an Issue on " +
             "https://github.com/astropy/halotools.\n")
         raise ValueError(msg)
 

--- a/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
+++ b/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
@@ -253,9 +253,8 @@ def counts_in_cylinders_engine(
     counts_uns = np.array(counts)[unsorting_indices(double_mesh.mesh1.idx_sorted)]
     if c_return_indexes:
         # https://github.com/numpy/numpy/issues/2407 for str("colname")
-        np_indexes = np.squeeze(
-                np.asarray(indexes[:current_indexes_cnt]).view(
-	            dtype=[(str("i1"), np.uint32), (str("i2"), np.uint32)]))
+        np_indexes = np.asarray(indexes[:current_indexes_cnt]).flatten().view(
+	            dtype=[(str("i1"), np.uint32), (str("i2"), np.uint32)])
         np_indexes["i1"] = double_mesh.mesh1.idx_sorted[np_indexes["i1"]]
         np_indexes["i2"] = double_mesh.mesh2.idx_sorted[np_indexes["i2"]]
         return counts_uns, np_indexes

--- a/halotools/mock_observables/counts_in_cells/tests/test_counts_in_cylinders.py
+++ b/halotools/mock_observables/counts_in_cells/tests/test_counts_in_cylinders.py
@@ -256,5 +256,21 @@ def test_counts_in_cylinders_with_indexes(num_threads):
         assert np.all(counts == brute_force_counts)
         assert len(indexes) > npts1 # assert that we have tested array resizing
 
+def test_counts_in_cylinders_single_index():
+    sample1 = np.random.random((1, 3))
+    sample2 = sample1
+    rp_max = np.zeros(1) + 0.2
+    pi_max = np.zeros(1) + 0.2
+    counts, indexes = counts_in_cylinders(sample1, sample2, rp_max, pi_max, return_indexes=True)
+    assert len(indexes) == 1 and counts == np.array([1])
+
+def test_counts_in_cylinders_indexes_no_match():
+    sample1 = np.random.random((1, 3))
+    sample2 = sample1 + 0.2
+    rp_max = np.zeros(1) + 0.02
+    pi_max = np.zeros(1) + 0.02
+    counts, indexes = counts_in_cylinders(sample1, sample2, rp_max, pi_max, return_indexes=True)
+    assert len(indexes) == 0 and counts == np.array([0])
+
 def _sort(indexes):
     return np.sort(indexes, order=["i1", "i2"])


### PR DESCRIPTION
In the case where there is only one pair, return indexes would return
```array((1086, 143), dtype=[('i1', '<u4'), ('i2', '<u4')])``` which is not an array and so can't be treated in the same way as the normal output which looks like
```array([(1086, 143), ( ... ),  ], dtype=[('i1', '<u4'), ('i2', '<u4')])```
What I'm pretty sure we want is to be consistent. This changes makes it look lie
```array([(1086, 143)], dtype=[('i1', '<u4'), ('i2', '<u4')])```