### PR TITLE
Added language_level=2 switch to cython code

### DIFF
--- a/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
+++ b/halotools/empirical_models/abunmatch/engines/bin_free_cam_kernel.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from libc.stdlib cimport rand, RAND_MAX

--- a/halotools/empirical_models/occupation_models/engines/cacciato09_sats_mc_prim_galprop_engine.pyx
+++ b/halotools/empirical_models/occupation_models/engines/cacciato09_sats_mc_prim_galprop_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """ Module containing the `~halotools.empirical_models.occupation_models.engines.cacciato09_sats_mc_prim_galprop_engine`
 cython function driving the `mc_prim_galprop` function of the
 `~halotools.empirical_models.occupation_models.Cacciato09Sats` class.

--- a/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
+++ b/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/halotools/mock_observables/isolation_functions/engines/cylindrical_isolation_engine.pyx
+++ b/halotools/mock_observables/isolation_functions/engines/cylindrical_isolation_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """ Module containing the `~halotools.mock_observables.isolation_functions.engines.cylindrical_isolation_engine`
 cython function driving the `~halotools.mock_observables.cylindrical_isolation` function.
 """

--- a/halotools/mock_observables/isolation_functions/engines/isolation_criteria_marking_functions.pxd
+++ b/halotools/mock_observables/isolation_functions/engines/isolation_criteria_marking_functions.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=2
 cimport numpy as cnp
 
 cdef bint trivial(cnp.float64_t* w1, cnp.float64_t* w2)

--- a/halotools/mock_observables/isolation_functions/engines/isolation_criteria_marking_functions.pyx
+++ b/halotools/mock_observables/isolation_functions/engines/isolation_criteria_marking_functions.pyx
@@ -1,5 +1,6 @@
+# cython: language_level=2
 # cython: profile=False
-""" Module containing C implementations of the isolation functions. 
+""" Module containing C implementations of the isolation functions.
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 cimport numpy as np

--- a/halotools/mock_observables/isolation_functions/engines/marked_cylindrical_isolation_engine.pyx
+++ b/halotools/mock_observables/isolation_functions/engines/marked_cylindrical_isolation_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """ Module containing the `~halotools.mock_observables.isolation_functions.engines.marked_cylindrical_isolation_engine`
 cython function driving the `~halotools.mock_observables.marked_cylindrical_isolation` function.
 """

--- a/halotools/mock_observables/isolation_functions/engines/marked_spherical_isolation_engine.pyx
+++ b/halotools/mock_observables/isolation_functions/engines/marked_spherical_isolation_engine.pyx
@@ -1,13 +1,14 @@
-""" Module containing the `~halotools.mock_observables.isolation_functions.engines.marked_spherical_isolation_engine` 
-cython function driving the `~halotools.mock_observables.marked_spherical_isolation` function. 
+# cython: language_level=2
+""" Module containing the `~halotools.mock_observables.isolation_functions.engines.marked_spherical_isolation_engine`
+cython function driving the `~halotools.mock_observables.marked_spherical_isolation` function.
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil
-from .isolation_criteria_marking_functions cimport (trivial, gt_cond, lt_cond, 
+from .isolation_criteria_marking_functions cimport (trivial, gt_cond, lt_cond,
     eq_cond, neq_cond, lg_cond, tg_cond)
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
@@ -18,61 +19,61 @@ ctypedef bint (*f_type)(cnp.float64_t* w1, cnp.float64_t* w2)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     weights1in, weights2in, weight_func_idin, r_max, cell1_tuple):
     """
-    Cython engine for determining if points in 'sample 1' are isolated, meaning no 
+    Cython engine for determining if points in 'sample 1' are isolated, meaning no
     neighbors within a spherical volume, with respect to points in 'sample 2', where
-    points are counted as neighbors if and only if a weighting function dependent on 
+    points are counted as neighbors if and only if a weighting function dependent on
     weights for each point in sample 1 and sample 2 evaulates to true.
-    
+
     Parameters
     ----------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
-    
+
     x1in : numpy.array
         array storing Cartesian x-coordinates of points of 'sample 1'
-        
+
     y1in : numpy.array
         array storing Cartesian y-coordinates of points of 'sample 1'
-        
+
     z1in : numpy.array
         array storing Cartesian z-coordinates of points of 'sample 1'
-        
+
     x2in : numpy.array
         array storing Cartesian x-coordinates of points of 'sample 2'
-        
+
     y2in : numpy.array
         array storing Cartesian y-coordinates of points of 'sample 2'
-        
+
     z2in : numpy.array
         array storing Cartesian z-coordinates of points of 'sample 2'
-        
+
     weights1in : numpy.ndarray
         array storing weight(s) for each point in 'sample 1'
-        
+
     weights2in : numpy.ndarray
         array storing weight(s) for each point in 'sample 2'
-        
+
     weight_func_idin : int
         integer ID of weighting function (conditional function) to be used
-        
+
     r_max : numpy.array
         array storing the radial distance to search for neighbors around each point
         in 'sample 1'
-        
+
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
-        
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
+
     Returns
     -------
     is_isolated : numpy.array
         boolean array indicating if each point in 'sample 1' is isolated
     """
-    
+
     cdef int weight_func_id = weight_func_idin
 
     cdef f_type wfunc
@@ -131,7 +132,7 @@ def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in,
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq, weight
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp, r_max_squaredtmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp, r_max_squaredtmp
     cdef int Ni, Nj, i, j, k, l, current_data1_index
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
@@ -163,9 +164,9 @@ def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in,
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -218,7 +219,7 @@ def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in,
                                 y1tmp = y_icell1[i] - y2shift
                                 z1tmp = z_icell1[i] - z2shift
                                 r_max_squaredtmp = r_max_squared[ifirst1+i]
-                                
+
                                 #loop over points in cell2 points
                                 for j in range(0,Nj):
                                     #calculate the square distance
@@ -231,8 +232,8 @@ def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in,
 
                                     if (dsq < r_max_squaredtmp) & (weight == 1) & (dsq > 0.0):
                                         has_neighbor[ifirst1+i] = 1
-                                        break 
-                                        
+                                        break
+
     #turn result into numpy array
     new_has_neighbor = np.array(has_neighbor)
 
@@ -244,7 +245,7 @@ def marked_spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in,
 
     new_is_isolated = np.zeros(Npts1)
     new_is_isolated[is_isolated] = 1
-    
+
     return new_is_isolated
 
 
@@ -252,7 +253,7 @@ cdef f_type return_conditional_function(cond_func_id):
     """
     returns a pointer to the user-specified conditional function.
     """
-    
+
     if cond_func_id==0:
         return trivial
     elif cond_func_id==1:

--- a/halotools/mock_observables/isolation_functions/engines/spherical_isolation_engine.pyx
+++ b/halotools/mock_observables/isolation_functions/engines/spherical_isolation_engine.pyx
@@ -1,12 +1,13 @@
-""" Module containing the `~halotools.mock_observables.isolation_functions.engines.spherical_isolation_engine` 
-cython function driving the `~halotools.mock_observables.spherical_isolation` function. 
+# cython: language_level=2
+""" Module containing the `~halotools.mock_observables.isolation_functions.engines.spherical_isolation_engine`
+cython function driving the `~halotools.mock_observables.spherical_isolation` function.
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
-from libc.math cimport ceil 
+cimport cython
+from libc.math cimport ceil
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
 __all__ = ('spherical_isolation_engine', )
@@ -16,47 +17,47 @@ __all__ = ('spherical_isolation_engine', )
 @cython.nonecheck(False)
 def spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, r_max, cell1_tuple):
     """
