### PR TITLE
Shortened length of wp_jackknife doctest

### DIFF
--- a/halotools/mock_observables/two_point_clustering/wp_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/wp_jackknife.py
@@ -198,7 +198,7 @@ def wp_jackknife(sample1, randoms, rp_bins, pi_max, Nsub=[5, 5, 5],
 
     Create some 'randoms' in the same way:
 
-    >>> Nran = Npts*500
+    >>> Nran = Npts*5
     >>> xran = np.random.uniform(0, Lbox, Nran)
     >>> yran = np.random.uniform(0, Lbox, Nran)
     >>> zran = np.random.uniform(0, Lbox, Nran)


### PR DESCRIPTION
The wp_jackknife doctest was timing out in some CI builds. This PR reduces the number of points in the doctest calculation. 