### PR TITLE
Bug fix for cross-correlations with non-natural estimators

### DIFF
--- a/halotools/mock_observables/two_point_clustering/angular_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/angular_tpcf.py
@@ -7,6 +7,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 
 from .tpcf_estimators import _TP_estimator_requirements, _TP_estimator
+from .tpcf_estimators import _TP_estimator_crossx
+
 from .clustering_helpers import verify_tpcf_estimator, process_optional_input_sample2
 
 
@@ -319,11 +321,11 @@ def angular_tpcf(
     else:
         if (do_auto is True) & (do_cross is True):
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_12, xi_22
         elif do_cross is True:
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)
             return xi_12
         elif do_auto is True:
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)

--- a/halotools/mock_observables/two_point_clustering/angular_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/angular_tpcf.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 
 from .tpcf_estimators import _TP_estimator_requirements, _TP_estimator
-from .clustering_helpers import (verify_tpcf_estimator, process_optional_input_sample2)
+from .clustering_helpers import verify_tpcf_estimator, process_optional_input_sample2
 
 
 from ..pair_counters import npairs_3d
@@ -17,14 +17,22 @@ from ...utils.spherical_geometry import spherical_to_cartesian, chord_to_cartesi
 from ...custom_exceptions import HalotoolsError
 from ...utils.array_utils import array_is_monotonic
 
-__all__ = ['angular_tpcf']
-__author__ = ['Duncan Campbell']
+__all__ = ["angular_tpcf"]
+__author__ = ["Duncan Campbell"]
 
-np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD/RR
+np.seterr(divide="ignore", invalid="ignore")  # ignore divide by zero in e.g. DD/RR
 
 
-def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
-        do_auto=True, do_cross=True, estimator='Natural', num_threads=1):
+def angular_tpcf(
+    sample1,
+    theta_bins,
+    sample2=None,
+    randoms=None,
+    do_auto=True,
+    do_cross=True,
+    estimator="Natural",
+    num_threads=1,
+):
     r"""
     Calculate the angular two-point correlation function, :math:`w(\theta)`.
 
@@ -123,12 +131,28 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
     """
 
     # check input arguments using clustering helper functions
-    function_args = (sample1, theta_bins, sample2, randoms, do_auto, do_cross,
-        estimator, num_threads)
+    function_args = (
+        sample1,
+        theta_bins,
+        sample2,
+        randoms,
+        do_auto,
+        do_cross,
+        estimator,
+        num_threads,
+    )
 
     # pass arguments in, and get out processed arguments, plus some control flow variables
-    sample1, theta_bins, sample2, randoms, do_auto, do_cross, num_threads,\
-        _sample1_is_sample2 = _angular_tpcf_process_args(*function_args)
+    (
+        sample1,
+        theta_bins,
+        sample2,
+        randoms,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+    ) = _angular_tpcf_process_args(*function_args)
 
     # convert angular bins to coord lengths on a unit sphere
     chord_bins = chord_to_cartesian(theta_bins, radians=False)
@@ -145,29 +169,36 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
         x, y, z = spherical_to_cartesian(randoms[:, 0], randoms[:, 1])
         randoms = np.vstack((x, y, z)).T
 
-    def random_counts(sample1, sample2, randoms, chord_bins,
-            num_threads, do_RR, do_DR, _sample1_is_sample2):
+    def random_counts(
+        sample1,
+        sample2,
+        randoms,
+        chord_bins,
+        num_threads,
+        do_RR,
+        do_DR,
+        _sample1_is_sample2,
+    ):
         """
         Count random pairs.
         """
+
         def area_spherical_cap(chord):
             """
             Calculate the area of a spherical cap on a unit sphere given the chord length
             """
-            h = 1.0 - np.sqrt(1.0-chord**2)
-            return np.pi*(chord**2+h**2)
+            h = 1.0 - np.sqrt(1.0 - chord**2)
+            return np.pi * (chord**2 + h**2)
 
         # randoms provided, so calculate random pair counts.
         if randoms is not None:
             if do_RR is True:
-                RR = npairs_3d(randoms, randoms, chord_bins,
-                            num_threads=num_threads)
+                RR = npairs_3d(randoms, randoms, chord_bins, num_threads=num_threads)
                 RR = np.diff(RR)
             else:
                 RR = None
             if do_DR is True:
-                D1R = npairs_3d(sample1, randoms, chord_bins,
-                             num_threads=num_threads)
+                D1R = npairs_3d(sample1, randoms, chord_bins, num_threads=num_threads)
                 D1R = np.diff(D1R)
             else:
                 D1R = None
@@ -175,8 +206,9 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
                 D2R = None
             else:
                 if do_DR is True:
-                    D2R = npairs_3d(sample2, randoms, chord_bins,
-                                 num_threads=num_threads)
+                    D2R = npairs_3d(
+                        sample2, randoms, chord_bins, num_threads=num_threads
+                    )
                     D2R = np.diff(D2R)
                 else:
                     D2R = None
@@ -190,26 +222,33 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
             # do area calculations
             da = area_spherical_cap(chord_bins)
             da = np.diff(da)
-            global_area = 4.0*np.pi  # surface area of a unit sphere
+            global_area = 4.0 * np.pi  # surface area of a unit sphere
 
             # calculate randoms for sample1
             N1 = np.shape(sample1)[0]  # number of points in sample1
-            rho1 = N1/global_area  # number density of points
-            D1R = (N1)*(da*rho1)  # random counts are N**2*dv*rho
+            rho1 = N1 / global_area  # number density of points
+            D1R = (N1) * (da * rho1)  # random counts are N**2*dv*rho
 
             N2 = np.shape(sample2)[0]
-            rho2 = N2/global_area  # number density of points
-            D2R = N2*(da*rho2)
+            rho2 = N2 / global_area  # number density of points
+            D2R = N2 * (da * rho2)
 
             # calculate the random-random pairs.
             # cbx: This should be NR(NR-1) if we are doing an autocorr I think? Maybe it doesn't matter.
-            rhor = NR**2/global_area
-            RR = (da*rhor)
+            rhor = NR**2 / global_area
+            RR = da * rhor
 
             return D1R, D2R, RR
 
-    def pair_counts(sample1, sample2, chord_bins,
-            num_threads, do_auto, do_cross, _sample1_is_sample2):
+    def pair_counts(
+        sample1,
+        sample2,
+        chord_bins,
+        num_threads,
+        do_auto,
+        do_cross,
+        _sample1_is_sample2,
+    ):
         """
         Count data-data pairs.
         """
@@ -252,11 +291,26 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
         NR = N1
 
     # count data pairs
-    D1D1, D1D2, D2D2 = pair_counts(sample1, sample2, chord_bins,
-        num_threads, do_auto, do_cross, _sample1_is_sample2)
+    D1D1, D1D2, D2D2 = pair_counts(
+        sample1,
+        sample2,
+        chord_bins,
+        num_threads,
+        do_auto,
+        do_cross,
+        _sample1_is_sample2,
+    )
     # count random pairs
-    D1R, D2R, RR = random_counts(sample1, sample2, randoms, chord_bins,
-        num_threads, do_RR, do_DR, _sample1_is_sample2)
+    D1R, D2R, RR = random_counts(
+        sample1,
+        sample2,
+        randoms,
+        chord_bins,
+        num_threads,
+        do_RR,
+        do_DR,
+        _sample1_is_sample2,
+    )
 
     # run results through the estimator and return relavent/user specified results.
     if _sample1_is_sample2:
