### PR TITLE
Switch to standalone six

### DIFF
--- a/halotools/conftest.py
+++ b/halotools/conftest.py
@@ -1,16 +1,34 @@
 # this contains imports plugins that configure py.test for astropy tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
+from distutils.version import LooseVersion
 
-from astropy.tests.pytest_plugins import *
-import os
-from . import version
+from astropy.version import version as astropy_version
 
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions
-# enable_deprecations_as_exceptions()
-import astropy
-if int(astropy.__version__[0]) > 1:
+if LooseVersion(astropy_version) < LooseVersion('2.0.3'):
+    # Astropy is not compatible with the standalone plugins prior this while
+    # astroquery requires them, so we need this workaround. This will mess
+    # up the test header, but everything else will work.
+    from astropy.tests.pytest_plugins import (PYTEST_HEADER_MODULES,
+                                              enable_deprecations_as_exceptions,
+                                              TESTED_VERSIONS)
+elif LooseVersion(astropy_version) < LooseVersion('3.0'):
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import (PYTEST_HEADER_MODULES,
+                                               TESTED_VERSIONS)
+
+from astropy.tests.helper import enable_deprecations_as_exceptions
+
+from .version import version, astropy_helpers_version
+
+if LooseVersion(astropy_version) > LooseVersion('1'):
     # The warnings_to_ignore_by_pyver parameter was added in astropy 2.0
     enable_deprecations_as_exceptions(modules_to_ignore_on_import=['requests'])
 
@@ -28,5 +46,5 @@ except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
 # This is to figure out the affiliated package version, rather than
 # using Astropy's
 
-packagename = os.path.basename(os.path.dirname(__file__))
-TESTED_VERSIONS[packagename] = version.version
+TESTED_VERSIONS['halotools'] = version
+TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version

--- a/halotools/empirical_models/component_model_templates/binary_galprop_models.py
+++ b/halotools/empirical_models/component_model_templates/binary_galprop_models.py
@@ -5,7 +5,7 @@ used to map a binary-valued galaxy property to a halo catalog.
 from __future__ import division, print_function, absolute_import
 
 import numpy as np
-from astropy.extern import six
+import six
 from abc import ABCMeta
 from astropy.utils.misc import NumpyRNGContext
 

--- a/halotools/empirical_models/component_model_templates/prim_galprop_model.py
+++ b/halotools/empirical_models/component_model_templates/prim_galprop_model.py
@@ -8,7 +8,7 @@ from __future__ import (
     division, print_function, absolute_import, unicode_literals)
 
 import numpy as np
-from astropy.extern import six
+import six
 from abc import ABCMeta
 from warnings import warn
 

--- a/halotools/empirical_models/factories/mock_factory_template.py
+++ b/halotools/empirical_models/factories/mock_factory_template.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import
 import numpy as np
 from multiprocessing import cpu_count
 from copy import copy
-from astropy.extern import six
+import six
 from abc import ABCMeta, abstractmethod
 from astropy.table import Table
 

--- a/halotools/empirical_models/factories/model_factory_template.py
+++ b/halotools/empirical_models/factories/model_factory_template.py
@@ -5,7 +5,7 @@ any composite model of the galaxy-halo connection.
 """
 
 import numpy as np
-from astropy.extern import six
+import six
 from abc import ABCMeta
 
 

--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -6,7 +6,7 @@ in all HOD-style models of the galaxy-halo connection.
 
 import numpy as np
 from scipy.special import pdtrik
-from astropy.extern import six
+import six
 from abc import ABCMeta
 from astropy.utils.misc import NumpyRNGContext
 

--- a/halotools/empirical_models/phase_space_models/analytic_models/profile_model_template.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/profile_model_template.py
@@ -6,7 +6,7 @@ within dark matter halos.
 from __future__ import division, print_function, absolute_import, unicode_literals
 
 import numpy as np
-from astropy.extern import six
+import six
 from abc import ABCMeta, abstractmethod
 from scipy.integrate import quad as quad_integration
 from scipy.optimize import minimize as scipy_minimize

--- a/halotools/mock_observables/void_statistics/underdensity_prob_func.py
+++ b/halotools/mock_observables/void_statistics/underdensity_prob_func.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 
-from astropy.extern.six.moves import xrange as range
+from six.moves import xrange as range
 from astropy.utils.misc import NumpyRNGContext
 
 from ..pair_counters import npairs_per_object_3d

--- a/halotools/mock_observables/void_statistics/void_prob_func.py
+++ b/halotools/mock_observables/void_statistics/void_prob_func.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import numpy as np
 
-from astropy.extern.six.moves import xrange as range
+from six.moves import xrange as range
 from astropy.utils.misc import NumpyRNGContext
 
 from ..pair_counters import npairs_per_object_3d

--- a/halotools/sim_manager/download_manager.py
+++ b/halotools/sim_manager/download_manager.py
@@ -21,7 +21,7 @@ except ImportError:
     raise HalotoolsError("Must have requests package installed to use the DownloadManager")
 
 import posixpath
-from astropy.extern.six.moves import urllib
+from six.moves import urllib
 
 import os
 import fnmatch

--- a/halotools/sim_manager/supported_sims.py
+++ b/halotools/sim_manager/supported_sims.py
@@ -6,7 +6,7 @@ halo catalogs as they are loaded into memory.
 """
 
 from abc import ABCMeta
-from astropy.extern import six
+import six
 from astropy import cosmology
 import numpy as np
 

--- a/halotools/sim_manager/tabular_ascii_reader.py
+++ b/halotools/sim_manager/tabular_ascii_reader.py
@@ -10,7 +10,7 @@ import collections
 from time import time
 import numpy as np
 
-from astropy.extern.six.moves import xrange as range
+from six.moves import xrange as range
 
 from ..utils.python_string_comparisons import _passively_decode_string
 

--- a/halotools/utils/io_utils.py
+++ b/halotools/utils/io_utils.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from time import time
 import sys
-from astropy.extern.six.moves import urllib
+from six.moves import urllib
 
 __all__ = ['file_len', 'download_file_from_url']
 

--- a/halotools/utils/tests/test_value_added_halo_table_functions.py
+++ b/halotools/utils/tests/test_value_added_halo_table_functions.py
@@ -10,7 +10,7 @@ from collections import Counter
 import numpy as np
 
 import pytest
-from astropy.extern.six.moves import xrange as range
+from six.moves import xrange as range
 
 from ..value_added_halo_table_functions import broadcast_host_halo_property, add_halo_hostid
 from ..crossmatch import crossmatch


### PR DESCRIPTION
as we're about to remove it from astropy.

The PR also fixes the pytest plugin imports.