### PR TITLE
Fix incompatibility with recent versions of astropy

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -28,6 +28,16 @@ jobs:
             python: 3.7
             toxenv: 'py37-test-alldeps'
 
+          - name: Ubuntu - Python 3.9 with all optional dependencies
+            os: ubuntu-latest
+            python: 3.9
+            toxenv: 'py39-test-alldeps'
+
+          - name: MacOs - Python 3.9 with all optional dependencies
+            os: macos-latest
+            python: 3.9
+            toxenv: 'py39-test-alldeps'
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
Halotools seems to only work with very old versions of astropy. This WIP PR attempts to resolve the lingering issues.