@@ -268,17 +322,18 @@ def angular_tpcf(sample1, theta_bins, sample2=None, randoms=None,
             xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_12, xi_22
-        elif (do_cross is True):
+        elif do_cross is True:
             xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
             return xi_12
-        elif (do_auto is True):
+        elif do_auto is True:
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_22
 
 
-def _angular_tpcf_process_args(sample1, theta_bins, sample2, randoms,
-        do_auto, do_cross, estimator, num_threads):
+def _angular_tpcf_process_args(
+    sample1, theta_bins, sample2, randoms, do_auto, do_cross, estimator, num_threads
+):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.angular_tpcf`.
@@ -287,7 +342,8 @@ def _angular_tpcf_process_args(sample1, theta_bins, sample2, randoms,
     sample1 = np.atleast_1d(sample1)
 
     sample2, _sample1_is_sample2, do_cross = process_optional_input_sample2(
-        sample1, sample2, do_cross, ndim=2)
+        sample1, sample2, do_cross, ndim=2
+    )
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
@@ -300,23 +356,35 @@ def _angular_tpcf_process_args(sample1, theta_bins, sample2, randoms,
         if len(theta_bins) > 2:
             assert array_is_monotonic(theta_bins, strict=True) == 1
     except AssertionError:
-        msg = ("\n Input `theta_bins` must be a monotonically increasing 1-D \n"
-               "array with at least two entries.")
+        msg = (
+            "\n Input `theta_bins` must be a monotonically increasing 1-D \n"
+            "array with at least two entries."
+        )
         raise HalotoolsError(msg)
 
     # check for input parameter consistency
-    if (theta_max >= 180.0):
-        msg = ("\n The maximum length over which you search for pairs of points \n"
-               "cannot be larger than 180.0 deg. \n")
+    if theta_max >= 180.0:
+        msg = (
+            "\n The maximum length over which you search for pairs of points \n"
+            "cannot be larger than 180.0 deg. \n"
+        )
         raise HalotoolsError(msg)
 
     if (type(do_auto) is not bool) | (type(do_cross) is not bool):
-        msg = ('\n `do_auto` and `do_cross` keywords must be of type boolean.')
+        msg = "\n `do_auto` and `do_cross` keywords must be of type boolean."
         raise HalotoolsError(msg)
 
     num_threads = get_num_threads(num_threads)
 
     verify_tpcf_estimator(estimator)
 
-    return sample1, theta_bins, sample2, randoms, do_auto, do_cross, num_threads,\
-        _sample1_is_sample2
+    return (
+        sample1,
+        theta_bins,
+        sample2,
+        randoms,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+    )

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
@@ -10,6 +10,7 @@ from math import pi
 
 from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
+from .tpcf_estimators import _TP_estimator_crossx
 
 from ..mock_observables_helpers import (
     enforce_sample_has_correct_shape,
@@ -280,11 +281,11 @@ def rp_pi_tpcf(
     else:
         if (do_auto is True) & (do_cross is True):
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_12, xi_22
         elif do_cross is True:
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)
             return xi_12
         elif do_auto is True:
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf.py
@@ -8,26 +8,43 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from math import pi
 
-from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
+from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
 
-from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
-    get_separation_bins_array, get_line_of_sight_bins_array, get_period, get_num_threads)
+from ..mock_observables_helpers import (
+    enforce_sample_has_correct_shape,
+    get_separation_bins_array,
+    get_line_of_sight_bins_array,
+    get_period,
+    get_num_threads,
+)
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
 from ..pair_counters import npairs_xy_z
 
 
-__all__ = ['rp_pi_tpcf']
-__author__ = ['Duncan Campbell']
+__all__ = ["rp_pi_tpcf"]
+__author__ = ["Duncan Campbell"]
 
 
-np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD/RR
+np.seterr(divide="ignore", invalid="ignore")  # ignore divide by zero in e.g. DD/RR
 
 
-def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
-        period=None, do_auto=True, do_cross=True, estimator='Natural',
-        num_threads=1, approx_cell1_size=None,
-        approx_cell2_size=None, approx_cellran_size=None, seed=None):
+def rp_pi_tpcf(
+    sample1,
+    rp_bins,
+    pi_bins,
+    sample2=None,
+    randoms=None,
+    period=None,
+    do_auto=True,
+    do_cross=True,
+    estimator="Natural",
+    num_threads=1,
+    approx_cell1_size=None,
+    approx_cell2_size=None,
+    approx_cellran_size=None,
+    seed=None,
+):
     r"""
     Calculate the redshift space correlation function, :math:`\xi(r_{p}, \pi)`
 
@@ -182,12 +199,36 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
 
     """
 
-    function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
-        do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
+    function_args = (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        estimator,
+        num_threads,
+        approx_cell1_size,
+        approx_cell2_size,
+        approx_cellran_size,
+        seed,
+    )
 
-    sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
-        _sample1_is_sample2, PBCs = _rp_pi_tpcf_process_args(*function_args)
+    (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    ) = _rp_pi_tpcf_process_args(*function_args)
 
     do_DD, do_DR, do_RR = _TP_estimator_requirements(estimator)
 
@@ -202,13 +243,36 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
         NR = N1
 
     # count pairs
-    D1D1, D1D2, D2D2 = pair_counts(sample1, sample2, rp_bins, pi_bins,
-        period, num_threads, do_auto, do_cross,
-        _sample1_is_sample2, approx_cell1_size, approx_cell2_size)
+    D1D1, D1D2, D2D2 = pair_counts(
+        sample1,
+        sample2,
+        rp_bins,
+        pi_bins,
+        period,
+        num_threads,
+        do_auto,
+        do_cross,
+        _sample1_is_sample2,
+        approx_cell1_size,
+        approx_cell2_size,
+    )
 
-    D1R, D2R, RR = random_counts(sample1, sample2, randoms, rp_bins, pi_bins,
-        period, PBCs, num_threads, do_RR, do_DR,
-        _sample1_is_sample2, approx_cell1_size, approx_cell2_size, approx_cellran_size)
+    D1R, D2R, RR = random_counts(
+        sample1,
+        sample2,
+        randoms,
+        rp_bins,
+        pi_bins,
+        period,
+        PBCs,
+        num_threads,
+        do_RR,
+        do_DR,
+        _sample1_is_sample2,
+        approx_cell1_size,
+        approx_cell2_size,
+        approx_cellran_size,
+    )
 
     if _sample1_is_sample2:
         xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)
@@ -219,42 +283,71 @@ def rp_pi_tpcf(sample1, rp_bins, pi_bins, sample2=None, randoms=None,
             xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_12, xi_22
-        elif (do_cross is True):
+        elif do_cross is True:
             xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
             return xi_12
-        elif (do_auto is True):
+        elif do_auto is True:
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_22
 
 
-def pair_counts(sample1, sample2, rp_bins, pi_bins, period,
-        num_threads, do_auto, do_cross, _sample1_is_sample2,
-        approx_cell1_size, approx_cell2_size):
+def pair_counts(
+    sample1,
+    sample2,
+    rp_bins,
+    pi_bins,
+    period,
+    num_threads,
+    do_auto,
+    do_cross,
+    _sample1_is_sample2,
+    approx_cell1_size,
+    approx_cell2_size,
+):
     """
     Count data pairs.
     """
-    D1D1 = npairs_xy_z(sample1, sample1, rp_bins, pi_bins, period=period,
-        num_threads=num_threads, approx_cell1_size=approx_cell1_size,
-        approx_cell2_size=approx_cell1_size)
+    D1D1 = npairs_xy_z(
+        sample1,
+        sample1,
+        rp_bins,
+        pi_bins,
+        period=period,
+        num_threads=num_threads,
+        approx_cell1_size=approx_cell1_size,
+        approx_cell2_size=approx_cell1_size,
+    )
     D1D1 = np.diff(np.diff(D1D1, axis=0), axis=1)
     if _sample1_is_sample2:
         D1D2 = D1D1
         D2D2 = D1D1
     else:
         if do_cross is True:
-            D1D2 = npairs_xy_z(sample1, sample2, rp_bins, pi_bins, period=period,
+            D1D2 = npairs_xy_z(
+                sample1,
+                sample2,
+                rp_bins,
+                pi_bins,
+                period=period,
                 num_threads=num_threads,
                 approx_cell1_size=approx_cell1_size,
-                approx_cell2_size=approx_cell2_size)
+                approx_cell2_size=approx_cell2_size,
+            )
             D1D2 = np.diff(np.diff(D1D2, axis=0), axis=1)
         else:
             D1D2 = None
         if do_auto is True:
-            D2D2 = npairs_xy_z(sample2, sample2, rp_bins, pi_bins,
-                period=period, num_threads=num_threads,
+            D2D2 = npairs_xy_z(
+                sample2,
+                sample2,
+                rp_bins,
+                pi_bins,
+                period=period,
+                num_threads=num_threads,
                 approx_cell1_size=approx_cell2_size,
-                approx_cell2_size=approx_cell2_size)
+                approx_cell2_size=approx_cell2_size,
+            )
             D2D2 = np.diff(np.diff(D2D2, axis=0), axis=1)
         else:
             D2D2 = None
@@ -266,12 +359,25 @@ def cylinder_volume(R, h):
     """
     Calculate the volume of a cylinder(s), used for the analytical randoms.
     """
-    return pi*np.outer(R**2.0, h)
+    return pi * np.outer(R**2.0, h)
 
 
-def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
-        PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size):
+def random_counts(
+    sample1,
+    sample2,
+    randoms,
+    rp_bins,
+    pi_bins,
+    period,
+    PBCs,
+    num_threads,
+    do_RR,
+    do_DR,
+    _sample1_is_sample2,
+    approx_cell1_size,
+    approx_cell2_size,
+    approx_cellran_size,
+):
     r"""
     Count random pairs.  There are two high level branches:
         1. w/ or wo/ PBCs and randoms.
@@ -286,18 +392,30 @@ def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
     # No PBCs, randoms must have been provided.
     if randoms is not None:
         if do_RR is True:
-            RR = npairs_xy_z(randoms, randoms, rp_bins, pi_bins,
-                period=period, num_threads=num_threads,
+            RR = npairs_xy_z(
+                randoms,
+                randoms,
+                rp_bins,
+                pi_bins,
+                period=period,
+                num_threads=num_threads,
                 approx_cell1_size=approx_cellran_size,
-                approx_cell2_size=approx_cellran_size)
+                approx_cell2_size=approx_cellran_size,
+            )
             RR = np.diff(np.diff(RR, axis=0), axis=1)
         else:
             RR = None
         if do_DR is True:
-            D1R = npairs_xy_z(sample1, randoms, rp_bins, pi_bins,
-                period=period, num_threads=num_threads,
+            D1R = npairs_xy_z(
+                sample1,
+                randoms,
+                rp_bins,
+                pi_bins,
+                period=period,
+                num_threads=num_threads,
                 approx_cell1_size=approx_cell1_size,
-                approx_cell2_size=approx_cellran_size)
+                approx_cell2_size=approx_cellran_size,
+            )
             D1R = np.diff(np.diff(D1R, axis=0), axis=1)
         else:
             D1R = None
@@ -305,10 +423,16 @@ def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
             D2R = None
         else:
             if do_DR is True:
-                D2R = npairs_xy_z(sample2, randoms, rp_bins, pi_bins,
-                    period=period, num_threads=num_threads,
+                D2R = npairs_xy_z(
+                    sample2,
+                    randoms,
+                    rp_bins,
+                    pi_bins,
+                    period=period,
+                    num_threads=num_threads,
                     approx_cell1_size=approx_cell2_size,
-                    approx_cell2_size=approx_cellran_size)
+                    approx_cell2_size=approx_cellran_size,
+                )
                 D2R = np.diff(np.diff(D2R, axis=0), axis=1)
             else:
                 D2R = None
@@ -321,37 +445,51 @@ def random_counts(sample1, sample2, randoms, rp_bins, pi_bins, period,
         NR = len(sample1)
 
         # do volume calculations
-        v = cylinder_volume(rp_bins, 2.0*pi_bins)  # volume of spheres
+        v = cylinder_volume(rp_bins, 2.0 * pi_bins)  # volume of spheres
         dv = np.diff(np.diff(v, axis=0), axis=1)  # volume of annuli
         global_volume = period.prod()
 
         # calculate randoms for sample1
         N1 = np.shape(sample1)[0]
-        rho1 = N1/global_volume
-        D1R = (N1)*(dv*rho1)  # read note about pair counter
+        rho1 = N1 / global_volume
+        D1R = (N1) * (dv * rho1)  # read note about pair counter
 
         # calculate randoms for sample2
         N2 = np.shape(sample2)[0]
-        rho2 = N2/global_volume
-        D2R = N2*(dv*rho2)  # read note about pair counter
+        rho2 = N2 / global_volume
+        D2R = N2 * (dv * rho2)  # read note about pair counter
 
         # calculate the random-random pairs.
-        rhor = NR**2/global_volume
-        RR = (dv*rhor)  # RR is only the RR for the cross-correlation.
+        rhor = NR**2 / global_volume
+        RR = dv * rhor  # RR is only the RR for the cross-correlation.
 
         return D1R, D2R, RR
 
 
-def _rp_pi_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
-        period, do_auto, do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
+def _rp_pi_tpcf_process_args(
+    sample1,
+    rp_bins,
+    pi_bins,
+    sample2,
+    randoms,
+    period,
+    do_auto,
+    do_cross,
+    estimator,
+    num_threads,
+    approx_cell1_size,
+    approx_cell2_size,
+    approx_cellran_size,
+    seed,
+):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.redshift_space_tpcf`.
     """
     sample1 = enforce_sample_has_correct_shape(sample1)
     sample2, _sample1_is_sample2, do_cross = process_optional_input_sample2(
-        sample1, sample2, do_cross)
+        sample1, sample2, do_cross
+    )
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
@@ -381,5 +519,16 @@ def _rp_pi_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
 
     verify_tpcf_estimator(estimator)
 
-    return sample1, rp_bins, pi_bins, sample2, randoms, period,\
-        do_auto, do_cross, num_threads, _sample1_is_sample2, PBCs
+    return (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    )

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf_jackknife.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
+from .tpcf_estimators import _TP_estimator_crossx
 from .rp_pi_tpcf import _rp_pi_tpcf_process_args
 from .tpcf_jackknife import get_subvolume_numbers, _enclose_in_box
 
@@ -394,8 +395,8 @@ def rp_pi_tpcf_jackknife(
             D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator
         )
     if do_cross is True:
-        xi_12_full = _TP_estimator(
-            D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator
+        xi_12_full = _TP_estimator_crossx(
+            D1D2_full, D1R_full, D2R_full, RR_full, N1, N2, NR, NR, estimator
         )
 
     # calculate the correlation function for the subsamples
@@ -407,8 +408,16 @@ def rp_pi_tpcf_jackknife(
             D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator
         )
     if do_cross is True:
-        xi_12_sub = _TP_estimator(
-            D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator
+        xi_12_sub = _TP_estimator_crossx(
+            D1D2_sub,
+            D1R_sub,
+            D2R_sub,
+            RR_sub,
+            N1_subs,
+            N2_subs,
+            NR_subs,
+            NR_subs,
+            estimator,
         )
 
     # calculate the covariance matrix

--- a/halotools/mock_observables/two_point_clustering/rp_pi_tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/rp_pi_tpcf_jackknife.py
@@ -12,26 +12,44 @@ from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
 from .rp_pi_tpcf import _rp_pi_tpcf_process_args
 from .tpcf_jackknife import get_subvolume_numbers, _enclose_in_box
 
-from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
-from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
-    get_separation_bins_array, get_line_of_sight_bins_array, get_period, get_num_threads)
+from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
+from ..mock_observables_helpers import (
+    enforce_sample_has_correct_shape,
+    get_separation_bins_array,
+    get_line_of_sight_bins_array,
+    get_period,
+    get_num_threads,
+)
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
 from ..pair_counters import npairs_jackknife_xy_z
 
 from ..catalog_analysis_helpers import cuboid_subvolume_labels
 
 
-__all__ = ('rp_pi_tpcf_jackknife', )
-__author__ = ('Duncan Campbell', 'Andrew Hearin')
+__all__ = ("rp_pi_tpcf_jackknife",)
+__author__ = ("Duncan Campbell", "Andrew Hearin")
 
 
-np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD/RR
+np.seterr(divide="ignore", invalid="ignore")  # ignore divide by zero in e.g. DD/RR
 
 
-def rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins, Nsub=[5, 5, 5],
-        sample2=None, period=None, do_auto=True, do_cross=True,
-        estimator='Natural', num_threads=1, seed=None,
-        approx_cell1_size=None, approx_cell2_size=None, approx_cellran_size=None):
+def rp_pi_tpcf_jackknife(
+    sample1,
+    randoms,
+    rp_bins,
+    pi_bins,
+    Nsub=[5, 5, 5],
+    sample2=None,
+    period=None,
+    do_auto=True,
+    do_cross=True,
+    estimator="Natural",
+    num_threads=1,
+    seed=None,
+    approx_cell1_size=None,
+    approx_cell2_size=None,
+    approx_cellran_size=None,
+):
     r"""
     redshift space correlation function, :math:`\xi(r_{p}, \pi)` and the covariance
     matrix, :math:`{C}_{ij}`, between ith and jth bin.
@@ -233,11 +251,35 @@ def rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins, Nsub=[5, 5, 5],
     """
 
     # process input parameters
-    function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
-        do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
-    sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
-        _sample1_is_sample2, PBCs = _rp_pi_tpcf_jackknife_process_args(*function_args)
+    function_args = (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        estimator,
+        num_threads,
+        approx_cell1_size,
+        approx_cell2_size,
+        approx_cellran_size,
+        seed,
+    )
+    (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    ) = _rp_pi_tpcf_jackknife_process_args(*function_args)
 
     # determine box size the data occupies.
     # This is used in determining jackknife samples.
@@ -267,29 +309,62 @@ def rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins, Nsub=[5, 5, 5],
 
     # calculate all the pair counts
     D1D1, D1D2, D2D2 = jnpair_counts(
-        sample1, sample2, j_index_1, j_index_2, N_sub_vol,
-        rp_bins, pi_bins, period, num_threads, do_auto, do_cross, _sample1_is_sample2)
+        sample1,
+        sample2,
+        j_index_1,
+        j_index_2,
+        N_sub_vol,
+        rp_bins,
+        pi_bins,
+        period,
+        num_threads,
+        do_auto,
+        do_cross,
+        _sample1_is_sample2,
+    )
 
     # pull out the full and sub sample results
-    if (do_auto is True):
+    if do_auto is True:
         D1D1_full = D1D1[0, :, :]
         D1D1_sub = D1D1[1:, :, :]
         D2D2_full = D2D2[0, :, :]
         D2D2_sub = D2D2[1:, :, :]
-    if (do_cross is True):
+    if do_cross is True:
         D1D2_full = D1D2[0, :, :]
         D1D2_sub = D1D2[1:, :, :]
 
     # do random counts
-    D1R, RR = jrandom_counts(sample1, randoms, j_index_1, j_index_random, N_sub_vol,
-        rp_bins, pi_bins, period, num_threads, do_DR, do_RR)
+    D1R, RR = jrandom_counts(
+        sample1,
+        randoms,
+        j_index_1,
+        j_index_random,
+        N_sub_vol,
+        rp_bins,
+        pi_bins,
+        period,
+        num_threads,
+        do_DR,
+        do_RR,
+    )
 
     if _sample1_is_sample2:
         D2R = D1R
     else:
         if do_DR is True:
-            D2R, RR_dummy = jrandom_counts(sample2, randoms, j_index_2, j_index_random,
-                N_sub_vol, rp_bins, pi_bins, period, num_threads, do_DR, do_RR=False)
+            D2R, RR_dummy = jrandom_counts(
+                sample2,
+                randoms,
+                j_index_2,
+                j_index_random,
+                N_sub_vol,
+                rp_bins,
+                pi_bins,
+                period,
+                num_threads,
+                do_DR,
+                do_RR=False,
+            )
         else:
             D2R = None
 
@@ -311,32 +386,50 @@ def rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins, Nsub=[5, 5, 5],
         RR_sub = None
 
     # calculate the correlation function for the full sample
-    if (do_auto is True):
-        xi_11_full = _TP_estimator(D1D1_full, D1R_full, RR_full, N1, N1, NR, NR, estimator)
-        xi_22_full = _TP_estimator(D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator)
-    if (do_cross is True):
-        xi_12_full = _TP_estimator(D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator)
+    if do_auto is True:
+        xi_11_full = _TP_estimator(
+            D1D1_full, D1R_full, RR_full, N1, N1, NR, NR, estimator
+        )
+        xi_22_full = _TP_estimator(
+            D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator
+        )
+    if do_cross is True:
+        xi_12_full = _TP_estimator(
+            D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator
+        )
 
     # calculate the correlation function for the subsamples
-    if (do_auto is True):
-        xi_11_sub = _TP_estimator(D1D1_sub, D1R_sub, RR_sub, N1_subs, N1_subs, NR_subs, NR_subs, estimator)
-        xi_22_sub = _TP_estimator(D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator)
-    if (do_cross is True):
-        xi_12_sub = _TP_estimator(D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator)
+    if do_auto is True:
+        xi_11_sub = _TP_estimator(
+            D1D1_sub, D1R_sub, RR_sub, N1_subs, N1_subs, NR_subs, NR_subs, estimator
+        )
+        xi_22_sub = _TP_estimator(
+            D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator
+        )
+    if do_cross is True:
+        xi_12_sub = _TP_estimator(
+            D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator
+        )
 
     # calculate the covariance matrix
     # format correlation functions into 1-D vector
-    if (do_auto is True):
-        xi_11_sub_flat = np.reshape(xi_11_sub, (N_sub_vol, (len(rp_bins)-1)*(len(pi_bins)-1)))
-        xi_22_sub_flat = np.reshape(xi_22_sub, (N_sub_vol, (len(rp_bins)-1)*(len(pi_bins)-1)))
-    if (do_cross is True):
-        xi_12_sub_flat = np.reshape(xi_12_sub, (N_sub_vol, (len(rp_bins)-1)*(len(pi_bins)-1)))
+    if do_auto is True:
+        xi_11_sub_flat = np.reshape(
+            xi_11_sub, (N_sub_vol, (len(rp_bins) - 1) * (len(pi_bins) - 1))
+        )
+        xi_22_sub_flat = np.reshape(
+            xi_22_sub, (N_sub_vol, (len(rp_bins) - 1) * (len(pi_bins) - 1))
+        )
+    if do_cross is True:
+        xi_12_sub_flat = np.reshape(
+            xi_12_sub, (N_sub_vol, (len(rp_bins) - 1) * (len(pi_bins) - 1))
+        )
 
-    if (do_auto is True):
-        xi_11_cov = np.array(np.cov(xi_11_sub_flat.T, bias=True))*(N_sub_vol-1)
-        xi_22_cov = np.array(np.cov(xi_22_sub_flat.T, bias=True))*(N_sub_vol-1)
-    if (do_cross is True):
-        xi_12_cov = np.array(np.cov(xi_12_sub_flat.T, bias=True))*(N_sub_vol-1)
+    if do_auto is True:
+        xi_11_cov = np.array(np.cov(xi_11_sub_flat.T, bias=True)) * (N_sub_vol - 1)
+        xi_22_cov = np.array(np.cov(xi_22_sub_flat.T, bias=True)) * (N_sub_vol - 1)
+    if do_cross is True:
+        xi_12_cov = np.array(np.cov(xi_12_sub_flat.T, bias=True)) * (N_sub_vol - 1)
 
     if _sample1_is_sample2:
         return xi_11_full, xi_11_cov
@@ -349,15 +442,35 @@ def rp_pi_tpcf_jackknife(sample1, randoms, rp_bins, pi_bins, Nsub=[5, 5, 5],
             return xi_12_full, xi_12_cov
 
 
-def jnpair_counts(sample1, sample2, j_index_1, j_index_2, N_sub_vol, rp_bins, pi_bins,
-        period, num_threads, do_auto, do_cross, _sample1_is_sample2):
+def jnpair_counts(
+    sample1,
+    sample2,
+    j_index_1,
+    j_index_2,
+    N_sub_vol,
+    rp_bins,
+    pi_bins,
+    period,
+    num_threads,
+    do_auto,
+    do_cross,
+    _sample1_is_sample2,
+):
     """
     Count jackknife data pairs: DD
     """
     if do_auto is True:
-        D1D1 = npairs_jackknife_xy_z(sample1, sample1, rp_bins, pi_bins, period=period,
-            jtags1=j_index_1, jtags2=j_index_1,  N_samples=N_sub_vol,
-            num_threads=num_threads)
+        D1D1 = npairs_jackknife_xy_z(
+            sample1,
+            sample1,
+            rp_bins,
+            pi_bins,
+            period=period,
+            jtags1=j_index_1,
+            jtags2=j_index_1,
+            N_samples=N_sub_vol,
+            num_threads=num_threads,
+        )
         D1D1 = np.diff(np.diff(D1D1, axis=1), axis=2)
     else:
         D1D1 = None
@@ -368,38 +481,81 @@ def jnpair_counts(sample1, sample2, j_index_1, j_index_2, N_sub_vol, rp_bins, pi
         D2D2 = D1D1
     else:
         if do_cross is True:
-            D1D2 = npairs_jackknife_xy_z(sample1, sample2, rp_bins, pi_bins, period=period,
-                jtags1=j_index_1, jtags2=j_index_2,
-                N_samples=N_sub_vol, num_threads=num_threads)
+            D1D2 = npairs_jackknife_xy_z(
+                sample1,
+                sample2,
+                rp_bins,
+                pi_bins,
+                period=period,
+                jtags1=j_index_1,
+                jtags2=j_index_2,
+                N_samples=N_sub_vol,
+                num_threads=num_threads,
+            )
             D1D2 = np.diff(np.diff(D1D2, axis=1), axis=2)
         else:
             D1D2 = None
         if do_auto is True:
-            D2D2 = npairs_jackknife_xy_z(sample2, sample2, rp_bins, pi_bins, period=period,
-                jtags1=j_index_2, jtags2=j_index_2,
-                N_samples=N_sub_vol, num_threads=num_threads)
+            D2D2 = npairs_jackknife_xy_z(
+                sample2,
+                sample2,
+                rp_bins,
+                pi_bins,
+                period=period,
+                jtags1=j_index_2,
+                jtags2=j_index_2,
+                N_samples=N_sub_vol,
+                num_threads=num_threads,
+            )
             D2D2 = np.diff(np.diff(D2D2, axis=1), axis=2)
 
     return D1D1, D1D2, D2D2
 
 
-def jrandom_counts(sample, randoms, j_index, j_index_randoms, N_sub_vol, rp_bins, pi_bins,
-        period, num_threads, do_DR, do_RR):
+def jrandom_counts(
+    sample,
+    randoms,
+    j_index,
+    j_index_randoms,
+    N_sub_vol,
+    rp_bins,
+    pi_bins,
+    period,
+    num_threads,
+    do_DR,
+    do_RR,
+):
     """
     Count jackknife random pairs: DR, RR
     """
 
     if do_DR is True:
-        DR = npairs_jackknife_xy_z(sample, randoms, rp_bins, pi_bins, period=period,
-            jtags1=j_index, jtags2=j_index_randoms,
-            N_samples=N_sub_vol, num_threads=num_threads)
+        DR = npairs_jackknife_xy_z(
+            sample,
+            randoms,
+            rp_bins,
+            pi_bins,
+            period=period,
+            jtags1=j_index,
+            jtags2=j_index_randoms,
+            N_samples=N_sub_vol,
+            num_threads=num_threads,
+        )
         DR = np.diff(np.diff(DR, axis=1), axis=2)
     else:
         DR = None
     if do_RR is True:
-        RR = npairs_jackknife_xy_z(randoms, randoms, rp_bins, pi_bins, period=period,
-            jtags1=j_index_randoms, jtags2=j_index_randoms,
-            N_samples=N_sub_vol, num_threads=num_threads)
+        RR = npairs_jackknife_xy_z(
+            randoms,
+            randoms,
+            rp_bins,
+            pi_bins,
+            period=period,
+            jtags1=j_index_randoms,
+            jtags2=j_index_randoms,
+            N_samples=N_sub_vol,
+            num_threads=num_threads,
+        )
         RR = np.diff(np.diff(RR, axis=1), axis=2)
     else:
         RR = None
@@ -407,16 +563,30 @@ def jrandom_counts(sample, randoms, j_index, j_index_randoms, N_sub_vol, rp_bins
     return DR, RR
 
 
-def _rp_pi_tpcf_jackknife_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
-        period, do_auto, do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
+def _rp_pi_tpcf_jackknife_process_args(
+    sample1,
+    rp_bins,
+    pi_bins,
+    sample2,
+    randoms,
+    period,
+    do_auto,
+    do_cross,
+    estimator,
+    num_threads,
+    approx_cell1_size,
+    approx_cell2_size,
+    approx_cellran_size,
+    seed,
+):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.redshift_space_tpcf`.
     """
     sample1 = enforce_sample_has_correct_shape(sample1)
     sample2, _sample1_is_sample2, do_cross = process_optional_input_sample2(
-        sample1, sample2, do_cross)
+        sample1, sample2, do_cross
+    )
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
@@ -434,11 +604,13 @@ def _rp_pi_tpcf_jackknife_process_args(sample1, rp_bins, pi_bins, sample2, rando
         N_randoms = randoms[0]
         if PBCs is True:
             with NumpyRNGContext(seed):
-                randoms = np.random.random((N_randoms, 3))*period
+                randoms = np.random.random((N_randoms, 3)) * period
         else:
-            msg = ("\n When no `period` parameter is passed, \n"
-                   "the user must provide true randoms, and \n"
-                   "not just the number of randoms desired.")
+            msg = (
+                "\n When no `period` parameter is passed, \n"
+                "the user must provide true randoms, and \n"
+                "not just the number of randoms desired."
+            )
             raise KeyError(msg)
 
     _enforce_maximum_search_length([rp_max, rp_max, pi_max], period)
@@ -458,5 +630,16 @@ def _rp_pi_tpcf_jackknife_process_args(sample1, rp_bins, pi_bins, sample2, rando
 
     verify_tpcf_estimator(estimator)
 
-    return sample1, rp_bins, pi_bins, sample2, randoms, period,\
-        do_auto, do_cross, num_threads, _sample1_is_sample2, PBCs
+    return (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    )

--- a/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/s_mu_tpcf.py
@@ -21,6 +21,7 @@ from ..mock_observables_helpers import (
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
 
 from .tpcf_estimators import _TP_estimator_requirements, _TP_estimator
+from .tpcf_estimators import _TP_estimator_crossx
 from ..pair_counters import npairs_s_mu
 
 __all__ = ["s_mu_tpcf"]
@@ -303,11 +304,15 @@ def s_mu_tpcf(
     else:
         if (do_auto is True) & (do_cross is True):
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)[:, ::-1]
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)[:, ::-1]
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)[
+                :, ::-1
+            ]
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)[:, ::-1]
             return xi_11, xi_12, xi_22
         elif do_cross is True:
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)[:, ::-1]
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)[
+                :, ::-1
+            ]
             return xi_12
         elif do_auto is True:
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)[:, ::-1]

