### PR TITLE
Add support for non-Poissonian satellite occupation statistics

### DIFF
--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -15,7 +15,7 @@ from .. import model_defaults, model_helpers
 from ...utils.array_utils import custom_len
 from ...custom_exceptions import HalotoolsError
 
-__all__ = ('OccupationComponent', )
+__all__ = ("OccupationComponent",)
 
 
 @six.add_metaclass(ABCMeta)
@@ -50,57 +50,61 @@ class OccupationComponent(object):
         ---------
         :ref:`writing_your_own_hod_occupation_component`
         """
-        required_kwargs = ['gal_type', 'threshold']
+        required_kwargs = ["gal_type", "threshold"]
         model_helpers.bind_required_kwargs(required_kwargs, self, **kwargs)
 
         try:
-            self.prim_haloprop_key = kwargs['prim_haloprop_key']
+            self.prim_haloprop_key = kwargs["prim_haloprop_key"]
         except:
             pass
 
         try:
-            self._upper_occupation_bound = kwargs['upper_occupation_bound']
+            self._upper_occupation_bound = kwargs["upper_occupation_bound"]
         except KeyError:
-            msg = ("\n``upper_occupation_bound`` is a required keyword argument of OccupationComponent\n")
+            msg = "\n``upper_occupation_bound`` is a required keyword argument of OccupationComponent\n"
             raise KeyError(msg)
 
-        self._lower_occupation_bound = 0.
+        self._lower_occupation_bound = 0.0
 
-        if not hasattr(self, 'param_dict'):
+        if not hasattr(self, "param_dict"):
             self.param_dict = {}
 
         # Enforce the requirement that sub-classes have been configured properly
-        required_method_name = 'mean_occupation'
+        required_method_name = "mean_occupation"
         if not hasattr(self, required_method_name):
-            raise SyntaxError("Any sub-class of OccupationComponent must "
-                "implement a method named %s " % required_method_name)
+            raise SyntaxError(
+                "Any sub-class of OccupationComponent must "
+                "implement a method named %s " % required_method_name
+            )
 
         try:
-            self.redshift = kwargs['redshift']
+            self.redshift = kwargs["redshift"]
         except KeyError:
             pass
 
         # The _methods_to_inherit determines which methods will be directly callable
         # by the composite model built by the HodModelFactory
         try:
-            self._methods_to_inherit.extend(['mc_occupation', 'mean_occupation'])
+            self._methods_to_inherit.extend(["mc_occupation", "mean_occupation"])
         except AttributeError:
-            self._methods_to_inherit = ['mc_occupation', 'mean_occupation']
+            self._methods_to_inherit = ["mc_occupation", "mean_occupation"]
 
         # The _attrs_to_inherit determines which methods will be directly bound
         # to the composite model built by the HodModelFactory
         try:
-            self._attrs_to_inherit.append('threshold')
+            self._attrs_to_inherit.append("threshold")
         except AttributeError:
-            self._attrs_to_inherit = ['threshold']
+            self._attrs_to_inherit = ["threshold"]
 
-        if not hasattr(self, 'publications'):
+        if not hasattr(self, "publications"):
             self.publications = []
 
         # The _mock_generation_calling_sequence determines which methods
         # will be called during mock population, as well as in what order they will be called
-        self._mock_generation_calling_sequence = ['mc_occupation']
-        self._galprop_dtypes_to_allocate = np.dtype([('halo_num_' + self.gal_type, 'i4')])
+        self._mock_generation_calling_sequence = ["mc_occupation"]
+        self._galprop_dtypes_to_allocate = np.dtype(
+            [("halo_num_" + self.gal_type, "i4")]
+        )
 
     def mc_occupation(self, seed=None, **kwargs):
         """ Method to generate Monte Carlo realizations of the abundance of galaxies.
