### PR TITLE
Update installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,18 @@ However, users who prefer pip can install via::
     		pip install halotools
 
 You can find detailed installation instructions
-in the :ref:`step_by_step_install` section of http://halotools.readthedocs.io. After installing the package, you should follow the :ref:`step_by_step_install` 10-minute tutorial. This will get you set up with the default halo catalog so that you can quickly get started with creating mock galaxy populations.
+in the :ref:`step_by_step_install` section of http://halotools.readthedocs.io.
+After installing the package, you should follow the :ref:`step_by_step_install` 10-minute tutorial.
+This will get you set up with the default halo catalog so that you can quickly get started
+with creating mock galaxy populations.
+
+After installation, it is recommended that you download the default halo catalog::
+
+    $ download_initial_halocat.py
+
+Halotools works with any halo catalog, but downloading the default halo catalog
+automatically configures the halotools cache directory. More information about
+halo catalog download options in the :ref:`download_default_halos` section of the 10-minute tutorial.
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -14,16 +14,17 @@ The code is publicly available at https://github.com/astropy/halotools.
 
 Installation
 -------------
-The simplest way to install the latest release of the code is with conda-forge::
+The simplest and most reliable way to install the latest release of the code is with conda-forge::
 
     conda install -c conda-forge halotools
 
-Or alternatively, you can install using pip::
+Pip installation is not recommended because the conda-forge dependency solver is much more robust.
+However, users who prefer pip can install via::
 
     		pip install halotools
 
 You can find detailed installation instructions
-in the **Package Installation** section of http://halotools.readthedocs.io. After installing the package, you should navigate to the *Quickstart Guides and Tutorials* section and follow the *Getting started with Halotools* 10-minute tutorial. This will get you set up with the default halo catalog so that you can quickly get started with creating mock galaxy populations.
+in the :ref:`step_by_step_install` section of http://halotools.readthedocs.io. After installing the package, you should follow the :ref:`step_by_step_install` 10-minute tutorial. This will get you set up with the default halo catalog so that you can quickly get started with creating mock galaxy populations.
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -23,20 +23,11 @@ However, users who prefer pip can install via::
 
     		pip install halotools
 
-You can find detailed installation instructions
-in the :ref:`step_by_step_install` section of http://halotools.readthedocs.io.
-After installing the package, you should follow the :ref:`step_by_step_install` 10-minute tutorial.
-This will get you set up with the default halo catalog so that you can quickly get started
-with creating mock galaxy populations.
+You can find detailed installation instructions `halotools.readthedocs.io <http://halotools.readthedocs.io/>`_.
 
-After installation, it is recommended that you download the default halo catalog::
-
-    $ download_initial_halocat.py
-
-Halotools works with any halo catalog, but downloading the default halo catalog
-automatically configures the halotools cache directory. More information about
-halo catalog download options in the :ref:`download_default_halos` section of the 10-minute tutorial.
-
+After installing the package, you should navigate to the *Quickstart Guides and Tutorials*
+section and follow the *Getting started with Halotools* 10-minute tutorial.
+This will get you set up with the default halo catalog so that you can quickly get started with creating mock galaxy populations.
 
 Documentation
 -------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,18 +4,19 @@
 Package Installation
 ************************
 
-To install Halotools, you can use conda-forge, pip, or clone the repo from GitHub and build the source code.
+To install Halotools, you can use conda-forge (recommended), pip, or clone the repo from GitHub and build the source code.
 Either way, be sure to read the :ref:`halotools_dependencies` section prior to installation.
 
 Using conda-forge and pip
 =========================
 
-The simplest way to install the latest release of the code is with conda-forge.
+The simplest and most reliable way to install the latest release of the code is with conda-forge.
 If you will be :ref:`installing_halotools_with_virtualenv`, activate the environment before installing::
 
     conda install -c conda-forge halotools
 
-Alternatively, you can install using pip::
+Pip installation is not recommended because the conda-forge dependency solver is much more robust.
+However, users who prefer pip can install via::
 
 		pip install halotools
 

--- a/halotools/sim_manager/tests/test_download_manager.py
+++ b/halotools/sim_manager/tests/test_download_manager.py
@@ -519,6 +519,7 @@ class TestDownloadManager(TestCase):
         substr = "you must set the ``overwrite`` keyword argument to True."
         assert substr in err.value.args[0]
 
+    @pytest.mark.skipif("not APH_MACHINE")
     def test_download_ptcl_table4(self):
         """ """
         with pytest.raises(HalotoolsError) as err:


### PR DESCRIPTION
Updated docs notify users that conda-forge is the preferred installation method over pip