### PR TITLE
Relaxed requirement that monte carlo realizations of NFW profiles must respect a SO mass definition

### DIFF
--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/mc_generate_nfw_radial_positions.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/kernels/mc_generate_nfw_radial_positions.py
@@ -76,11 +76,6 @@ def mc_generate_nfw_radial_positions(num_pts=int(1e4), conc=5,
     >>> radial_positions = mc_generate_nfw_radial_positions(halo_mass = 1e12, conc = 10)
     >>> radial_positions = mc_generate_nfw_radial_positions(halo_radius = 0.25)
     """
-    if ('halo_radius' in kwargs) and ('halo_mass' in kwargs):
-        msg = ("\nDo not specify both ``halo_mass`` and ``halo_radius``. \n"
-            "Pick a single option, and the other will be determined self-consistently.")
-        raise HalotoolsError(msg)
-
     try:
         halo_radius = kwargs['halo_radius']
     except KeyError:

--- a/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_nfw_profile/test_nfw_profile.py
+++ b/halotools/empirical_models/phase_space_models/analytic_models/satellites/nfw/tests/test_nfw_profile/test_nfw_profile.py
@@ -310,3 +310,22 @@ def test_mc_generate_nfw_radial_positions_stochasticity():
         halo_radius=halo_radius, conc=conc, num_pts=num_pts, seed=44)
     assert np.allclose(r1, r2, rtol=0.001)
     assert not np.allclose(r1, r3, rtol=0.001)
+
+
+def test_user_defined_halo_radius():
+    """Regression test for #940
+    """
+    M = 1e14
+    model = NFWProfile()
+    virial_radius = model.halo_mass_to_halo_radius(M)
+    user_defined_radius = 7
+
+    r = model.mc_generate_nfw_radial_positions(
+        halo_radius=user_defined_radius, conc=5, num_pts=int(1000), seed=43)
+    assert np.all(r <= user_defined_radius)
+    assert np.any(r > virial_radius)
+
+    r = model.mc_generate_nfw_radial_positions(
+        halo_mass=M, conc=5, num_pts=int(1000), seed=43)
+    assert np.all(r <= virial_radius)
+


### PR DESCRIPTION
Resolves #940. 