--- a/halotools/mock_observables/two_point_clustering/tests/test_tpcf_estimators.py
+++ b/halotools/mock_observables/two_point_clustering/tests/test_tpcf_estimators.py
@@ -5,10 +5,14 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import numpy as np
 
-from ..tpcf_estimators import _test_for_zero_division, _list_estimators, _TP_estimator_requirements
+from ..tpcf_estimators import (
+    _test_for_zero_division,
+    _list_estimators,
+    _TP_estimator_requirements,
+)
 from ....custom_exceptions import HalotoolsError
 
-__all__ = ('test_zero_division1', )
+__all__ = ("test_zero_division1",)
 
 
 def test_zero_division1():
@@ -29,8 +33,8 @@ def test_zero_division2():
     RR = np.arange(nbins) + 10
     ND1, ND2, NR1, NR2 = 100, 100, 100, 100
 
-    RR[0] = 0.
-    DR[0] = 0.
+    RR[0] = 0.0
+    DR[0] = 0.0
     for estimator in _list_estimators():
         with pytest.raises(ValueError) as err:
             _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator)
@@ -39,22 +43,22 @@ def test_zero_division2():
 
 
 def test_TP_estimator_requirements_davis_peebles():
-    do_DD, do_DR, do_RR = _TP_estimator_requirements('Davis-Peebles')
+    do_DD, do_DR, do_RR = _TP_estimator_requirements("Davis-Peebles")
     assert np.all((do_DD, do_DR, do_RR) == (True, True, False))
 
 
 def test_TP_estimator_requirements_hewett():