@@ -126,17 +130,25 @@ class OccupationComponent(object):
         """
         first_occupation_moment = self.mean_occupation(**kwargs)
         if self._upper_occupation_bound == 1:
-            return self._nearest_integer_distribution(first_occupation_moment, seed=seed, **kwargs)
+            return self._nearest_integer_distribution(
+                first_occupation_moment, seed=seed, **kwargs
+            )
         elif self._upper_occupation_bound == float("inf"):
-            return self._poisson_distribution(first_occupation_moment, seed=seed, **kwargs)
+            return self._poisson_distribution(
+                first_occupation_moment, seed=seed, **kwargs
+            )
         else:
-            msg = ("\nYou have chosen to set ``_upper_occupation_bound`` to some value \n"
+            msg = (
+                "\nYou have chosen to set ``_upper_occupation_bound`` to some value \n"
                 "besides 1 or infinity. In such cases, you must also \n"
                 "write your own ``mc_occupation`` method that overrides the method in the \n"
-                "OccupationComponent super-class\n")
+                "OccupationComponent super-class\n"
+            )
             raise HalotoolsError(msg)
 
-    def _nearest_integer_distribution(self, first_occupation_moment, seed=None, **kwargs):
+    def _nearest_integer_distribution(
+        self, first_occupation_moment, seed=None, **kwargs
+    ):
         """ Nearest-integer distribution used to draw Monte Carlo occupation statistics
         for central-like populations with only permissible galaxy per halo.
 
@@ -158,8 +170,8 @@ class OccupationComponent(object):
             mc_generator = np.random.random(custom_len(first_occupation_moment))
 
         result = np.where(mc_generator < first_occupation_moment, 1, 0)
-        if 'table' in kwargs:
-            kwargs['table']['halo_num_'+self.gal_type] = result
+        if "table" in kwargs:
+            kwargs["table"]["halo_num_" + self.gal_type] = result
         return result
 
     def _poisson_distribution(self, first_occupation_moment, seed=None, **kwargs):
@@ -183,8 +195,12 @@ class OccupationComponent(object):
         # We don't use the built-in Poisson number generator so that when a seed
         # is specified, it preserves the ranks among rvs even when mean is changed.
         with NumpyRNGContext(seed):
-            result = np.ceil(pdtrik(np.random.rand(*first_occupation_moment.shape),
-                                    first_occupation_moment)).astype(np.int)
-        if 'table' in kwargs:
-            kwargs['table']['halo_num_'+self.gal_type] = result
+            result = np.ceil(
+                pdtrik(
+                    np.random.rand(*first_occupation_moment.shape),
+                    first_occupation_moment,
+                )
+            ).astype(np.int)
+        if "table" in kwargs:
+            kwargs["table"]["halo_num_" + self.gal_type] = result
         return result

--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -242,7 +242,7 @@ class OccupationComponent(object):
         nsat_lo = np.floor(first_occupation_moment)
         with NumpyRNGContext(seed):
             uran = np.random.uniform(nsat_lo, nsat_lo + 1, first_occupation_moment.size)
-        result = np.where(uran < first_occupation_moment, nsat_lo, nsat_lo + 1)
+        result = np.where(uran > first_occupation_moment, nsat_lo, nsat_lo + 1)
         if "table" in kwargs:
             kwargs["table"]["halo_num_" + self.gal_type] = result
         return result

--- a/halotools/empirical_models/occupation_models/tests/test_zheng07_satellites.py
+++ b/halotools/empirical_models/occupation_models/tests/test_zheng07_satellites.py
@@ -324,3 +324,15 @@ def test_get_published_parameters3():
         d2 = default_model.get_published_parameters(default_model.threshold)
 
         assert d1 == d2
+
+
+def test_weighted_nearest_integer():
+    model1 = Zheng07Sats()
+    model2 = Zheng07Sats(second_moment="weighted_nearest_integer")
+
+    mtest = np.zeros(int(1e5)) + 1e13
+    nsat1 = model1.mc_occupation(prim_haloprop=mtest)
+    nsat2 = model2.mc_occupation(prim_haloprop=mtest)
+
+    assert np.allclose(nsat1.mean(), nsat2.mean(), rtol=0.05)
+    assert np.std(nsat1) > np.std(nsat2) + 0.1

--- a/halotools/empirical_models/occupation_models/tests/test_zheng07_satellites.py
+++ b/halotools/empirical_models/occupation_models/tests/test_zheng07_satellites.py
@@ -10,7 +10,7 @@ from ....empirical_models import OccupationComponent, Zheng07Sats, Zheng07Cens
 
 from ....custom_exceptions import HalotoolsError
 
-__all__ = ('test_alternate_threshold_models', )
+__all__ = ("test_alternate_threshold_models",)
 
 
 supported_thresholds = np.arange(-22, -17.5, 0.5)
@@ -36,16 +36,16 @@ def test_alternate_threshold_models():
 
 def enforce_required_attributes(model):
     assert isinstance(model, OccupationComponent)
-    assert model.gal_type == 'satellites'
+    assert model.gal_type == "satellites"
 
