### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
+addopts = --doctest-ignore-import-errors
 minversion = 2.2
 norecursedirs = build docs/_build
 doctest_plus = enabled


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.