### PR TITLE
Update build wheel to macos-11

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
According to [this issue](https://github.com/actions/virtual-environments/issues/5583), wheels based on macos-10.15 are now deprecated. This updates the Action brought in by #1017 so that macos-11 is now used instead.

Tagging @EiffL in case he has any other suggestions for wheel updates. If not, this is the last planned commit prior to releasing v0.8.