-    assert hasattr(model, 'prim_haloprop_key')
+    assert hasattr(model, "prim_haloprop_key")
 
     assert model._upper_occupation_bound == float("inf")
 
 
 def enforce_mean_occupation_behavior(model):
 
-    assert hasattr(model, 'mean_occupation')
+    assert hasattr(model, "mean_occupation")
 
     mvir_array = np.logspace(10, 16, 10)
     mean_occ = model.mean_occupation(prim_haloprop=mvir_array)
@@ -59,19 +59,19 @@ def enforce_mean_occupation_behavior(model):
 def enforce_mc_occupation_behavior(model):
 
     # Check the Monte Carlo realization method
-    assert hasattr(model, 'mc_occupation')
+    assert hasattr(model, "mc_occupation")
 
-    model.param_dict['alpha'] = 1
-    model.param_dict['logM0'] = 11.25
-    model.param_dict['logM1'] = model.param_dict['logM0'] + np.log10(20.)
+    model.param_dict["alpha"] = 1
+    model.param_dict["logM0"] = 11.25
+    model.param_dict["logM1"] = model.param_dict["logM0"] + np.log10(20.0)
 
     Npts = int(1e3)
-    masses = np.ones(Npts)*10.**model.param_dict['logM1']
+    masses = np.ones(Npts) * 10.0 ** model.param_dict["logM1"]
     mc_occ = model.mc_occupation(prim_haloprop=masses, seed=43)
     # We chose a specific seed that has been pre-tested,
     # so we should always get the same result
     expected_result = 1.0
-    np.testing.assert_allclose(mc_occ.mean(), expected_result, rtol=1e-2, atol=1.e-2)
+    np.testing.assert_allclose(mc_occ.mean(), expected_result, rtol=1e-2, atol=1.0e-2)
 
 
 def test_ncen_inheritance_behavior1():
@@ -88,8 +88,10 @@ def test_ncen_inheritance_behavior1():
     diff = mean_occ_satmodel_cens - mean_occ_satmodel_nocens
     assert diff.sum() < 0
 
-    mean_occ_cens = satmodel_cens.central_occupation_model.mean_occupation(prim_haloprop=masses)
-    assert np.all(mean_occ_satmodel_cens == mean_occ_satmodel_nocens*mean_occ_cens)
+    mean_occ_cens = satmodel_cens.central_occupation_model.mean_occupation(
+        prim_haloprop=masses
+    )
+    assert np.all(mean_occ_satmodel_cens == mean_occ_satmodel_nocens * mean_occ_cens)
 
 
 def test_ncen_inheritance_behavior2():
@@ -100,30 +102,34 @@ def test_ncen_inheritance_behavior2():
     from .. import OccupationComponent
 
     class MyCenModel(OccupationComponent):
-
         def __init__(self, threshold):
-            OccupationComponent.__init__(self, gal_type='centrals',
-                    threshold=threshold, upper_occupation_bound=1.)
-            self.param_dict['new_cen_param'] = 0.5
+            OccupationComponent.__init__(
+                self,
+                gal_type="centrals",
+                threshold=threshold,
+                upper_occupation_bound=1.0,
+            )
+            self.param_dict["new_cen_param"] = 0.5
 
         def mean_occupation(self, **kwargs):
             try:
-                halo_table = kwargs['table']
+                halo_table = kwargs["table"]
                 num_halos = len(halo_table)
             except KeyError:
-                mass_array = kwargs['prim_haloprop']
+                mass_array = kwargs["prim_haloprop"]
                 num_halos = len(mass_array)
 
-            result = np.zeros(num_halos) + self.param_dict['new_cen_param']
+            result = np.zeros(num_halos) + self.param_dict["new_cen_param"]
             return result
 
     my_cen_model = MyCenModel(threshold=-20)
     my_sat_model1 = Zheng07Sats(
-        threshold=-20, modulate_with_cenocc=True, cenocc_model=my_cen_model)
-    my_sat_model2 = Zheng07Sats(
-        threshold=-20, modulate_with_cenocc=True)
+        threshold=-20, modulate_with_cenocc=True, cenocc_model=my_cen_model
+    )
+    my_sat_model2 = Zheng07Sats(threshold=-20, modulate_with_cenocc=True)
     my_sat_model3 = Zheng07Sats(
-        threshold=-20, modulate_with_cenocc=False, cenocc_model=my_cen_model)
+        threshold=-20, modulate_with_cenocc=False, cenocc_model=my_cen_model
+    )
 
     mass_array = np.logspace(11, 15, 10)
     result1a = my_sat_model1.mean_occupation(prim_haloprop=mass_array)
