### PR TITLE
fixed bug for weighted nearest integer distributions

### DIFF
--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -239,7 +239,7 @@ class OccupationComponent(object):
         mc_abundance : array
             Integer array giving the number of galaxies in each of the input table.
         """
-        nsat_lo = np.floor(first_occupation_moment)
+        nsat_lo = np.floor(first_occupation_moment).astype(int)
         with NumpyRNGContext(seed):
             uran = np.random.uniform(nsat_lo, nsat_lo + 1, first_occupation_moment.size)
         result = np.where(uran > first_occupation_moment, nsat_lo, nsat_lo + 1)


### PR DESCRIPTION
Currently, the function `_weighted_nearest_integer` function returns floats when it should return integers. This leads to crashes if one wants to populate a halo catalog with an HOD model that has non-Poisson numbers for satellites. This PR fixes that.