-    do_DD, do_DR, do_RR = _TP_estimator_requirements('Hewett')
+    do_DD, do_DR, do_RR = _TP_estimator_requirements("Hewett")
     assert np.all((do_DD, do_DR, do_RR) == (True, True, True))
 
 
 def test_TP_estimator_requirements_hamilton():
-    do_DD, do_DR, do_RR = _TP_estimator_requirements('Hamilton')
+    do_DD, do_DR, do_RR = _TP_estimator_requirements("Hamilton")
     assert np.all((do_DD, do_DR, do_RR) == (True, True, True))
 
 
 def test_TP_estimator_requirements_bad_estimator():
     with pytest.raises(HalotoolsError) as err:
-        __ = _TP_estimator_requirements('Ron Perlman')
+        __ = _TP_estimator_requirements("Ron Perlman")
     substr = "Input `estimator` must be one of the following"
     assert substr in err.value.args[0]

--- a/halotools/mock_observables/two_point_clustering/tpcf.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf.py
@@ -14,6 +14,7 @@ from .clustering_helpers import (
     tpcf_estimator_dd_dr_rr_requirements,
 )
 from .tpcf_estimators import _TP_estimator
+from .tpcf_estimators import _TP_estimator_crossx
 
 from ..mock_observables_helpers import (
     enforce_sample_has_correct_shape,
@@ -485,11 +486,11 @@ def tpcf(
     else:
         if (do_auto is True) & (do_cross is True):
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)
             xi_22 = _TP_estimator(D2D2, D2R, RR, N2, N2, NR, NR, estimator)
             return xi_11, xi_12, xi_22
         elif do_cross is True:
-            xi_12 = _TP_estimator(D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            xi_12 = _TP_estimator_crossx(D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator)
             return xi_12
         elif do_auto is True:
             xi_11 = _TP_estimator(D1D1, D1R, RR, N1, N1, NR, NR, estimator)

--- a/halotools/mock_observables/two_point_clustering/tpcf_estimators.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_estimators.py
@@ -7,8 +7,8 @@ import numpy as np
 
 from ...custom_exceptions import HalotoolsError
 
-__all__ = ['_TP_estimator', '_list_estimators', '_TP_estimator_requirements']
-__author__ = ['Duncan Campbell']
+__all__ = ["_TP_estimator", "_list_estimators", "_TP_estimator_requirements"]
+__author__ = ["Duncan Campbell"]
 
 
 def _TP_estimator(DD, DR, RR, ND1, ND2, NR1, NR2, estimator):
@@ -28,34 +28,36 @@ def _TP_estimator(DD, DR, RR, ND1, ND2, NR1, NR2, estimator):
         # the N arrays are the number of points in each dimension.
         # so, what we want to do is multiple each row of e.g. DD by the number of 1/N
         def mult(x, y):
-            return (x*y.T).T
+            return (x * y.T).T
+
     else:
+
         def mult(x, y):
-            return x*y
+            return x * y
 
     _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator)
 
-    if estimator == 'Natural':
-        factor = ND1*ND2/(NR1*NR2)
+    if estimator == "Natural":
+        factor = ND1 * ND2 / (NR1 * NR2)
         # DD/RR-1
-        xi = mult(1.0/factor, DD/RR) - 1.0
-    elif estimator == 'Davis-Peebles':
-        factor = ND1*ND2/(ND1*NR2)
+        xi = mult(1.0 / factor, DD / RR) - 1.0
+    elif estimator == "Davis-Peebles":
+        factor = ND1 * ND2 / (ND1 * NR2)
         # DD/DR-1
-        xi = mult(1.0/factor, DD/DR) - 1.0
-    elif estimator == 'Hewett':
-        factor1 = ND1*ND2/(NR1*NR2)
-        factor2 = ND1*NR2/(NR1*NR2)
+        xi = mult(1.0 / factor, DD / DR) - 1.0
+    elif estimator == "Hewett":
+        factor1 = ND1 * ND2 / (NR1 * NR2)
+        factor2 = ND1 * NR2 / (NR1 * NR2)
         # (DD-DR)/RR
-        xi = mult(1.0/factor1, DD/RR) - mult(1.0/factor2, DR/RR)
-    elif estimator == 'Hamilton':
+        xi = mult(1.0 / factor1, DD / RR) - mult(1.0 / factor2, DR / RR)
+    elif estimator == "Hamilton":
         # DDRR/DRDR-1
-        xi = (DD*RR)/(DR*DR) - 1.0
-    elif estimator == 'Landy-Szalay':
-        factor1 = ND1*ND2/(NR1*NR2)
-        factor2 = ND1*NR2/(NR1*NR2)
+        xi = (DD * RR) / (DR * DR) - 1.0
+    elif estimator == "Landy-Szalay":
+        factor1 = ND1 * ND2 / (NR1 * NR2)
+        factor2 = ND1 * NR2 / (NR1 * NR2)
         # (DD - 2.0*DR + RR)/RR
-        xi = mult(1.0/factor1, DD/RR) - mult(1.0/factor2, 2.0*DR/RR) + 1.0
+        xi = mult(1.0 / factor1, DD / RR) - mult(1.0 / factor2, 2.0 * DR / RR) + 1.0
     else:
         raise ValueError("unsupported estimator!")
 
@@ -69,7 +71,7 @@ def _list_estimators():
     """
     list available tpcf estimators.
     """
-    estimators = ['Natural', 'Davis-Peebles', 'Hewett', 'Hamilton', 'Landy-Szalay']
+    estimators = ["Natural", "Davis-Peebles", "Hewett", "Hamilton", "Landy-Szalay"]
     return estimators
 
 
@@ -77,49 +79,53 @@ def _TP_estimator_requirements(estimator):
     """
     return booleans indicating which pairs need to be counted for the chosen estimator
     """
-    if estimator == 'Natural':
+    if estimator == "Natural":
         do_DD = True
         do_DR = False
         do_RR = True
-    elif estimator == 'Davis-Peebles':
+    elif estimator == "Davis-Peebles":
         do_DD = True
         do_DR = True
         do_RR = False
-    elif estimator == 'Hewett':
+    elif estimator == "Hewett":
         do_DD = True
         do_DR = True
         do_RR = True
-    elif estimator == 'Hamilton':
+    elif estimator == "Hamilton":
         do_DD = True
         do_DR = True
         do_RR = True
-    elif estimator == 'Landy-Szalay':
+    elif estimator == "Landy-Szalay":
         do_DD = True
         do_DR = True
         do_RR = True
     else:
         available_estimators = _list_estimators()
         if estimator not in available_estimators:
-            msg = ("Input `estimator` must be one of the following:{0}".format(available_estimators))
+            msg = "Input `estimator` must be one of the following:{0}".format(
+                available_estimators
+            )
             raise HalotoolsError(msg)
 
     return do_DD, do_DR, do_RR
 
 
 def _test_for_zero_division(DD, DR, RR, ND1, ND2, NR1, NR2, estimator):
-    zero_msg = ("When calculating the two-point function, there was at least one \n"
+    zero_msg = (
+        "When calculating the two-point function, there was at least one \n"
         "separation bin with zero {0} pairs. Since the ``{1}`` estimator you chose \n"
         "divides by {0}, you will have at least one NaN returned value.\n"
         "Most likely, the innermost separation bin is the problem.\n"
         "Try increasing the number of randoms and/or using broader bins.\n"
         "To estimate the number of required randoms, the following expression \n"
         "for the expected number of pairs inside a sphere of radius ``r`` may be useful:\n\n"
-        "<Npairs> = (Nran_tot)*(4pi/3)*(r/Lbox)^3 \n\n")
+        "<Npairs> = (Nran_tot)*(4pi/3)*(r/Lbox)^3 \n\n"
+    )
 
-    estimators_dividing_by_rr = ('Natural', 'Davis-Peebles', 'Hewett', 'Landy-Szalay')
+    estimators_dividing_by_rr = ("Natural", "Davis-Peebles", "Hewett", "Landy-Szalay")
     if (estimator in estimators_dividing_by_rr) & (np.any(RR == 0)):
-        raise ValueError(zero_msg.format('RR', estimator))
+        raise ValueError(zero_msg.format("RR", estimator))
 
-    estimators_dividing_by_dr = ('Hamilton', )
+    estimators_dividing_by_dr = ("Hamilton",)
     if (estimator in estimators_dividing_by_dr) & (np.any(DR == 0)):
-        raise ValueError(zero_msg.format('DR', estimator))
+        raise ValueError(zero_msg.format("DR", estimator))

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
+from .tpcf_estimators import _TP_estimator_crossx
 from ..pair_counters import npairs_jackknife_3d
 
 from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
@@ -356,8 +357,8 @@ def tpcf_jackknife(
             D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator
         )
     if do_cross is True:
-        xi_12_full = _TP_estimator(
-            D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator
+        xi_12_full = _TP_estimator_crossx(
+            D1D2_full, D1R_full, D2R_full, RR_full, N1, N2, NR, NR, estimator
         )
 
     # calculate the correlation function for the subsamples
@@ -369,8 +370,16 @@ def tpcf_jackknife(
             D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator
         )
     if do_cross is True:
-        xi_12_sub = _TP_estimator(
-            D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator
+        xi_12_sub = _TP_estimator_crossx(
+            D1D2_sub,
+            D1R_sub,
+            D2R_sub,
+            RR_sub,
+            N1_subs,
+            N2_subs,
+            NR_subs,
+            NR_subs,
+            estimator,
         )
 
     # calculate the covariance matrix

--- a/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_jackknife.py
@@ -75,7 +75,8 @@ def tpcf_jackknife(
     Nsub : array_like, optional
         Lenght-3 numpy array of number of divisions along each dimension defining
         jackknife sample subvolumes.  If single integer is given, it is assumed to be
-        equivalent for each dimension.  The total number of samples used is then given by
+        equivalent for each dimension.
+        The total number of samples used is then given by
         *numpy.prod(Nsub)*. Default is 5 divisions per dimension.
 
     sample2 : array_like, optional

--- a/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
@@ -9,10 +9,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import numpy as np
 from math import gamma
 
-from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
+from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
 
-from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
-    get_separation_bins_array, get_period, get_num_threads)
+from ..mock_observables_helpers import (
+    enforce_sample_has_correct_shape,
+    get_separation_bins_array,
+    get_period,
+    get_num_threads,
+)
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
 
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
@@ -21,19 +25,30 @@ from ..pair_counters import marked_npairs_3d
 
 from ...custom_exceptions import HalotoolsError
 
-__all__ = ['tpcf_one_two_halo_decomp']
-__author__ = ['Duncan Campbell']
+__all__ = ["tpcf_one_two_halo_decomp"]
+__author__ = ["Duncan Campbell"]
 
 
-np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD/RR
+np.seterr(divide="ignore", invalid="ignore")  # ignore divide by zero in e.g. DD/RR
 
 
-def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
-        sample2=None, sample2_host_halo_id=None,
-        randoms=None, period=None,
-        do_auto=True, do_cross=True, estimator='Natural', num_threads=1,
-        approx_cell1_size=None, approx_cell2_size=None,
-        approx_cellran_size=None, seed=None):
+def tpcf_one_two_halo_decomp(
+    sample1,
+    sample1_host_halo_id,
+    rbins,
+    sample2=None,
+    sample2_host_halo_id=None,
+    randoms=None,
+    period=None,
+    do_auto=True,
+    do_cross=True,
+    estimator="Natural",
+    num_threads=1,
+    approx_cell1_size=None,
+    approx_cell2_size=None,
+    approx_cellran_size=None,
+    seed=None,
+):
     r"""
     Calculate the real space one-halo and two-halo decomposed two-point correlation
     functions, :math:`\xi^{1h}(r)` and :math:`\xi^{2h}(r)`.
@@ -186,14 +201,39 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
     """
 
     # check input arguments using clustering helper functions
-    function_args = (sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id,
-        randoms, period, do_auto, do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
+    function_args = (
+        sample1,
+        sample1_host_halo_id,
+        rbins,
+        sample2,
+        sample2_host_halo_id,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        estimator,
+        num_threads,
+        approx_cell1_size,
+        approx_cell2_size,
+        approx_cellran_size,
+        seed,
+    )
 
     # pass arguments in, and get out processed arguments, plus some control flow variables
-    sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id, randoms, period,\
-        do_auto, do_cross, num_threads, _sample1_is_sample2, PBCs =\
-        _tpcf_one_two_halo_decomp_process_args(*function_args)
+    (
+        sample1,
+        sample1_host_halo_id,
+        rbins,
+        sample2,
+        sample2_host_halo_id,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    ) = _tpcf_one_two_halo_decomp_process_args(*function_args)
 
     # What needs to be done?
     do_DD, do_DR, do_RR = _TP_estimator_requirements(estimator)
@@ -211,46 +251,110 @@ def tpcf_one_two_halo_decomp(sample1, sample1_host_halo_id, rbins,
     # calculate 1-halo pairs
     weight_func_id = 3
     one_halo_D1D1, one_halo_D1D2, one_halo_D2D2 = marked_pair_counts(
-            sample1, sample2, rbins, period, num_threads,
-            do_auto, do_cross, sample1_host_halo_id,
-            sample2_host_halo_id, weight_func_id, _sample1_is_sample2)
+        sample1,
+        sample2,
+        rbins,
+        period,
+        num_threads,
+        do_auto,
+        do_cross,
+        sample1_host_halo_id,
+        sample2_host_halo_id,
+        weight_func_id,
+        _sample1_is_sample2,
+    )
 
     # calculate 2-halo pairs
     weight_func_id = 4
     two_halo_D1D1, two_halo_D1D2, two_halo_D2D2 = marked_pair_counts(
-            sample1, sample2, rbins, period, num_threads,
-            do_auto, do_cross, sample1_host_halo_id,
-            sample2_host_halo_id, weight_func_id, _sample1_is_sample2)
+        sample1,
+        sample2,
+        rbins,
+        period,
+        num_threads,
+        do_auto,
+        do_cross,
+        sample1_host_halo_id,
+        sample2_host_halo_id,
+        weight_func_id,
+        _sample1_is_sample2,
+    )
 
     # count random pairs
-    D1R, D2R, RR = random_counts(sample1, sample2, randoms, rbins, period,
-                                 PBCs, num_threads, do_RR, do_DR, _sample1_is_sample2,
-                                 approx_cell1_size, approx_cell2_size, approx_cellran_size)
+    D1R, D2R, RR = random_counts(
+        sample1,
+        sample2,
+        randoms,
+        rbins,
+        period,
+        PBCs,
+        num_threads,
+        do_RR,
+        do_DR,
+        _sample1_is_sample2,
+        approx_cell1_size,
+        approx_cell2_size,
+        approx_cellran_size,
+    )
 
     # run results through the estimator and return relavent/user specified results.
     if _sample1_is_sample2:
-        one_halo_xi_11 = _TP_estimator(one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-        two_halo_xi_11 = _TP_estimator(two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator)
+        one_halo_xi_11 = _TP_estimator(
+            one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
+        )
+        two_halo_xi_11 = _TP_estimator(
+            two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
+        )
         return one_halo_xi_11, two_halo_xi_11
     else:
         if (do_auto is True) & (do_cross is True):
-            one_halo_xi_11 = _TP_estimator(one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            one_halo_xi_12 = _TP_estimator(one_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator)
-            one_halo_xi_22 = _TP_estimator(one_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator)
-            two_halo_xi_11 = _TP_estimator(two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            two_halo_xi_12 = _TP_estimator(two_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator)
-            two_halo_xi_22 = _TP_estimator(two_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator)
-            return one_halo_xi_11, two_halo_xi_11, one_halo_xi_12,\
-                two_halo_xi_12, one_halo_xi_22, two_halo_xi_22
-        elif (do_cross is True):
-            one_halo_xi_12 = _TP_estimator(one_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator)
-            two_halo_xi_12 = _TP_estimator(two_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator)
+            one_halo_xi_11 = _TP_estimator(
+                one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
+            )
+            one_halo_xi_12 = _TP_estimator(
+                one_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            )
+            one_halo_xi_22 = _TP_estimator(
+                one_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator
+            )
+            two_halo_xi_11 = _TP_estimator(
+                two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
+            )
+            two_halo_xi_12 = _TP_estimator(
+                two_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            )
+            two_halo_xi_22 = _TP_estimator(
+                two_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator
+            )
+            return (
+                one_halo_xi_11,
+                two_halo_xi_11,
+                one_halo_xi_12,
+                two_halo_xi_12,
+                one_halo_xi_22,
+                two_halo_xi_22,
+            )
+        elif do_cross is True:
+            one_halo_xi_12 = _TP_estimator(
+                one_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            )
+            two_halo_xi_12 = _TP_estimator(
+                two_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            )
             return one_halo_xi_12, two_halo_xi_12
-        elif (do_auto is True):
-            one_halo_xi_11 = _TP_estimator(one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            one_halo_xi_22 = _TP_estimator(one_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator)
-            two_halo_xi_11 = _TP_estimator(two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator)
-            two_halo_xi_22 = _TP_estimator(two_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator)
+        elif do_auto is True:
+            one_halo_xi_11 = _TP_estimator(
+                one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
+            )
+            one_halo_xi_22 = _TP_estimator(
+                one_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator
+            )
+            two_halo_xi_11 = _TP_estimator(
+                two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
+            )
+            two_halo_xi_22 = _TP_estimator(
+                two_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator
+            )
             return one_halo_xi_11, two_halo_xi_11, one_halo_xi_22, two_halo_xi_22
 
 
@@ -259,12 +363,24 @@ def nball_volume(R, k=3):
     Calculate the volume of a n-shpere.
     This is used for the analytical randoms.
     """
-    return (np.pi**(k/2.0)/gamma(k/2.0+1.0))*R**k
+    return (np.pi ** (k / 2.0) / gamma(k / 2.0 + 1.0)) * R**k
 
 
-def random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
-        do_RR, do_DR, _sample1_is_sample2, approx_cell1_size,
-        approx_cell2_size, approx_cellran_size):
+def random_counts(
+    sample1,
+    sample2,
+    randoms,
+    rbins,
+    period,
+    PBCs,
+    num_threads,
+    do_RR,
+    do_DR,
+    _sample1_is_sample2,
+    approx_cell1_size,
+    approx_cell2_size,
+    approx_cellran_size,
+):
     r"""
     Count random pairs.  There are two high level branches:
         1. w/ or wo/ PBCs and randoms.
@@ -279,19 +395,28 @@ def random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
     # randoms provided, so calculate random pair counts.
     if randoms is not None:
         if do_RR is True:
-            RR = npairs_3d(randoms, randoms, rbins, period=period,
-                        num_threads=num_threads,
-                        approx_cell1_size=approx_cellran_size,
-                        approx_cell2_size=approx_cellran_size)
+            RR = npairs_3d(
+                randoms,
+                randoms,
+                rbins,
+                period=period,
+                num_threads=num_threads,
+                approx_cell1_size=approx_cellran_size,
+                approx_cell2_size=approx_cellran_size,
+            )
             RR = np.diff(RR)
         else:
             RR = None
         if do_DR is True:
-            D1R = npairs_3d(sample1, randoms, rbins, period=period,
-                         num_threads=num_threads,
-                         approx_cell1_size=approx_cell1_size,
-                         approx_cell2_size=approx_cellran_size
-                            )
+            D1R = npairs_3d(
+                sample1,
+                randoms,
+                rbins,
+                period=period,
+                num_threads=num_threads,
+                approx_cell1_size=approx_cell1_size,
+                approx_cell2_size=approx_cellran_size,
+            )
             D1R = np.diff(D1R)
         else:
             D1R = None
@@ -299,10 +424,15 @@ def random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
             D2R = None
         else:
             if do_DR is True:
-                D2R = npairs_3d(sample2, randoms, rbins, period=period,
-                             num_threads=num_threads,
-                             approx_cell1_size=approx_cell2_size,
-                             approx_cell2_size=approx_cellran_size)
+                D2R = npairs_3d(
+                    sample2,
+                    randoms,
+                    rbins,
+                    period=period,
+                    num_threads=num_threads,
+                    approx_cell1_size=approx_cell2_size,
+                    approx_cell2_size=approx_cellran_size,
+                )
                 D2R = np.diff(D2R)
             else:
                 D2R = None
@@ -320,23 +450,34 @@ def random_counts(sample1, sample2, randoms, rbins, period, PBCs, num_threads,
 
         # calculate randoms for sample1
         N1 = np.shape(sample1)[0]  # number of points in sample1
-        rho1 = N1/global_volume  # number density of points
-        D1R = (NR)*(dv*rho1)  # random counts are N**2*dv*rho
+        rho1 = N1 / global_volume  # number density of points
+        D1R = (NR) * (dv * rho1)  # random counts are N**2*dv*rho
 
         # calculate randoms for sample2
         N2 = np.shape(sample2)[0]  # number of points in sample2
-        rho2 = N2/global_volume  # number density of points
-        D2R = (NR)*(dv*rho2)  # random counts are N**2*dv*rho
+        rho2 = N2 / global_volume  # number density of points
+        D2R = (NR) * (dv * rho2)  # random counts are N**2*dv*rho
 
         # calculate the random-random pairs.
-        rhor = (NR**2)/global_volume
-        RR = (dv*rhor)
+        rhor = (NR**2) / global_volume
+        RR = dv * rhor
 
         return D1R, D2R, RR
 
 
-def marked_pair_counts(sample1, sample2, rbins, period, num_threads,
-        do_auto, do_cross, marks1, marks2, weight_func_id, _sample1_is_sample2):
+def marked_pair_counts(
+    sample1,
+    sample2,
+    rbins,
+    period,
+    num_threads,
+    do_auto,
+    do_cross,
+    marks1,
+    marks2,
+    weight_func_id,
+    _sample1_is_sample2,
+):
     """
     Count weighted data pairs.
     """
@@ -346,9 +487,16 @@ def marked_pair_counts(sample1, sample2, rbins, period, num_threads,
     marks2 = np.vstack((marks2, np.ones(len(marks2)))).T
 
     if do_auto is True:
-        D1D1 = marked_npairs_3d(sample1, sample1, rbins,
-            weights1=marks1, weights2=marks1,
-            weight_func_id=weight_func_id, period=period, num_threads=num_threads)
+        D1D1 = marked_npairs_3d(
+            sample1,
+            sample1,
+            rbins,
+            weights1=marks1,
+            weights2=marks1,
+            weight_func_id=weight_func_id,
+            period=period,
+            num_threads=num_threads,
+        )
         D1D1 = np.diff(D1D1)
     else:
         D1D1 = None
@@ -359,16 +507,30 @@ def marked_pair_counts(sample1, sample2, rbins, period, num_threads,
         D2D2 = D1D1
     else:
         if do_cross is True:
-            D1D2 = marked_npairs_3d(sample1, sample2, rbins,
-                weights1=marks1, weights2=marks2,
-                weight_func_id=weight_func_id, period=period, num_threads=num_threads)
+            D1D2 = marked_npairs_3d(
+                sample1,
+                sample2,
+                rbins,
+                weights1=marks1,
+                weights2=marks2,
+                weight_func_id=weight_func_id,
+                period=period,
+                num_threads=num_threads,
+            )
             D1D2 = np.diff(D1D2)
         else:
             D1D2 = None
         if do_auto is True:
-            D2D2 = marked_npairs_3d(sample2, sample2, rbins,
-                weights1=marks2, weights2=marks2,
-                weight_func_id=weight_func_id, period=period, num_threads=num_threads)
+            D2D2 = marked_npairs_3d(
+                sample2,
+                sample2,
+                rbins,
+                weights1=marks2,
+                weights2=marks2,
+                weight_func_id=weight_func_id,
+                period=period,
+                num_threads=num_threads,
+            )
             D2D2 = np.diff(D2D2)
         else:
             D2D2 = None
@@ -376,10 +538,23 @@ def marked_pair_counts(sample1, sample2, rbins, period, num_threads,
     return D1D1, D1D2, D2D2
 
 
-def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
-        sample2, sample2_host_halo_id, randoms,
-        period, do_auto, do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
+def _tpcf_one_two_halo_decomp_process_args(
+    sample1,
+    sample1_host_halo_id,
+    rbins,
+    sample2,
+    sample2_host_halo_id,
+    randoms,
+    period,
+    do_auto,
+    do_cross,
+    estimator,
+    num_threads,
+    approx_cell1_size,
+    approx_cell2_size,
+    approx_cellran_size,
+    seed,
+):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.tpcf_one_two_halo_decomp`.
@@ -389,12 +564,13 @@ def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
     sample1_host_halo_id = np.atleast_1d(sample1_host_halo_id).astype(np.int64)
 
     sample2, _sample1_is_sample2, do_cross = process_optional_input_sample2(
-        sample1, sample2, do_cross)
+        sample1, sample2, do_cross
+    )
     if _sample1_is_sample2 is True:
         sample2_host_halo_id = sample1_host_halo_id
     else:
         if sample2_host_halo_id is None:
-            msg = ("If passing an input ``sample2``, must also pass sample2_host_halo_id")
+            msg = "If passing an input ``sample2``, must also pass sample2_host_halo_id"
             raise ValueError(msg)
         else:
             sample2_host_halo_id = np.atleast_1d(sample2_host_halo_id).astype(np.int64)
@@ -404,12 +580,16 @@ def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
 
     # test to see if halo ids are the same length as samples
     if np.shape(sample1_host_halo_id) != (len(sample1),):
-        msg = ("\n `sample1_host_halo_id` must be a 1-D \n"
-               "array the same length as `sample1`.")
+        msg = (
+            "\n `sample1_host_halo_id` must be a 1-D \n"
+            "array the same length as `sample1`."
+        )
         raise HalotoolsError(msg)
     if np.shape(sample2_host_halo_id) != (len(sample2),):
-        msg = ("\n `sample2_host_halo_id` must be a 1-D \n"
-               "array the same length as `sample2`.")
+        msg = (
+            "\n `sample2_host_halo_id` must be a 1-D \n"
+            "array the same length as `sample2`."
+        )
         raise HalotoolsError(msg)
 
     rbins = get_separation_bins_array(rbins)
@@ -420,7 +600,7 @@ def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
     _enforce_maximum_search_length(rmax, period)
 
     if (randoms is None) & (PBCs is False):
-        msg = ('\n If no PBCs are specified, randoms must be provided.')
+        msg = "\n If no PBCs are specified, randoms must be provided."
         raise HalotoolsError(msg)
 
     try:
@@ -434,5 +614,17 @@ def _tpcf_one_two_halo_decomp_process_args(sample1, sample1_host_halo_id, rbins,
 
     verify_tpcf_estimator(estimator)
 
-    return sample1, sample1_host_halo_id, rbins, sample2, sample2_host_halo_id,\
-        randoms, period, do_auto, do_cross, num_threads, _sample1_is_sample2, PBCs
+    return (
+        sample1,
+        sample1_host_halo_id,
+        rbins,
+        sample2,
+        sample2_host_halo_id,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    )

--- a/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
+++ b/halotools/mock_observables/two_point_clustering/tpcf_one_two_halo_decomp.py
@@ -20,6 +20,7 @@ from ..mock_observables_helpers import (
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
 
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
+from .tpcf_estimators import _TP_estimator_crossx
 from ..pair_counters import npairs_3d
 from ..pair_counters import marked_npairs_3d
 
@@ -311,8 +312,8 @@ def tpcf_one_two_halo_decomp(
             one_halo_xi_11 = _TP_estimator(
                 one_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
             )
-            one_halo_xi_12 = _TP_estimator(
-                one_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            one_halo_xi_12 = _TP_estimator_crossx(
+                one_halo_D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator
             )
             one_halo_xi_22 = _TP_estimator(
                 one_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator
@@ -320,8 +321,8 @@ def tpcf_one_two_halo_decomp(
             two_halo_xi_11 = _TP_estimator(
                 two_halo_D1D1, D1R, RR, N1, N1, NR, NR, estimator
             )
-            two_halo_xi_12 = _TP_estimator(
-                two_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            two_halo_xi_12 = _TP_estimator_crossx(
+                two_halo_D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator
             )
             two_halo_xi_22 = _TP_estimator(
                 two_halo_D2D2, D2R, RR, N2, N2, NR, NR, estimator
@@ -335,11 +336,11 @@ def tpcf_one_two_halo_decomp(
                 two_halo_xi_22,
             )
         elif do_cross is True:
-            one_halo_xi_12 = _TP_estimator(
-                one_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            one_halo_xi_12 = _TP_estimator_crossx(
+                one_halo_D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator
             )
-            two_halo_xi_12 = _TP_estimator(
-                two_halo_D1D2, D1R, RR, N1, N2, NR, NR, estimator
+            two_halo_xi_12 = _TP_estimator_crossx(
+                two_halo_D1D2, D1R, D2R, RR, N1, N2, NR, NR, estimator
             )
             return one_halo_xi_12, two_halo_xi_12
         elif do_auto is True:

--- a/halotools/mock_observables/two_point_clustering/wp_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/wp_jackknife.py
@@ -9,6 +9,7 @@ import numpy as np
 from astropy.utils.misc import NumpyRNGContext
 
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
+from .tpcf_estimators import _TP_estimator_crossx
 from .tpcf_jackknife import get_subvolume_numbers, _enclose_in_box
 
 from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
@@ -376,8 +377,8 @@ def wp_jackknife(
             D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator
         )
     if do_cross is True:
-        xi_12_full = _TP_estimator(
-            D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator
+        xi_12_full = _TP_estimator_crossx(
+            D1D2_full, D1R_full, D2R_full, RR_full, N1, N2, NR, NR, estimator
         )
 
     # calculate the correlation function for the subsamples
@@ -389,8 +390,16 @@ def wp_jackknife(
             D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator
         )
     if do_cross is True:
-        xi_12_sub = _TP_estimator(
-            D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator
+        xi_12_sub = _TP_estimator_crossx(
+            D1D2_sub,
+            D1R_sub,
+            D2R_sub,
+            RR_sub,
+            N1_subs,
+            N2_subs,
+            NR_subs,
+            NR_subs,
+            estimator,
         )
 
     # account for factor of 2*pi_max in the integration

--- a/halotools/mock_observables/two_point_clustering/wp_jackknife.py
+++ b/halotools/mock_observables/two_point_clustering/wp_jackknife.py
@@ -11,26 +11,44 @@ from astropy.utils.misc import NumpyRNGContext
 from .tpcf_estimators import _TP_estimator, _TP_estimator_requirements
 from .tpcf_jackknife import get_subvolume_numbers, _enclose_in_box
 
-from .clustering_helpers import (process_optional_input_sample2, verify_tpcf_estimator)
-from ..mock_observables_helpers import (enforce_sample_has_correct_shape,
-    get_separation_bins_array, get_line_of_sight_bins_array, get_period, get_num_threads)
+from .clustering_helpers import process_optional_input_sample2, verify_tpcf_estimator
+from ..mock_observables_helpers import (
+    enforce_sample_has_correct_shape,
+    get_separation_bins_array,
+    get_line_of_sight_bins_array,
+    get_period,
+    get_num_threads,
+)
 from ..pair_counters.mesh_helpers import _enforce_maximum_search_length
 from ..pair_counters import npairs_jackknife_xy_z
 
 from ..catalog_analysis_helpers import cuboid_subvolume_labels
 
 
-__all__ = ('wp_jackknife', )
-__author__ = ('Duncan Campbell', 'Andrew Hearin')
+__all__ = ("wp_jackknife",)
+__author__ = ("Duncan Campbell", "Andrew Hearin")
 
 
-np.seterr(divide='ignore', invalid='ignore')  # ignore divide by zero in e.g. DD/RR
+np.seterr(divide="ignore", invalid="ignore")  # ignore divide by zero in e.g. DD/RR
 
 
-def wp_jackknife(sample1, randoms, rp_bins, pi_max, Nsub=[5, 5, 5],
-        sample2=None, period=None, do_auto=True, do_cross=True,
-        estimator='Natural', num_threads=1, seed=None,
-        approx_cell1_size=None, approx_cell2_size=None, approx_cellran_size=None):
+def wp_jackknife(
+    sample1,
+    randoms,
+    rp_bins,
+    pi_max,
+    Nsub=[5, 5, 5],
+    sample2=None,
+    period=None,
+    do_auto=True,
+    do_cross=True,
+    estimator="Natural",
+    num_threads=1,
+    seed=None,
+    approx_cell1_size=None,
+    approx_cell2_size=None,
+    approx_cellran_size=None,
+):
     r"""
     Calculate the projected two-point correlation function, :math:`w_p(r_p)` and the covariance
     matrix, :math:`{C}_{ij}`, between ith and jth projected radial bin.
@@ -215,11 +233,35 @@ def wp_jackknife(sample1, randoms, rp_bins, pi_max, Nsub=[5, 5, 5],
     pi_bins = np.array([0.0, float(pi_max)])
 
     # process input parameters
-    function_args = (sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto,
-        do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed)
-    sample1, rp_bins, pi_bins, sample2, randoms, period, do_auto, do_cross, num_threads,\
-        _sample1_is_sample2, PBCs = _wp_jackknife_tpcf_process_args(*function_args)
+    function_args = (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        estimator,
+        num_threads,
+        approx_cell1_size,
+        approx_cell2_size,
+        approx_cellran_size,
+        seed,
+    )
+    (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    ) = _wp_jackknife_tpcf_process_args(*function_args)
 
     # determine box size the data occupies.
     # This is used in determining jackknife samples.
@@ -249,30 +291,62 @@ def wp_jackknife(sample1, randoms, rp_bins, pi_max, Nsub=[5, 5, 5],
 
     # calculate all the pair counts
     D1D1, D1D2, D2D2 = jnpair_counts(
-        sample1, sample2, j_index_1, j_index_2, N_sub_vol,
-        rp_bins, pi_bins, period, num_threads, do_auto, do_cross, _sample1_is_sample2)
+        sample1,
+        sample2,
+        j_index_1,
+        j_index_2,
+        N_sub_vol,
+        rp_bins,
+        pi_bins,
+        period,
+        num_threads,
+        do_auto,
+        do_cross,
+        _sample1_is_sample2,
+    )
 
     # pull out the full and sub sample results
-    if (do_auto is True):
+    if do_auto is True:
         D1D1_full = D1D1[0, :, 0]
         D1D1_sub = D1D1[1:, :, 0]
         D2D2_full = D2D2[0, :, 0]
         D2D2_sub = D2D2[1:, :, 0]
-    if (do_cross is True):
+    if do_cross is True:
         D1D2_full = D1D2[0, :, 0]
         D1D2_sub = D1D2[1:, :, 0]
 
-
     # do random counts
-    D1R, RR = jrandom_counts(sample1, randoms, j_index_1, j_index_random, N_sub_vol,
-        rp_bins, pi_bins, period, num_threads, do_DR, do_RR)
+    D1R, RR = jrandom_counts(
+        sample1,
+        randoms,
+        j_index_1,
+        j_index_random,
+        N_sub_vol,
+        rp_bins,
+        pi_bins,
+        period,
+        num_threads,
+        do_DR,
+        do_RR,
+    )
 
     if _sample1_is_sample2:
         D2R = D1R
     else:
         if do_DR is True:
-            D2R, RR_dummy = jrandom_counts(sample2, randoms, j_index_2, j_index_random,
-                N_sub_vol, rp_bins, pi_bins, period, num_threads, do_DR, do_RR=False)
+            D2R, RR_dummy = jrandom_counts(
+                sample2,
+                randoms,
+                j_index_2,
+                j_index_random,
+                N_sub_vol,
+                rp_bins,
+                pi_bins,
+                period,
+                num_threads,
+                do_DR,
+                do_RR=False,
+            )
         else:
             D2R = None
 
@@ -294,35 +368,47 @@ def wp_jackknife(sample1, randoms, rp_bins, pi_max, Nsub=[5, 5, 5],
         RR_sub = None
 
     # calculate the correlation function for the full sample
-    if (do_auto is True):
-        xi_11_full = _TP_estimator(D1D1_full, D1R_full, RR_full, N1, N1, NR, NR, estimator)
-        xi_22_full = _TP_estimator(D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator)
-    if (do_cross is True):
-        xi_12_full = _TP_estimator(D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator)
+    if do_auto is True:
+        xi_11_full = _TP_estimator(
+            D1D1_full, D1R_full, RR_full, N1, N1, NR, NR, estimator
+        )
+        xi_22_full = _TP_estimator(
+            D2D2_full, D2R_full, RR_full, N2, N2, NR, NR, estimator
+        )
+    if do_cross is True:
+        xi_12_full = _TP_estimator(
+            D1D2_full, D1R_full, RR_full, N1, N2, NR, NR, estimator
+        )
 
     # calculate the correlation function for the subsamples
-    if (do_auto is True):
-        xi_11_sub = _TP_estimator(D1D1_sub, D1R_sub, RR_sub, N1_subs, N1_subs, NR_subs, NR_subs, estimator)
-        xi_22_sub = _TP_estimator(D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator)
-    if (do_cross is True):
-        xi_12_sub = _TP_estimator(D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator)
+    if do_auto is True:
+        xi_11_sub = _TP_estimator(
+            D1D1_sub, D1R_sub, RR_sub, N1_subs, N1_subs, NR_subs, NR_subs, estimator
+        )
+        xi_22_sub = _TP_estimator(
+            D2D2_sub, D2R_sub, RR_sub, N2_subs, N2_subs, NR_subs, NR_subs, estimator
+        )
+    if do_cross is True:
+        xi_12_sub = _TP_estimator(
+            D1D2_sub, D1R_sub, RR_sub, N1_subs, N2_subs, NR_subs, NR_subs, estimator
+        )
 
     # account for factor of 2*pi_max in the integration
-    if (do_auto is True):
-        xi_11_full = 2.0*pi_max*xi_11_full
-        xi_22_full = 2.0*pi_max*xi_22_full
-        xi_11_sub = 2.0*pi_max*xi_11_sub
-        xi_22_sub = 2.0*pi_max*xi_22_sub
-    if (do_cross is True):
-        xi_12_full = 2.0*pi_max*xi_12_full
-        xi_12_sub = 2.0*pi_max*xi_12_sub
+    if do_auto is True:
+        xi_11_full = 2.0 * pi_max * xi_11_full
+        xi_22_full = 2.0 * pi_max * xi_22_full
+        xi_11_sub = 2.0 * pi_max * xi_11_sub
+        xi_22_sub = 2.0 * pi_max * xi_22_sub
+    if do_cross is True:
+        xi_12_full = 2.0 * pi_max * xi_12_full
+        xi_12_sub = 2.0 * pi_max * xi_12_sub
 
     # calculate the covariance matrix
-    if (do_auto is True):
-        xi_11_cov = np.array(np.cov(xi_11_sub.T, bias=True))*(N_sub_vol-1)
-        xi_22_cov = np.array(np.cov(xi_22_sub.T, bias=True))*(N_sub_vol-1)
-    if (do_cross is True):
-        xi_12_cov = np.array(np.cov(xi_12_sub.T, bias=True))*(N_sub_vol-1)
+    if do_auto is True:
+        xi_11_cov = np.array(np.cov(xi_11_sub.T, bias=True)) * (N_sub_vol - 1)
+        xi_22_cov = np.array(np.cov(xi_22_sub.T, bias=True)) * (N_sub_vol - 1)
+    if do_cross is True:
+        xi_12_cov = np.array(np.cov(xi_12_sub.T, bias=True)) * (N_sub_vol - 1)
 
     if _sample1_is_sample2:
         return xi_11_full, xi_11_cov
@@ -335,15 +421,35 @@ def wp_jackknife(sample1, randoms, rp_bins, pi_max, Nsub=[5, 5, 5],
             return xi_12_full, xi_12_cov
 
 
-def jnpair_counts(sample1, sample2, j_index_1, j_index_2, N_sub_vol, rp_bins, pi_bins,
-        period, num_threads, do_auto, do_cross, _sample1_is_sample2):
+def jnpair_counts(
+    sample1,
+    sample2,
+    j_index_1,
+    j_index_2,
+    N_sub_vol,
+    rp_bins,
+    pi_bins,
+    period,
+    num_threads,
+    do_auto,
+    do_cross,
+    _sample1_is_sample2,
+):
     """
     Count jackknife data pairs: DD
     """
     if do_auto is True:
-        D1D1 = npairs_jackknife_xy_z(sample1, sample1, rp_bins, pi_bins, period=period,
-            jtags1=j_index_1, jtags2=j_index_1,  N_samples=N_sub_vol,
-            num_threads=num_threads)
+        D1D1 = npairs_jackknife_xy_z(
+            sample1,
+            sample1,
+            rp_bins,
+            pi_bins,
+            period=period,
+            jtags1=j_index_1,
+            jtags2=j_index_1,
+            N_samples=N_sub_vol,
+            num_threads=num_threads,
+        )
         D1D1 = np.diff(np.diff(D1D1, axis=1), axis=2)
     else:
         D1D1 = None
@@ -354,38 +460,81 @@ def jnpair_counts(sample1, sample2, j_index_1, j_index_2, N_sub_vol, rp_bins, pi
         D2D2 = D1D1
     else:
         if do_cross is True:
-            D1D2 = npairs_jackknife_xy_z(sample1, sample2, rp_bins, pi_bins, period=period,
-                jtags1=j_index_1, jtags2=j_index_2,
-                N_samples=N_sub_vol, num_threads=num_threads)
+            D1D2 = npairs_jackknife_xy_z(
+                sample1,
+                sample2,
+                rp_bins,
+                pi_bins,
+                period=period,
+                jtags1=j_index_1,
+                jtags2=j_index_2,
+                N_samples=N_sub_vol,
+                num_threads=num_threads,
+            )
             D1D2 = np.diff(np.diff(D1D2, axis=1), axis=2)
         else:
             D1D2 = None
         if do_auto is True:
-            D2D2 = npairs_jackknife_xy_z(sample2, sample2, rp_bins, pi_bins, period=period,
-                jtags1=j_index_2, jtags2=j_index_2,
-                N_samples=N_sub_vol, num_threads=num_threads)
+            D2D2 = npairs_jackknife_xy_z(
+                sample2,
+                sample2,
+                rp_bins,
+                pi_bins,
+                period=period,
+                jtags1=j_index_2,
+                jtags2=j_index_2,
+                N_samples=N_sub_vol,
+                num_threads=num_threads,
+            )
             D2D2 = np.diff(np.diff(D2D2, axis=1), axis=2)
 
     return D1D1, D1D2, D2D2
 
 
-def jrandom_counts(sample, randoms, j_index, j_index_randoms, N_sub_vol, rp_bins, pi_bins,
-        period, num_threads, do_DR, do_RR):
+def jrandom_counts(
+    sample,
+    randoms,
+    j_index,
+    j_index_randoms,
+    N_sub_vol,
+    rp_bins,
+    pi_bins,
+    period,
+    num_threads,
+    do_DR,
+    do_RR,
+):
     """
     Count jackknife random pairs: DR, RR
     """
 
     if do_DR is True:
-        DR = npairs_jackknife_xy_z(sample, randoms, rp_bins, pi_bins, period=period,
-            jtags1=j_index, jtags2=j_index_randoms,
-            N_samples=N_sub_vol, num_threads=num_threads)
+        DR = npairs_jackknife_xy_z(
+            sample,
+            randoms,
+            rp_bins,
+            pi_bins,
+            period=period,
+            jtags1=j_index,
+            jtags2=j_index_randoms,
+            N_samples=N_sub_vol,
+            num_threads=num_threads,
+        )
         DR = np.diff(np.diff(DR, axis=1), axis=2)
     else:
         DR = None
     if do_RR is True:
-        RR = npairs_jackknife_xy_z(randoms, randoms, rp_bins, pi_bins, period=period,
-            jtags1=j_index_randoms, jtags2=j_index_randoms,
-            N_samples=N_sub_vol, num_threads=num_threads)
+        RR = npairs_jackknife_xy_z(
+            randoms,
+            randoms,
+            rp_bins,
+            pi_bins,
+            period=period,
+            jtags1=j_index_randoms,
+            jtags2=j_index_randoms,
+            N_samples=N_sub_vol,
+            num_threads=num_threads,
+        )
         RR = np.diff(np.diff(RR, axis=1), axis=2)
     else:
         RR = None
@@ -393,16 +542,30 @@ def jrandom_counts(sample, randoms, j_index, j_index_randoms, N_sub_vol, rp_bins
     return DR, RR
 
 
-def _wp_jackknife_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
-        period, do_auto, do_cross, estimator, num_threads,
-        approx_cell1_size, approx_cell2_size, approx_cellran_size, seed):
+def _wp_jackknife_tpcf_process_args(
+    sample1,
+    rp_bins,
+    pi_bins,
+    sample2,
+    randoms,
+    period,
+    do_auto,
+    do_cross,
+    estimator,
+    num_threads,
+    approx_cell1_size,
+    approx_cell2_size,
+    approx_cellran_size,
+    seed,
+):
     """
     Private method to do bounds-checking on the arguments passed to
     `~halotools.mock_observables.redshift_space_tpcf`.
     """
     sample1 = enforce_sample_has_correct_shape(sample1)
     sample2, _sample1_is_sample2, do_cross = process_optional_input_sample2(
-        sample1, sample2, do_cross)
+        sample1, sample2, do_cross
+    )
 
     if randoms is not None:
         randoms = np.atleast_1d(randoms)
@@ -420,11 +583,13 @@ def _wp_jackknife_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
         N_randoms = randoms[0]
         if PBCs is True:
             with NumpyRNGContext(seed):
-                randoms = np.random.random((N_randoms, 3))*period
+                randoms = np.random.random((N_randoms, 3)) * period
         else:
-            msg = ("\n When no `period` parameter is passed, \n"
-                   "the user must provide true randoms, and \n"
-                   "not just the number of randoms desired.")
+            msg = (
+                "\n When no `period` parameter is passed, \n"
+                "the user must provide true randoms, and \n"
+                "not just the number of randoms desired."
+            )
             raise ValueError(msg)
 
     _enforce_maximum_search_length([rp_max, rp_max, pi_max], period)
@@ -444,5 +609,16 @@ def _wp_jackknife_tpcf_process_args(sample1, rp_bins, pi_bins, sample2, randoms,
 
     verify_tpcf_estimator(estimator)
 
-    return sample1, rp_bins, pi_bins, sample2, randoms, period,\
-        do_auto, do_cross, num_threads, _sample1_is_sample2, PBCs
+    return (
+        sample1,
+        rp_bins,
+        pi_bins,
+        sample2,
+        randoms,
+        period,
+        do_auto,
+        do_cross,
+        num_threads,
+        _sample1_is_sample2,
+        PBCs,
+    )


### PR DESCRIPTION
This PR brings in a fix for the calculation of two-point cross-correlations based on the Hamilton and Landy-Szalay estimators. Thanks to @ts485 for calling attention to this error.