@@ -134,7 +140,7 @@ def test_ncen_inheritance_behavior2():
     assert not np.allclose(result1a, result3, rtol=0.001)
     assert not np.allclose(result2, result3, rtol=0.001)
 
-    my_sat_model1.param_dict['new_cen_param'] = 1.
+    my_sat_model1.param_dict["new_cen_param"] = 1.0
     result1b = my_sat_model1.mean_occupation(prim_haloprop=mass_array)
     assert not np.allclose(result1a, result1b, rtol=0.001)
     assert np.allclose(result1b, result3, rtol=0.001)
@@ -143,117 +149,128 @@ def test_ncen_inheritance_behavior2():
 def test_alpha_scaling1_mean_occupation():
     default_model = Zheng07Sats()
     model2 = Zheng07Sats()
-    model2.param_dict['alpha'] *= 1.25
+    model2.param_dict["alpha"] *= 1.25
 
-    logmass = model2.param_dict['logM1'] + np.log10(5)
-    mass = 10.**logmass
-    assert (model2.mean_occupation(prim_haloprop=mass) >
-        default_model.mean_occupation(prim_haloprop=mass))
+    logmass = model2.param_dict["logM1"] + np.log10(5)
+    mass = 10.0 ** logmass
+    assert model2.mean_occupation(prim_haloprop=mass) > default_model.mean_occupation(
+        prim_haloprop=mass
+    )
 
 
 def test_alpha_scaling2_mc_occupation():
     default_model = Zheng07Sats()
     model2 = Zheng07Sats()
-    model2.param_dict['alpha'] *= 1.25
+    model2.param_dict["alpha"] *= 1.25
 
-    logmass = model2.param_dict['logM1'] + np.log10(5)
-    mass = 10.**logmass
+    logmass = model2.param_dict["logM1"] + np.log10(5)
+    mass = 10.0 ** logmass
     Npts = 1000
-    masses = np.ones(Npts)*mass
+    masses = np.ones(Npts) * mass
 
-    assert (model2.mc_occupation(prim_haloprop=masses, seed=43).mean() >
-        default_model.mc_occupation(prim_haloprop=masses, seed=43).mean())
+    assert (
+        model2.mc_occupation(prim_haloprop=masses, seed=43).mean()
+        > default_model.mc_occupation(prim_haloprop=masses, seed=43).mean()
+    )
 
 
 def test_alpha_propagation():
     default_model = Zheng07Sats()
     model2 = Zheng07Sats()
-    model2.param_dict['alpha'] *= 1.25
+    model2.param_dict["alpha"] *= 1.25
 
-    logmass = model2.param_dict['logM1'] + np.log10(5)
-    mass = 10.**logmass
+    logmass = model2.param_dict["logM1"] + np.log10(5)
+    mass = 10.0 ** logmass
     Npts = 1000
-    masses = np.ones(Npts)*mass
+    masses = np.ones(Npts) * mass
 
     alt_default_model = deepcopy(default_model)
 
-    alt_default_model.param_dict['alpha'] = model2.param_dict['alpha']
+    alt_default_model.param_dict["alpha"] = model2.param_dict["alpha"]
 
-    assert (model2.mc_occupation(prim_haloprop=masses, seed=43).mean() ==
-        alt_default_model.mc_occupation(prim_haloprop=masses, seed=43).mean())
+    assert (
+        model2.mc_occupation(prim_haloprop=masses, seed=43).mean()
+        == alt_default_model.mc_occupation(prim_haloprop=masses, seed=43).mean()
+    )
 
 
 def test_logM0_scaling1_mean_occupation():
     default_model = Zheng07Sats()
     model3 = Zheng07Sats()
-    model3.param_dict['logM0'] += np.log10(2)
+    model3.param_dict["logM0"] += np.log10(2)
 
     # At very low mass, both models should have zero satellites
     lowmass = 1e10
-    assert (model3.mean_occupation(prim_haloprop=lowmass) ==
-        default_model.mean_occupation(prim_haloprop=lowmass))
+    assert model3.mean_occupation(
+        prim_haloprop=lowmass
+    ) == default_model.mean_occupation(prim_haloprop=lowmass)
 
 
 def test_logM0_scaling2_mean_occupation():
     default_model = Zheng07Sats()
     model3 = Zheng07Sats()
