### PR TITLE
Resolve cibuildwheel failures

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -27,7 +27,7 @@ jobs:
         # uses: pypa/cibuildwheel@2.10.0
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BEFORE_BUILD: pip install oldest-supported-numpy Cython
+          CIBW_BEFORE_BUILD: pip install oldest-supported-numpy Cython extension-helpers
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_SKIP: pp*
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,6 @@
 name: Build wheels
 
-on:
-  workflow_dispatch:
-  release:
-    types:
-      - published
+on: [push, pull_request]
 
 jobs:
   build_wheels:

--- a/halotools/empirical_models/assembias_models/heaviside_assembias.py
+++ b/halotools/empirical_models/assembias_models/heaviside_assembias.py
@@ -160,7 +160,7 @@ class HeavisideAssembias(object):
         if 'splitting_model' in kwargs:
             self.splitting_model = kwargs['splitting_model']
             func = getattr(self.splitting_model, kwargs['splitting_method_name'])
-            if isinstance(func, collections.Callable):
+            if isinstance(func, collections.abc.Callable):
                 self._input_split_func = func
             else:
                 raise HalotoolsError("Input ``splitting_model`` must have a callable function "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=42.0.0",
             "setuptools_scm",
             "wheel",
             "oldest-supported-numpy",
-            "cython==0.29.14",
+            "cython==0.29.32",
             "extension-helpers"]
 
 build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = ["setuptools>=42.0.0",
             "setuptools_scm",
             "wheel",
             "oldest-supported-numpy",
-            "cython==0.29.14",
-            "extension-helpers"]
+            "cython==0.29.14"]
 
 build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = ["setuptools>=42.0.0",
             "setuptools_scm",
             "wheel",
             "oldest-supported-numpy",
-            "cython==0.29.14"]
+            "cython==0.29.14",
+            "extension-helpers"]
 
 build-backend = 'setuptools.build_meta'

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@
 
 import os
 import sys
+from glob import glob
+import numpy as np
+from setuptools import setup, Extension
 
-from setuptools import setup
-
-from extension_helpers import get_extensions
-
+from Cython.Build import cythonize
 
 # First provide helpful messages if contributors try and run legacy commands
 # for tests or docs.
@@ -76,10 +76,34 @@ except Exception:
     version = '{version}'
 """.lstrip()
 
+ext_sources = glob("halotools/**/*.pyx", recursive=True)
+ext_names = [s[:-4].replace("/", ".") for s in ext_sources]
+
+
+def get_extensions(names, sources):
+
+    language = "c++"
+    extra_compile_args = ["-Ofast"]
+
+    extensions = []
+    for name, source in zip(names, sources):
+        extensions.append(
+            Extension(
+                name=name,
+                sources=[source],
+                include_dirs=[np.get_include()],
+                language=language,
+                extra_compile_args=extra_compile_args,
+            )
+        )
+
+    return extensions
+
+
 setup(
     use_scm_version={
         "write_to": os.path.join("halotools", "version.py"),
         "write_to_template": VERSION_TEMPLATE,
     },
-    ext_modules=get_extensions(),
+    ext_modules=cythonize(get_extensions(ext_names, ext_sources)),
 )

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@
 
 import os
 import sys
-from glob import glob
-import numpy as np
-from setuptools import setup, Extension
 
-from Cython.Build import cythonize
+from setuptools import setup
+
+from extension_helpers import get_extensions
+
 
 # First provide helpful messages if contributors try and run legacy commands
 # for tests or docs.
@@ -76,34 +76,10 @@ except Exception:
     version = '{version}'
 """.lstrip()
 
-ext_sources = glob("halotools/**/*.pyx", recursive=True)
-ext_names = [s[:-4].replace("/", ".") for s in ext_sources]
-
-
-def get_extensions(names, sources):
-
-    language = "c++"
-    extra_compile_args = ["-Ofast"]
-
-    extensions = []
-    for name, source in zip(names, sources):
-        extensions.append(
-            Extension(
-                name=name,
-                sources=[source],
-                include_dirs=[np.get_include()],
-                language=language,
-                extra_compile_args=extra_compile_args,
-            )
-        )
-
-    return extensions
-
-
 setup(
     use_scm_version={
         "write_to": os.path.join("halotools", "version.py"),
         "write_to_template": VERSION_TEMPLATE,
     },
-    ext_modules=cythonize(get_extensions(ext_names, ext_sources)),
+    ext_modules=get_extensions(),
 )


### PR DESCRIPTION
In PR #1047 halotools removed dependency on the astropy-helpers and began using extensions-helpers to handle the automation of the cython extensions. In the current master branch, [the cibuildwheel github action](https://github.com/astropy/halotools/blob/master/.github/workflows/wheels.yml) in current master branch [fails to successfully build a wheel](https://github.com/astropy/halotools/actions/runs/3122524070/jobs/5064519017) to upload to pypi. This PR attempts to resolve this failure.