-    Cython engine for determining if points in 'sample 1' are isolated, meaning no 
+    Cython engine for determining if points in 'sample 1' are isolated, meaning no
     neighbors within a spherical volume, with respect to points in 'sample 2'.
-    
+
     Parameters
     ----------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
-    
+
     x1in : numpy.array
         array storing Cartesian x-coordinates of points of 'sample 1'
-        
+
     y1in : numpy.array
         array storing Cartesian y-coordinates of points of 'sample 1'
-        
+
     z1in : numpy.array
         array storing Cartesian z-coordinates of points of 'sample 1'
-        
+
     x2in : numpy.array
         array storing Cartesian x-coordinates of points of 'sample 2'
-        
+
     y2in : numpy.array
         array storing Cartesian y-coordinates of points of 'sample 2'
-        
+
     z2in : numpy.array
         array storing Cartesian z-coordinates of points of 'sample 2'
-        
+
     r_max : numpy.array
         array storing the radial distance to search for neighbors around each point
         in 'sample 1'
-        
+
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
-        
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
+
     Returns
     -------
     is_isolated : numpy.array
         boolean array indicating if each point in 'sample 1' is isolated
     """
-    
+
     r_max_squared_tmp = r_max*r_max
     cdef cnp.float64_t[:] r_max_squared = np.ascontiguousarray(r_max_squared_tmp[double_mesh.mesh1.idx_sorted])
     cdef cnp.float64_t xperiod = double_mesh.xperiod
@@ -108,7 +109,7 @@ def spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp, r_max_squaredtmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp, r_max_squaredtmp
     cdef int Ni, Nj, i, j, k, l, current_data1_index
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
@@ -133,9 +134,9 @@ def spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -184,7 +185,7 @@ def spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
                                 y1tmp = y_icell1[i] - y2shift
                                 z1tmp = z_icell1[i] - z2shift
                                 r_max_squaredtmp = r_max_squared[ifirst1+i]
-                                
+
                                 #loop over points in cell2 points
                                 for j in range(0,Nj):
                                     #calculate the square distance
@@ -196,7 +197,7 @@ def spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
                                     if (dsq < r_max_squaredtmp) & (dsq > 0.0):
                                         has_neighbor[ifirst1+i] = 1
                                         break
-    
+
     #turn result into numpy array
     new_has_neighbor = np.array(has_neighbor)
 
@@ -208,7 +209,7 @@ def spherical_isolation_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
 
     new_is_isolated = np.zeros(Npts1)
     new_is_isolated[is_isolated] = 1
-    
+
     return new_is_isolated
 
 

--- a/halotools/mock_observables/pair_counters/cpairs/distances.pxd
+++ b/halotools/mock_observables/pair_counters/cpairs/distances.pxd
@@ -1,10 +1,11 @@
+# cython: language_level=2
 cimport numpy as cnp
 
 cdef double periodic_square_distance(
     cnp.float64_t x1, cnp.float64_t y1, cnp.float64_t z1,
     cnp.float64_t x2, cnp.float64_t y2, cnp.float64_t z2,
     cnp.float64_t* period)
-                                     
+
 cdef double square_distance(
     cnp.float64_t x1, cnp.float64_t y1, cnp.float64_t z1,
     cnp.float64_t x2, cnp.float64_t y2, cnp.float64_t z2)
@@ -15,7 +16,7 @@ cdef double perp_square_distance(
 cdef double para_square_distance(cnp.float64_t z1, cnp.float64_t z2)
 
 cdef double periodic_perp_square_distance(
-    cnp.float64_t x1, cnp.float64_t y1, 
+    cnp.float64_t x1, cnp.float64_t y1,
     cnp.float64_t x2, cnp.float64_t y2,
     cnp.float64_t* period)
 

--- a/halotools/mock_observables/pair_counters/cpairs/distances.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/distances.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 # cython: profile=False
 
 """

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_3d_engine.pyx
@@ -1,11 +1,12 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
-from libc.math cimport ceil 
+cimport cython
+from libc.math cimport ceil
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
 __all__ = ('npairs_3d_engine', )
@@ -14,34 +15,34 @@ __all__ = ('npairs_3d_engine', )
 @cython.wraparound(False)
 @cython.nonecheck(False)
 def npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rbins, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of three-dimensional separation. 
+    """ Cython engine for counting pairs of points as a function of three-dimensional separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
     rbins : array
         Boundaries defining the bins in which pairs are counted.
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rbins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rbins``. 
+    counts : array
+        Integer array of length len(rbins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rbins``.
 
-    """    
+    """
     cdef cnp.float64_t[:] rbins_squared = rbins*rbins
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
@@ -92,7 +93,7 @@ def npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rbins, cel
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef int Ni, Nj, i, j, k, l
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
@@ -117,9 +118,9 @@ def npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rbins, cel
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -179,7 +180,7 @@ def npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rbins, cel
                                         counts[k] += 1
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts)
 
 

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_jackknife_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_jackknife_3d_engine.pyx
@@ -1,11 +1,12 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
-from libc.math cimport ceil 
+cimport cython
+from libc.math cimport ceil
 
 __author__ = ('Andrew Hearin', 'Duncan Campbell')
 __all__ = ('npairs_jackknife_3d_engine', )
@@ -13,51 +14,51 @@ __all__ = ('npairs_jackknife_3d_engine', )
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def npairs_jackknife_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def npairs_jackknife_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     weights1in, weights2in, jtags1in, jtags2in, cnp.int64_t N_samples, rbins, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of three-dimensional separation. 
+    """ Cython engine for counting pairs of points as a function of three-dimensional separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
-    weights1in : array 
+    weights1in : array
         Numpy array storing the weights for points in sample 1
 
-    weights2in : array 
+    weights2in : array
         Numpy array storing the weights for points in sample 2
 
-    jtags1in : array 
+    jtags1in : array
         Numpy array storing the subvolume label integers for points in sample 1
 
-    jtags2in : array 
+    jtags2in : array
         Numpy array storing the subvolume label integers for points in sample 2
 