-    model3.param_dict['logM0'] += np.log10(2)
+    model3.param_dict["logM0"] += np.log10(2)
 
     # At intermediate masses, there should be fewer satellites for larger M0
     midmass = 1e12
-    assert (model3.mean_occupation(prim_haloprop=midmass) <
-        default_model.mean_occupation(prim_haloprop=midmass)
-            )
+    assert model3.mean_occupation(
+        prim_haloprop=midmass
+    ) < default_model.mean_occupation(prim_haloprop=midmass)
 
 
 def test_logM0_scaling3_mean_occupation():
     default_model = Zheng07Sats()
     model3 = Zheng07Sats()
-    model3.param_dict['logM0'] += np.log10(2)
+    model3.param_dict["logM0"] += np.log10(2)
 
     # At high masses, the difference should be negligible
     highmass = 1e15
     np.testing.assert_allclose(
         model3.mean_occupation(prim_haloprop=highmass),
         default_model.mean_occupation(prim_haloprop=highmass),
-        rtol=1e-3, atol=1.e-3)
+        rtol=1e-3,
+        atol=1.0e-3,
+    )
 
 
 def test_logM1_scaling1_mean_occupation():
     default_model = Zheng07Sats()
     model2 = Zheng07Sats()
-    model2.param_dict['alpha'] *= 1.25
+    model2.param_dict["alpha"] *= 1.25
     model3 = Zheng07Sats()
-    model3.param_dict['logM0'] += np.log10(2)
+    model3.param_dict["logM0"] += np.log10(2)
     model4 = Zheng07Sats()
-    model4.param_dict['logM1'] += np.log10(2)
+    model4.param_dict["logM1"] += np.log10(2)
 
     # At very low mass, both models should have zero satellites
     lowmass = 1e10
-    assert (model4.mean_occupation(prim_haloprop=lowmass) ==
-        default_model.mean_occupation(prim_haloprop=lowmass))
+    assert model4.mean_occupation(
+        prim_haloprop=lowmass
+    ) == default_model.mean_occupation(prim_haloprop=lowmass)
 
 
 def test_logM1_scaling2_mean_occupation():
     default_model = Zheng07Sats()
     model2 = Zheng07Sats()
-    model2.param_dict['alpha'] *= 1.25
+    model2.param_dict["alpha"] *= 1.25
     model3 = Zheng07Sats()
-    model3.param_dict['logM0'] += np.log10(2)
+    model3.param_dict["logM0"] += np.log10(2)
     model4 = Zheng07Sats()
-    model4.param_dict['logM1'] += np.log10(2)
+    model4.param_dict["logM1"] += np.log10(2)
 
     # At intermediate masses, there should be fewer satellites for larger M1
     midmass = 1e12
-    fracdiff_midmass = ((model4.mean_occupation(prim_haloprop=midmass) -
-        default_model.mean_occupation(prim_haloprop=midmass)) /
-        default_model.mean_occupation(prim_haloprop=midmass))
+    fracdiff_midmass = (
+        model4.mean_occupation(prim_haloprop=midmass)
+        - default_model.mean_occupation(prim_haloprop=midmass)
+    ) / default_model.mean_occupation(prim_haloprop=midmass)
     assert fracdiff_midmass < 0
 
     highmass = 1e14
-    fracdiff_highmass = ((model4.mean_occupation(prim_haloprop=highmass) -
-        default_model.mean_occupation(prim_haloprop=highmass)) /
-        default_model.mean_occupation(prim_haloprop=highmass))
+    fracdiff_highmass = (
+        model4.mean_occupation(prim_haloprop=highmass)
+        - default_model.mean_occupation(prim_haloprop=highmass)
+    ) / default_model.mean_occupation(prim_haloprop=highmass)
     assert fracdiff_highmass < 0
 
     # The fractional change due to alterations of logM1 should be identical at all mass
@@ -286,8 +303,9 @@ def test_get_published_parameters1():
 def test_get_published_parameters2():
     default_model = Zheng07Sats()
     with pytest.raises(KeyError) as err:
-        d2 = default_model.get_published_parameters(default_model.threshold,
-            publication='Parejko13')
+        d2 = default_model.get_published_parameters(
+            default_model.threshold, publication="Parejko13"
+        )
     substr = "For Zheng07Sats, only supported best-fit models are currently Zheng et al. 2007"
     assert substr == err.value.args[0]
 


### PR DESCRIPTION
PR adds support for the Monte Carlo realizations of satellite occupation statistics to follow a weighted nearest-integer distribution.

CC @johannesulf 