### PR TITLE
Fixed bug in CachedHaloCatalog treatment of simname

### DIFF
--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -580,7 +580,9 @@ class CachedHaloCatalog(object):
             for attr in matching_sim._attrlist:
                 if hasattr(self, attr):
                     try:
-                        assert np.all(getattr(self, attr) == getattr(matching_sim, attr))
+                        a = _passively_decode_string(getattr(self, attr))
+                        b = _passively_decode_string(getattr(matching_sim, attr))
+                        assert np.all(a == b)
                     except AssertionError:
                         msg = ("The ``" + attr + "`` metadata of the hdf5 file \n"
                             "is inconsistent with the corresponding attribute of the \n" +
@@ -602,7 +604,7 @@ class CachedHaloCatalog(object):
                 cl = getattr(supported_sims, clname)
                 obj = cl()
                 if isinstance(obj, supported_sims.NbodySimulation):
-                    if self.simname == obj.simname:
+                    if compare_strings_py23_safe(self.simname, obj.simname):
                         matching_sim = obj
             except TypeError:
                 pass

--- a/halotools/sim_manager/tests/test_cached_halo_catalog.py
+++ b/halotools/sim_manager/tests/test_cached_halo_catalog.py
@@ -82,6 +82,8 @@ class TestCachedHaloCatalog(TestCase):
             halocat = CachedHaloCatalog(**constructor_kwargs)
             assert hasattr(halocat, 'redshift')
             assert hasattr(halocat, 'Lbox')
+            assert hasattr(halocat, 'num_ptcl_per_dim')
+            assert hasattr(halocat, 'cosmology')
 
     @pytest.mark.skipif('not HAS_H5PY')
     def test_halo_ptcl_consistency(self):


### PR DESCRIPTION
The CachedHaloCatalog was failing to recognize that an input simulation matched a previously cached simulation. The cause of the problem was string-to-bytes comparisons in python 3. This PR resolves the bug by using the `compare_strings_py23_safe` function.