-    N_samples : int 
-        Total number of cells into which the simulated box has been subdivided 
+    N_samples : int
+        Total number of cells into which the simulated box has been subdivided
 
     rbins : array
         Boundaries defining the bins in which pairs are counted.
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rbins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rbins``. 
+    counts : array
+        Integer array of length len(rbins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rbins``.
 
-    """    
+    """
     cdef cnp.float64_t[:] rbins_squared = rbins*rbins
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
@@ -113,13 +114,13 @@ def npairs_jackknife_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
 
     cdef cnp.int64_t j1, j2
     cdef cnp.float64_t w1, w2
 
     cdef int Ni, Nj, i, j, k, l
-    cdef cnp.int64_t s 
+    cdef cnp.int64_t s
 
     cdef cnp.float64_t[:] x_icell1, x_icell2
     cdef cnp.float64_t[:] y_icell1, y_icell2
@@ -153,9 +154,9 @@ def npairs_jackknife_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -228,9 +229,9 @@ def npairs_jackknife_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                         while dsq<=rbins_squared[k]:
                                             counts[s,k] += jweight(s, j1, j2, w1, w2)
                                             k=k-1
-                                            if k<0: break                                        
-                                        
-                                        
+                                            if k<0: break
+
+
     return np.array(counts)
 
 
@@ -238,50 +239,50 @@ cdef inline cnp.float64_t jweight(cnp.int64_t j, cnp.int64_t j1, cnp.int64_t j2,
     cnp.float64_t w1, cnp.float64_t w2):
     """
     Return the jackknife weighted count.
-    
+
     parameters
     ----------
     j : int
         subsample being removed
-    
+
     j1 : int
         integer label indicating which subsample point 1 occupies
-    
+
     j2 : int
         integer label indicating which subsample point 2 occupies
-    
+
     w1 : float
         weight associated with point 1
-    
+
     w2 : float
         weight associated with point 2
-    
+
     Returns
     -------
     w : double
         0.0, w1*w2*0.5, or w1*w2
-    
+
     Notes
     -----
     We use the tag '0' to indicated we want to use the entire sample, i.e. no subsample
     should be labeled with a '0'.
-    
+
     jackknife wiehgt is caclulated as follows:
     if both points are inside the sample, return w1*w2
     if both points are outside the sample, return 0.0
     if one point is within and one point is outside the sample, return 0.5*w1*w2
     """
     cdef cnp.float64_t result
-    if j==0: 
+    if j==0:
         result = w1 * w2
     # both outside the sub-sample
-    elif (j1 == j2) & (j1 == j): 
+    elif (j1 == j2) & (j1 == j):
         result = 0.0
     # both inside the sub-sample
-    elif (j1 != j) & (j2 != j): 
+    elif (j1 != j) & (j2 != j):
         result = (w1 * w2)
     # only one inside the sub-sample
-    elif (j1 != j2) & ((j1 == j) | (j2 == j)): 
+    elif (j1 != j2) & ((j1 == j) | (j2 == j)):
         result = 0.5*(w1 * w2)
 
     return result

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_jackknife_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_jackknife_xy_z_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -62,7 +63,7 @@ def npairs_jackknife_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in
         separated by a distance less than the corresponding entry of ``rbins``.
 
     """
-    
+
     cdef cnp.float64_t[:] rp_bins_squared = rp_bins*rp_bins
     cdef cnp.float64_t[:] pi_bins_squared = pi_bins*pi_bins
     cdef cnp.float64_t xperiod = double_mesh.xperiod

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_per_object_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_per_object_3d_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_projected_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_projected_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_s_mu_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_s_mu_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -49,11 +50,11 @@ def npairs_s_mu_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     counts : array
         Integer array of length len(s_bins) giving the number of pairs
         separated by a distance less than the corresponding entry of ``s_bins``.
-    
+
     Notes
     -----
     mu is defined as the sin(theta_LOS) so that as theta_LOS increases, mu increases.
-    
+
     """
     cdef cnp.float64_t[:] sqr_s_bins = s_bins_in * s_bins_in
     cdef cnp.float64_t[:] sqr_mu_bins = mu_bins_in * mu_bins_in

--- a/halotools/mock_observables/pair_counters/cpairs/npairs_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/npairs_xy_z_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_3d_engine.pyx
@@ -1,10 +1,11 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil, sqrt
 from libcpp.vector cimport vector
 
@@ -15,84 +16,84 @@ __all__ = ('pairwise_distance_3d_engine', )
 @cython.wraparound(False)
 @cython.nonecheck(False)
 def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rmax, cell1_tuple):
-    """ 
-    Cython engine for returning pairs of points and three-dimensional separation. 
-    
-    Parameters 
+    """
+    Cython engine for returning pairs of points and three-dimensional separation.
+
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
-    
-    x1in, y1in, z1in : arrays 
+
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
-    
-    x2in, y2in, z2in : arrays 
+
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
-    
+
     rmax : array
         maximum separation distance to search for and return pairs
-    
+
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
-    
-    Returns 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
+
+    Returns
     --------
     distance : numpy.array
         array of pairwise separation distances
-    
+
     i : numpy.array
         array of 0-indexed indices in sample 1
-    
+
     j : numpy.array
         array of 0-indexed indices in sample2
