### PR TITLE
Adding GitHub Action to produce Python Wheels for Linux and Mac

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
         env:
-          CIBW_BEFORE_BUILD: pip install numpy
+          CIBW_BEFORE_BUILD: pip install numpy Cython
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,6 +21,7 @@ jobs:
         uses: pypa/cibuildwheel@v1.12.0
         env:
           CIBW_BEFORE_BUILD: pip install numpy Cython
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6"
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
+        env:
+          CIBW_BEFORE_BUILD: pip install numpy
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           CIBW_BEFORE_BUILD: pip install oldest-supported-numpy Cython
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6"
+          CIBW_SKIP: pp*
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
         env:
-          CIBW_BEFORE_BUILD: pip install numpy Cython
+          CIBW_BEFORE_BUILD: pip install oldest-supported-numpy Cython
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.6"
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
This short PR adds a GitHub action that will automatically trigger the build of python wheels for all versions of python above 3.6 for both Mac (intel) and linux architectures. It uses the excellent https://cibuildwheel.readthedocs.io/ tool that makes all of this very simple.

For maintainers, here are the steps to follow upon a new code release:
- Use the github release tool to tag a new version
- Go get a coffee for like 30 mins
- Go the Actions tab and find the latest `Build wheels` run, download the attached `artifact`
- Unzip the artifact
- Upload to pypi with: `twine upload  *.whl`

This is in addition to uploading the normal source distribution. Eventually the entire process can be automatized if you create a pypi key so that the action can directly push to pypi.


After that, a user can trivially install halotools by:
```
$ pip install halotools
```
and they wont have to recompile anything, this will automatically grab the appropriate python wheel.

If you want to test it out before merging, I've run the action on my fork:
- The output of the github action is here (notice the attached artifact): https://github.com/EiffL/halotools/actions/runs/1094382382
- I pushed to test.pypi.org for testing: https://test.pypi.org/project/halotools/
- To try installing halotools with binary wheel from the test pypi, do the following:
```
$ pip install -i https://test.pypi.org/simple/ halotools
```

Annnnd to demonstrate how cool this is: https://colab.research.google.com/drive/1_KjhW8zV7EGDyIzeIHC9tZiZpffs69G7?usp=sharing