-    
+
     """
-    
+
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
     cdef cnp.float64_t zperiod = double_mesh.zperiod
     cdef cnp.int64_t first_cell1_element = cell1_tuple[0]
     cdef cnp.int64_t last_cell1_element = cell1_tuple[1]
     cdef int PBCs = double_mesh._PBCs
-    
+
     cdef int Ncell1 = double_mesh.mesh1.ncells
-    
+
     rmax = rmax*rmax
     cdef cnp.float64_t[:] rmax_squared = np.ascontiguousarray(rmax[double_mesh.mesh1.idx_sorted], dtype=np.float64)
-    
+
     cdef cnp.float64_t[:] x1 = np.ascontiguousarray(x1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] y1 = np.ascontiguousarray(y1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] z1 = np.ascontiguousarray(z1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] x2 = np.ascontiguousarray(x2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] y2 = np.ascontiguousarray(y2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] z2 = np.ascontiguousarray(z2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
-    
+
     cdef vector[cnp.int_t] i_ind
     cdef vector[cnp.int_t] j_ind
     cdef vector[cnp.float64_t] distances
-    
+
     cdef cnp.int64_t icell1, icell2
     cdef cnp.int64_t[:] cell1_indices = np.ascontiguousarray(double_mesh.mesh1.cell_id_indices, dtype=np.int64)
     cdef cnp.int64_t[:] cell2_indices = np.ascontiguousarray(double_mesh.mesh2.cell_id_indices, dtype=np.int64)
-    
+
     cdef cnp.int64_t ifirst1, ilast1, ifirst2, ilast2
-    
+
     cdef int ix2, iy2, iz2, ix1, iy1, iz1
     cdef int nonPBC_ix2, nonPBC_iy2, nonPBC_iz2
-    
+
     cdef int num_x2_covering_steps = int(np.ceil(
         double_mesh.search_xlength / double_mesh.mesh2.xcell_size))
     cdef int num_y2_covering_steps = int(np.ceil(
         double_mesh.search_ylength / double_mesh.mesh2.ycell_size))
     cdef int num_z2_covering_steps = int(np.ceil(
         double_mesh.search_zlength / double_mesh.mesh2.zcell_size))
-    
+
     cdef int leftmost_ix2, rightmost_ix2
     cdef int leftmost_iy2, rightmost_iy2
     cdef int leftmost_iz2, rightmost_iz2
-    
+
     cdef int num_x1divs = double_mesh.mesh1.num_xdivs
     cdef int num_y1divs = double_mesh.mesh1.num_ydivs
     cdef int num_z1divs = double_mesh.mesh1.num_zdivs
@@ -102,37 +103,37 @@ def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     cdef int num_x2_per_x1 = num_x2divs // num_x1divs
     cdef int num_y2_per_y1 = num_y2divs // num_y1divs
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
-    
+
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef int Ni, Nj, i, j, k, l
-    
+
     cdef cnp.float64_t[:] x_icell1, x_icell2
     cdef cnp.float64_t[:] y_icell1, y_icell2
     cdef cnp.float64_t[:] z_icell1, z_icell2
-    
+
     for icell1 in range(first_cell1_element, last_cell1_element):
         ifirst1 = cell1_indices[icell1]
         ilast1 = cell1_indices[icell1+1]
         x_icell1 = x1[ifirst1:ilast1]
         y_icell1 = y1[ifirst1:ilast1]
         z_icell1 = z1[ifirst1:ilast1]
-        
+
         Ni = ilast1 - ifirst1
         if Ni > 0:
-            
+
             ix1 = icell1 // (num_y1divs*num_z1divs)
             iy1 = (icell1 - ix1*num_y1divs*num_z1divs) // num_z1divs
             iz1 = icell1 - (ix1*num_y1divs*num_z1divs) - (iy1*num_z1divs)
-            
+
             leftmost_ix2 = ix1*num_x2_per_x1 - num_x2_covering_steps
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
-            
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
-            
+
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
+
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
                     x2shift = -xperiod*PBCs
@@ -142,7 +143,7 @@ def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                     x2shift = 0.
                 # Now apply the PBCs
                 ix2 = nonPBC_ix2 % num_x2divs
-                
+
                 for nonPBC_iy2 in range(leftmost_iy2, rightmost_iy2):
                     if nonPBC_iy2 < 0:
                         y2shift = -yperiod*PBCs
@@ -152,7 +153,7 @@ def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                         y2shift = 0.
                     # Now apply the PBCs
                     iy2 = nonPBC_iy2 % num_y2divs
-                    
+
                     for nonPBC_iz2 in range(leftmost_iz2, rightmost_iz2):
                         if nonPBC_iz2 < 0:
                             z2shift = -zperiod*PBCs
@@ -162,15 +163,15 @@ def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                             z2shift = 0.
                         # Now apply the PBCs
                         iz2 = nonPBC_iz2 % num_z2divs
-                        
+
                         icell2 = ix2*(num_y2divs*num_z2divs) + iy2*num_z2divs + iz2
                         ifirst2 = cell2_indices[icell2]
                         ilast2 = cell2_indices[icell2+1]
-                        
+
                         x_icell2 = x2[ifirst2:ilast2]
                         y_icell2 = y2[ifirst2:ilast2]
                         z_icell2 = z2[ifirst2:ilast2]
-                        
+
                         Nj = ilast2 - ifirst2
                         #loop over points in cell1 points
                         if Nj > 0:
@@ -185,16 +186,16 @@ def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                     dy = y1tmp - y_icell2[j]
                                     dz = z1tmp - z_icell2[j]
                                     dsq = dx*dx + dy*dy + dz*dz
-                                    
+
                                     if dsq <= rmax_squared[ifirst1+i]:
                                         distances.push_back(dsq)
                                         i_ind.push_back(ifirst1 + i)
                                         j_ind.push_back(ifirst2 + j)
-    
+
     #input points were sorted.  return the indices of the unsorted arrays
     i_ind = np.array(i_ind).astype(int)
     i_ind = double_mesh.mesh1.idx_sorted[i_ind]
     j_ind = np.array(j_ind).astype(int)
     j_ind = double_mesh.mesh2.idx_sorted[j_ind]
-    
+
     return (np.sqrt(distances).astype(float), i_ind, j_ind)

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_xy_z_engine.pyx
@@ -1,10 +1,11 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil, sqrt
 from libcpp.vector cimport vector
 
@@ -15,93 +16,93 @@ __all__ = ('pairwise_distance_xy_z_engine', )
 @cython.wraparound(False)
 @cython.nonecheck(False)
 def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, rp_max, pi_max, cell1_tuple):
-    """ 
-    Cython engine for returning pairs of points and xy-projected and z separation. 
-    
-    Parameters 
+    """
+    Cython engine for returning pairs of points and xy-projected and z separation.
+
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
-    
-    x1in, y1in, z1in : arrays 
+
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
-    
-    x2in, y2in, z2in : arrays 
+
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
-    
+
     rp_max : array
         maximum xy-projected separation distance to search for and return pairs
-    
+
     pi_max : array
         maximum z separation distance to search for and return pairs
-    
+
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
-    
-    Returns 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
+
+    Returns
     --------
     distance_perp : numpy.array
         array of pairwise separation xy-projected distances
-    
+
     distance_para : numpy.array
         array of pairwise separation z distances
-    
+
     i : numpy.array
         array of 0-indexed indices in sample 1
-    
+
     j : numpy.array
         array of 0-indexed indices in sample2
-    
+
     """
-    
+
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
     cdef cnp.float64_t zperiod = double_mesh.zperiod
     cdef cnp.int64_t first_cell1_element = cell1_tuple[0]
     cdef cnp.int64_t last_cell1_element = cell1_tuple[1]
     cdef int PBCs = double_mesh._PBCs
-    
+
     cdef int Ncell1 = double_mesh.mesh1.ncells
-    
+
     rp_max = rp_max*rp_max
     cdef cnp.float64_t[:] rp_max_squared = np.ascontiguousarray(rp_max[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     pi_max = pi_max*pi_max
     cdef cnp.float64_t[:] pi_max_squared = np.ascontiguousarray(pi_max[double_mesh.mesh1.idx_sorted], dtype=np.float64)
-    
+
     cdef cnp.float64_t[:] x1 = np.ascontiguousarray(x1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] y1 = np.ascontiguousarray(y1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] z1 = np.ascontiguousarray(z1in[double_mesh.mesh1.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] x2 = np.ascontiguousarray(x2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] y2 = np.ascontiguousarray(y2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] z2 = np.ascontiguousarray(z2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
-    
+
     cdef vector[cnp.int_t] i_ind
     cdef vector[cnp.int_t] j_ind
     cdef vector[cnp.float64_t] rp_distances
     cdef vector[cnp.float64_t] pi_distances
-    
+
     cdef cnp.int64_t icell1, icell2
     cdef cnp.int64_t[:] cell1_indices = np.ascontiguousarray(double_mesh.mesh1.cell_id_indices, dtype=np.int64)
     cdef cnp.int64_t[:] cell2_indices = np.ascontiguousarray(double_mesh.mesh2.cell_id_indices, dtype=np.int64)
-    
+
     cdef cnp.int64_t ifirst1, ilast1, ifirst2, ilast2
-    
+
     cdef int ix2, iy2, iz2, ix1, iy1, iz1
     cdef int nonPBC_ix2, nonPBC_iy2, nonPBC_iz2
-    
+
     cdef int num_x2_covering_steps = int(np.ceil(
         double_mesh.search_xlength / double_mesh.mesh2.xcell_size))
     cdef int num_y2_covering_steps = int(np.ceil(
         double_mesh.search_ylength / double_mesh.mesh2.ycell_size))
     cdef int num_z2_covering_steps = int(np.ceil(
         double_mesh.search_zlength / double_mesh.mesh2.zcell_size))
-    
+
     cdef int leftmost_ix2, rightmost_ix2
     cdef int leftmost_iy2, rightmost_iy2
     cdef int leftmost_iz2, rightmost_iz2
-    
+
     cdef int num_x1divs = double_mesh.mesh1.num_xdivs
     cdef int num_y1divs = double_mesh.mesh1.num_ydivs
     cdef int num_z1divs = double_mesh.mesh1.num_zdivs
@@ -111,37 +112,37 @@ def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2i
     cdef int num_x2_per_x1 = num_x2divs // num_x1divs
     cdef int num_y2_per_y1 = num_y2divs // num_y1divs
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
-    
+
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dxy_sq, dz_sq
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef int Ni, Nj, i, j, k, l
-    
+
     cdef cnp.float64_t[:] x_icell1, x_icell2
     cdef cnp.float64_t[:] y_icell1, y_icell2
     cdef cnp.float64_t[:] z_icell1, z_icell2
-    
+
     for icell1 in range(first_cell1_element, last_cell1_element):
         ifirst1 = cell1_indices[icell1]
         ilast1 = cell1_indices[icell1+1]
         x_icell1 = x1[ifirst1:ilast1]
         y_icell1 = y1[ifirst1:ilast1]
         z_icell1 = z1[ifirst1:ilast1]
-        
+
         Ni = ilast1 - ifirst1
         if Ni > 0:
-            
+
             ix1 = icell1 // (num_y1divs*num_z1divs)
             iy1 = (icell1 - ix1*num_y1divs*num_z1divs) // num_z1divs
             iz1 = icell1 - (ix1*num_y1divs*num_z1divs) - (iy1*num_z1divs)
-            
+
             leftmost_ix2 = ix1*num_x2_per_x1 - num_x2_covering_steps
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
-            
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
-            
+
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
+
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
                     x2shift = -xperiod*PBCs
@@ -151,7 +152,7 @@ def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2i
                     x2shift = 0.
                 # Now apply the PBCs
                 ix2 = nonPBC_ix2 % num_x2divs
-                
+
                 for nonPBC_iy2 in range(leftmost_iy2, rightmost_iy2):
                     if nonPBC_iy2 < 0:
                         y2shift = -yperiod*PBCs
@@ -161,7 +162,7 @@ def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2i
                         y2shift = 0.
                     # Now apply the PBCs
                     iy2 = nonPBC_iy2 % num_y2divs
-                    
+
                     for nonPBC_iz2 in range(leftmost_iz2, rightmost_iz2):
                         if nonPBC_iz2 < 0:
                             z2shift = -zperiod*PBCs
@@ -171,15 +172,15 @@ def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2i
                             z2shift = 0.
                         # Now apply the PBCs
                         iz2 = nonPBC_iz2 % num_z2divs
-                        
+
                         icell2 = ix2*(num_y2divs*num_z2divs) + iy2*num_z2divs + iz2
                         ifirst2 = cell2_indices[icell2]
                         ilast2 = cell2_indices[icell2+1]
-                        
+
                         x_icell2 = x2[ifirst2:ilast2]
                         y_icell2 = y2[ifirst2:ilast2]
                         z_icell2 = z2[ifirst2:ilast2]
-                        
+
                         Nj = ilast2 - ifirst2
                         #loop over points in cell1 points
                         if Nj > 0:
@@ -195,17 +196,17 @@ def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2i
                                     dz = z1tmp - z_icell2[j]
                                     dxy_sq = dx*dx + dy*dy
                                     dz_sq = dz*dz
-                                    
+
                                     if (dxy_sq <= rp_max_squared[ifirst1+i]) & (dz_sq <= pi_max_squared[ifirst1+i]):
                                         rp_distances.push_back(dxy_sq)
                                         pi_distances.push_back(dz_sq)
                                         i_ind.push_back(ifirst1 + i)
                                         j_ind.push_back(ifirst2 + j)
-    
+
     #input points were sorted.  return the indices of the unsorted arrays
     i_ind = np.array(i_ind).astype(int)
     i_ind = double_mesh.mesh1.idx_sorted[i_ind]
     j_ind = np.array(j_ind).astype(int)
     j_ind = double_mesh.mesh2.idx_sorted[j_ind]
-    
+
     return (np.sqrt(rp_distances).astype(float), np.sqrt(pi_distances).astype(float), i_ind, j_ind)

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distances.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distances.pyx
@@ -1,5 +1,5 @@
+# cython: language_level=2
 # cython: profile=False
-
 """
 calculate and return the pairwise distances between two sets of points.
 """

--- a/halotools/mock_observables/pair_counters/cpairs/weighted_npairs_s_mu_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/weighted_npairs_s_mu_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/halotools/mock_observables/pair_counters/marked_cpairs/conditional_pairwise_distances.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/conditional_pairwise_distances.pyx
@@ -1,5 +1,5 @@
+# cython: language_level=2
 # cython: profile=False
-
 """
 calculate and return the conditional pairwise distances between two sets of points.
 """

--- a/halotools/mock_observables/pair_counters/marked_cpairs/custom_marking_func.pxd
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/custom_marking_func.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=2
 cimport numpy as cnp
 
 ##### declaration of user-defined custom marking function ####

--- a/halotools/mock_observables/pair_counters/marked_cpairs/custom_marking_func.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/custom_marking_func.pyx
@@ -1,7 +1,7 @@
+# cython: language_level=2
 # cython: profile=False
-
 """
-Custom weighting function. 
+Custom weighting function.
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -11,6 +11,6 @@ __author__ = ["Duncan Campbell"]
 
 cdef cnp.float64_t custom_func(cnp.float64_t* w1, cnp.float64_t* w2):
     """
-    Modify and use this function with weight_func_id=0 to get a custom function. 
+    Modify and use this function with weight_func_id=0 to get a custom function.
     """
     return w1[0]*w2[0]

--- a/halotools/mock_observables/pair_counters/marked_cpairs/custom_weighting_func.pxd
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/custom_weighting_func.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=2
 
 import numpy as np
 cimport numpy as np

--- a/halotools/mock_observables/pair_counters/marked_cpairs/custom_weighting_func.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/custom_weighting_func.pyx
@@ -1,5 +1,5 @@
+# cython: language_level=2
 # cython: profile=False
-
 """
 objective weighting functions.
 """

--- a/halotools/mock_observables/pair_counters/marked_cpairs/distances.pxd
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/distances.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=2
 import numpy as np
 cimport numpy as np
 
@@ -8,7 +9,7 @@ cdef double periodic_square_distance(np.float64_t x1,\
                                      np.float64_t y2,\
                                      np.float64_t z2,\
                                      np.float64_t* period)
-                                     
+
 cdef double square_distance(np.float64_t x1, np.float64_t y1, np.float64_t z1,\
                             np.float64_t x2, np.float64_t y2, np.float64_t z2)
 

--- a/halotools/mock_observables/pair_counters/marked_cpairs/distances.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/distances.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 # cython: profile=False
 
 """

--- a/halotools/mock_observables/pair_counters/marked_cpairs/marked_npairs_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/marked_npairs_3d_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/pair_counters/marked_cpairs/marked_npairs_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/marked_npairs_xy_z_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 r"""
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/pair_counters/marked_cpairs/marking_functions.pxd
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/marking_functions.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=2
 cimport numpy as cnp
 
 ##### built-in weighting functions####

--- a/halotools/mock_observables/pair_counters/marked_cpairs/marking_functions.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/marking_functions.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 # cython: profile=False
 """
 Marking function definitions.

--- a/halotools/mock_observables/pairwise_velocities/engines/mean_radial_velocity_vs_r_engine.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/mean_radial_velocity_vs_r_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/halotools/mock_observables/pairwise_velocities/engines/radial_pvd_vs_r_engine.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/radial_pvd_vs_r_engine.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_3d_engine.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_3d_engine.pyx
@@ -1,10 +1,11 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil
 
 from .velocity_marking_functions cimport *
@@ -17,41 +18,41 @@ ctypedef void (*f_type)(cnp.float64_t* w1, cnp.float64_t* w2, cnp.float64_t* shi
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def velocity_marked_npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def velocity_marked_npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     weights1in, weights2in, int weight_func_id, rbins, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of three-dimensional separation. 
+    """ Cython engine for counting pairs of points as a function of three-dimensional separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
     weight_func_id : int, optional
-        weighting function integer ID. 
+        weighting function integer ID.
 
-    weights1in : array 
+    weights1in : array
 
-    weights2in : array 
+    weights2in : array
 
     rbins : array
         Boundaries defining the bins in which pairs are counted.
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rbins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rbins``. 
+    counts : array
+        Integer array of length len(rbins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rbins``.
 
     """
     cdef f_type wfunc
@@ -112,7 +113,7 @@ def velocity_marked_npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, 
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dsq, weight
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef cnp.float64_t holder1 = 0.
     cdef cnp.float64_t holder2 = 0.
     cdef cnp.float64_t holder3 = 0.
@@ -148,9 +149,9 @@ def velocity_marked_npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, 
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -220,9 +221,9 @@ def velocity_marked_npairs_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, 
                                         counts3[k] += holder3
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts1), np.array(counts2), np.array(counts3)
-    
+
 
 cdef f_type return_velocity_weighting_function(weight_func_id):
     """

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_xy_z_engine.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marked_npairs_xy_z_engine.pyx
@@ -1,10 +1,11 @@
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil
 
 from .velocity_marking_functions cimport *
@@ -17,27 +18,27 @@ ctypedef void (*f_type)(cnp.float64_t* w1, cnp.float64_t* w2, cnp.float64_t* shi
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def velocity_marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def velocity_marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     weights1in, weights2in, int weight_func_id, rp_bins, pi_bins, cell1_tuple):
-    """ Cython engine for counting pairs of points as a function of three-dimensional separation. 
+    """ Cython engine for counting pairs of points as a function of three-dimensional separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
     weight_func_id : int, optional
-        weighting function integer ID. 
+        weighting function integer ID.
 
-    weights1in : array 
+    weights1in : array
 
-    weights2in : array 
+    weights2in : array
 
     rp_bins : array
         Boundaries defining the bins in which pairs are counted.
@@ -46,15 +47,15 @@ def velocity_marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in
         array defining parallel separation in which to sum the pair counts
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    counts : array 
-        Integer array of length len(rp_bins) giving the number of pairs 
-        separated by a distance less than the corresponding entry of ``rp_bins``. 
+    counts : array
+        Integer array of length len(rp_bins) giving the number of pairs
+        separated by a distance less than the corresponding entry of ``rp_bins``.
 
     """
     cdef f_type wfunc
@@ -117,7 +118,7 @@ def velocity_marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in
     cdef int num_z2_per_z1 = num_z2divs // num_z1divs
 
     cdef cnp.float64_t x2shift, y2shift, z2shift, dx, dy, dz, dxy_sq, dz_sq, weight
-    cdef cnp.float64_t x1tmp, y1tmp, z1tmp 
+    cdef cnp.float64_t x1tmp, y1tmp, z1tmp
     cdef cnp.float64_t holder1 = 0.
     cdef cnp.float64_t holder2 = 0.
     cdef cnp.float64_t holder3 = 0.
@@ -153,9 +154,9 @@ def velocity_marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -231,9 +232,9 @@ def velocity_marked_npairs_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in
                                             if g<0: break
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts1), np.array(counts2), np.array(counts3)
-    
+
 
 cdef f_type return_velocity_weighting_function(weight_func_id):
     """

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marking_functions.pxd
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marking_functions.pxd
@@ -1,3 +1,4 @@
+# cython: language_level=2
 cimport numpy as cnp
 
 #####built in weighting functions####

--- a/halotools/mock_observables/pairwise_velocities/engines/velocity_marking_functions.pyx
+++ b/halotools/mock_observables/pairwise_velocities/engines/velocity_marking_functions.pyx
@@ -1,5 +1,5 @@
+# cython: language_level=2
 # cython: profile=False
-
 """
 weighting fuctions that return pairwise velocity calculations.
 """
@@ -26,59 +26,59 @@ cdef void relative_radial_velocity_weights(cnp.float64_t* w1,
     Calculate the relative radial velocity between two points.
 
     func ID=1
-    
+
     Parameters
     ----------
     w1 : pointer to an array
         weights array associated with data1.
         w1[0:2] x,y,z positions
         w1[3:6] vx, vy, vz velocities
-    
+
     w2 : pointer to an array
         weights array associated with data2
         w2[0:2] x,y,z positions
         w2[3:6] vx, vy, vz velocities
-    
+
     shift : pointer to an array
-        Length-3 array storing the amount the points were shifted in each spatial 
-        dimension.  This is used when doing pair counts on periodic boxes and the 
+        Length-3 array storing the amount the points were shifted in each spatial
+        dimension.  This is used when doing pair counts on periodic boxes and the
         points have been preshifted.
-    
+
     result1 : pointer to a double
         relative radial velocity
-        
+
     result2 : pointer to a double
         0.0 (dummy)
-        
+
     result3 : pointer to a double
         1.0 (pairs involved, but also kind-of a dummy)
-    
+
     """
     #calculate radial vector between points
-    # Note that due to the application of the shift, 
+    # Note that due to the application of the shift,
     #   when PBCs are applied, rx, ry, rz has its normal sign flipped
     cdef cnp.float64_t rx = w1[0] - (w2[0] + shift[0])
     cdef cnp.float64_t ry = w1[1] - (w2[1] + shift[1])
     cdef cnp.float64_t rz = w1[2] - (w2[2] + shift[2])
     cdef cnp.float64_t norm = np.sqrt(rx*rx + ry*ry + rz*rz)
-        
+
     cdef cnp.float64_t dvx, dvy, dvz, result
-    
+
     if norm==0.0:
         result1[0] = 0.0 #radial velocity
         result2[0] = 0.0 #unused value
         result3[0] = 1.0 #number of pairs
-    else: 
+    else:
        #calculate the difference velocity.
        dvx = (w1[3] - w2[3])
        dvy = (w1[4] - w2[4])
        dvz = (w1[5] - w2[5])
-       
+
        #the radial component of the velocity difference
-       # Since rx, ry, rz have a flipped sign for PBC case, 
+       # Since rx, ry, rz have a flipped sign for PBC case,
        #    the following definition requires no further modification
        result = (dvx*rx + dvy*ry + dvz*rz)/norm
-       
+
        result1[0] = result #radial velocity
        result2[0] = 0.0 #unused value
        result3[0] = 1.0 #number of pairs
@@ -92,12 +92,12 @@ cdef void radial_velocity_variance_counter_weights(cnp.float64_t* w1,
                                                    cnp.float64_t* result2,
                                                    cnp.float64_t* result3):
     """
-    Calculate the relative radial velocity between two points minus an offset, and the 
-    squared quantity.  This function is used to calculate the variance using the 
+    Calculate the relative radial velocity between two points minus an offset, and the
+    squared quantity.  This function is used to calculate the variance using the
     "shifted data" technique where a constant value is subtracted from the value.
 
     func ID=2
-    
+
     Parameters
     ----------
     w1 : pointer to an array
@@ -105,37 +105,37 @@ cdef void radial_velocity_variance_counter_weights(cnp.float64_t* w1,
         w1[0:2] x,y,z positions
         w1[3:6] vx, vy, vz velocities
         w1[6] offset
-    
+
     w2 : pointer to an array
         weights array associated with data2
         w2[0:2] x,y,z positions
         w2[3:6] vx, vy, vz velocities
         w2[6] offset
-    
+
     shift : pointer to an array
-        Length-3 array storing the amount the points were shifted in each spatial 
-        dimension.  This is used when doing pair counts on periodic boxes and the 
+        Length-3 array storing the amount the points were shifted in each spatial
+        dimension.  This is used when doing pair counts on periodic boxes and the
         points have been preshifted.
-    
+
     result1 : pointer to a double
         relative radial velocity minus an offset
-        
+
     result2 : pointer to a double
         relative radial velocity minus an offset squared
-        
+
     result3 : pointer to a double
         1.0 (pairs involved, but also kind-of a dummy)
-    
+
     """
-    
+
     #calculate radial vector between points
     cdef cnp.float64_t rx = w1[0] - (w2[0] + shift[0])
     cdef cnp.float64_t ry = w1[1] - (w2[1] + shift[1])
     cdef cnp.float64_t rz = w1[2] - (w2[2] + shift[2])
     cdef cnp.float64_t norm = np.sqrt(rx*rx + ry*ry + rz*rz)
-        
+
     cdef cnp.float64_t dvx, dvy, dvz, result
-    
+
     if norm==0:
         result1[0] = 0.0
         result2[0] = 0.0
@@ -145,10 +145,10 @@ cdef void radial_velocity_variance_counter_weights(cnp.float64_t* w1,
         dvx = (w1[3] - w2[3])
         dvy = (w1[4] - w2[4])
         dvz = (w1[5] - w2[5])
-        
+
         #the radial component of the velocity difference
         result = (dvx*rx + dvy*ry + dvz*rz)/norm - w1[6]*w2[6]
-        
+
         result1[0] = result #radial velocity
         result2[0] = result*result #radial velocity squared
         result3[0] = 1.0 #number of pairs
@@ -164,34 +164,34 @@ cdef void relative_los_velocity_weights(cnp.float64_t* w1,
     Calculate the relative line-of-sight (LOS) velocity between two points.
 
     func ID=3
-    
+
     Parameters
     ----------
     w1 : pointer to an array
         weights array associated with data1.
         w1[0] vz velocities
-    
+
     w2 : pointer to an array
         weights array associated with data2
         w2[0] vz velocities
-    
+
     shift : pointer to an array
-        Length-3 array storing the amount the points were shifted in each spatial 
-        dimension.  This is used when doing pair counts on periodic boxes and the 
+        Length-3 array storing the amount the points were shifted in each spatial
+        dimension.  This is used when doing pair counts on periodic boxes and the
         points have been preshifted.
-    
+
     result1 : pointer to a double
         relative LOS velocity
-        
+
     result2 : pointer to a double
         0.0 (dummy)
-        
+
     result3 : pointer to a double
         1.0 (pairs involved, but also kind-of a dummy)
-    
+
     """
     #calculate radial vector between points
-    # Note that due to the application of the shift, 
+    # Note that due to the application of the shift,
     #   when PBCs are applied, rx, ry, rz has its normal sign flipped
     cdef cnp.float64_t rz = w1[2] - (w2[2] + shift[2])
     cdef cnp.float64_t norm = abs(rz)
@@ -215,39 +215,39 @@ cdef void los_velocity_variance_counter_weights(cnp.float64_t* w1,
                                                 cnp.float64_t* result2,
                                                 cnp.float64_t* result3):
     """
-    Calculate the relative LOS velocity between two points minus an offset, and the 
-    squared quantity.  This function is used to calculate the variance using the 
+    Calculate the relative LOS velocity between two points minus an offset, and the
+    squared quantity.  This function is used to calculate the variance using the
     "shifted data" technique where a constant value is subtracted from the value.
 
     func ID=4
-    
+
     Parameters
     ----------
     w1 : pointer to an array
         weights array associated with data1.
         w1[0] vz velocities
-    
+
     w2 : pointer to an array
         weights array associated with data2
         w2[0] vz velocities
-    
+
     shift : pointer to an array
-        Length-3 array storing the amount the points were shifted in each spatial 
-        dimension.  This is used when doing pair counts on periodic boxes and the 
+        Length-3 array storing the amount the points were shifted in each spatial
+        dimension.  This is used when doing pair counts on periodic boxes and the
         points have been preshifted.
-    
+
     result1 : pointer to a double
         relative LOS velocity minus an offset
-        
+
     result2 : pointer to a double
         relative LOS velocity minus an offset squared
-        
+
     result3 : pointer to a double
         1.0 (pairs involved, but also kind-of a dummy)
-    
+
     """
     #calculate radial vector between points
-    # Note that due to the application of the shift, 
+    # Note that due to the application of the shift,
     #   when PBCs are applied, rx, ry, rz has its normal sign flipped
     cdef cnp.float64_t rz = w1[2] - (w2[2] + shift[2])
     cdef cnp.float64_t norm = abs(rz)
@@ -258,7 +258,7 @@ cdef void los_velocity_variance_counter_weights(cnp.float64_t* w1,
         dvz = -abs(w1[5] - w2[5]) - w1[6]*w2[6]
     else:
         dvz = (w1[5] - w2[5])*rz/norm - w1[6]*w2[6]
-            
+
     result1[0] = dvz #radial velocity
     result2[0] = dvz*dvz #radial velocity squared
     result3[0] = 1.0 #number of pairs

--- a/halotools/mock_observables/radial_profiles/engines/radial_profile_3d_engine.pyx
+++ b/halotools/mock_observables/radial_profiles/engines/radial_profile_3d_engine.pyx
@@ -1,10 +1,11 @@
+#cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import numpy as np
 cimport numpy as cnp
-cimport cython 
+cimport cython
 from libc.math cimport ceil
 
 __author__ = ('Andrew Hearin', )
@@ -13,45 +14,45 @@ __all__ = ('radial_profile_3d_engine', )
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.nonecheck(False)
-def radial_profile_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in, 
+def radial_profile_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     squared_normalize_rbins_by_in, sample2_quantity_in, rbins_normalized, cell1_tuple):
-    """ Cython engine for computing radial profiles 
-    as a function of (optionally normalized) three-dimensional separation. 
+    """ Cython engine for computing radial profiles
+    as a function of (optionally normalized) three-dimensional separation.
 
-    Parameters 
+    Parameters
     ------------
-    double_mesh : object 
+    double_mesh : object
         Instance of `~halotools.mock_observables.RectangularDoubleMesh`
 
-    x1in, y1in, z1in : arrays 
+    x1in, y1in, z1in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 1
 
-    x2in, y2in, z2in : arrays 
+    x2in, y2in, z2in : arrays
         Numpy arrays storing Cartesian coordinates of points in sample 2
 
-    squared_normalize_rbins_by_in : array 
+    squared_normalize_rbins_by_in : array
 
-    sample2_quantity_in : array 
+    sample2_quantity_in : array
 
     rbins_normalized : array
         Boundaries defining the bins in which pairs are counted.
 
     cell1_tuple : tuple
-        Two-element tuple defining the first and last cells in 
-        double_mesh.mesh1 that will be looped over. Intended for use with 
-        python multiprocessing. 
+        Two-element tuple defining the first and last cells in
+        double_mesh.mesh1 that will be looped over. Intended for use with
+        python multiprocessing.
 
-    Returns 
+    Returns
     --------
-    weighted_counts : array 
-        Array of length len(rbins_normalized) giving the number of pairs 
-        in ``sample2``separated from points in ``sample1`` by a distance less than 
-        the corresponding entry of ``rbins_normalized``, 
-        weighted by the values stored in sample2_quantity_in. 
+    weighted_counts : array
+        Array of length len(rbins_normalized) giving the number of pairs
+        in ``sample2``separated from points in ``sample1`` by a distance less than
+        the corresponding entry of ``rbins_normalized``,
+        weighted by the values stored in sample2_quantity_in.
 
-    counts : array 
-        Array of length len(rbins_normalized) giving the number of pairs 
-        in ``sample2``separated from points in ``sample1`` by a distance less than 
+    counts : array
+        Array of length len(rbins_normalized) giving the number of pairs
+        in ``sample2``separated from points in ``sample1`` by a distance less than
         the corresponding entry of ``rbins_normalized``.
     """
 
@@ -141,9 +142,9 @@ def radial_profile_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
             leftmost_iy2 = iy1*num_y2_per_y1 - num_y2_covering_steps
             leftmost_iz2 = iz1*num_z2_per_z1 - num_z2_covering_steps
 
-            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps 
-            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps 
-            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps 
+            rightmost_ix2 = (ix1+1)*num_x2_per_x1 + num_x2_covering_steps
+            rightmost_iy2 = (iy1+1)*num_y2_per_y1 + num_y2_covering_steps
+            rightmost_iz2 = (iz1+1)*num_z2_per_z1 + num_z2_covering_steps
 
             for nonPBC_ix2 in range(leftmost_ix2, rightmost_ix2):
                 if nonPBC_ix2 < 0:
@@ -210,7 +211,7 @@ def radial_profile_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
                                         counts2[k] += 1.
                                         k=k-1
                                         if k<0: break
-                                        
+
     return np.array(counts), np.array(counts2)
 
 

--- a/halotools/mock_observables/surface_density/engines/mean_delta_sigma_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/mean_delta_sigma_engine.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/surface_density/engines/mean_delta_sigma_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/mean_delta_sigma_engine.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=2
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -51,7 +51,7 @@ def mean_delta_sigma_engine(double_mesh, x1in, y1in, x2in, y2in, m2in, rp_bins, 
 
     """
     cdef cnp.float64_t[:] rp_bins_squared = rp_bins*rp_bins
-    cdef cnp.float64_t[:] d_log_rp_bins = np.log(rp_bins[1:] / rp_bins[:-1])
+    cdef cnp.float64_t[:] d_log_rp_bins = np.log(rp_bins[1:] / rp_bins[:len(rp_bins)-1])
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
     cdef cnp.int64_t first_cell1_element = cell1_tuple[0]

--- a/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_halo_id_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_halo_id_engine.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=2
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -51,7 +51,7 @@ def mean_ds_12h_halo_id_engine(double_mesh, x1in, y1in, id1in, x2in, y2in, m2in,
 
     """
     cdef cnp.float64_t[:] rp_bins_squared = rp_bins*rp_bins
-    cdef cnp.float64_t[:] d_log_rp_bins = np.log(rp_bins[1:] / rp_bins[:-1])
+    cdef cnp.float64_t[:] d_log_rp_bins = np.log(rp_bins[1:] / rp_bins[:len(rp_bins)-1])
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
     cdef cnp.int64_t first_cell1_element = cell1_tuple[0]

--- a/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_halo_id_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_halo_id_engine.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_rhalo_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_rhalo_engine.pyx
@@ -1,4 +1,4 @@
-#cython: language_level=2
+# cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -50,8 +50,9 @@ def mean_ds_12h_rhalo_engine(double_mesh, zperiod_in, x1in, y1in, z1in, rhalo1in
     delta_sigma_2h : array
 
     """
+    _log_rp_bins = np.log(rp_bins[1:] / rp_bins[:len(rp_bins)-1])
     cdef cnp.float64_t[:] rp_bins_squared = rp_bins*rp_bins
-    cdef cnp.float64_t[:] d_log_rp_bins = np.log(rp_bins[1:] / rp_bins[:-1])
+    cdef cnp.float64_t[:] d_log_rp_bins = _log_rp_bins
     cdef cnp.float64_t xperiod = double_mesh.xperiod
     cdef cnp.float64_t yperiod = double_mesh.yperiod
     cdef cnp.float64_t zperiod = zperiod_in

--- a/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_rhalo_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/mean_ds_one_two_halo_decomp_rhalo_engine.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/surface_density/engines/weighted_npairs_per_object_xy_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/weighted_npairs_per_object_xy_engine.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/surface_density/engines/weighted_npairs_xy_engine.pyx
+++ b/halotools/mock_observables/surface_density/engines/weighted_npairs_xy_engine.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=2
 """
 """
 from __future__ import (absolute_import, division, print_function, unicode_literals)

--- a/halotools/mock_observables/tensor_calculations/engines/inertia_tensor_3d_engine.pyx
+++ b/halotools/mock_observables/tensor_calculations/engines/inertia_tensor_3d_engine.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=2
 """
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/halotools/utils/engines/conditional_rank_kernel.pyx
+++ b/halotools/utils/engines/conditional_rank_kernel.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 """
 """
 import numpy as np


### PR DESCRIPTION
Should eliminate cython warnings and resolve #965. 

At some point, should also modify the cython source so that `language_level=3` works, but currently this causes compile problems due to 3.x division defaulting to float.