### PR TITLE
Improve convenience of the download manager

### DIFF
--- a/halotools/sim_manager/download_manager.py
+++ b/halotools/sim_manager/download_manager.py
@@ -276,6 +276,7 @@ class DownloadManager(object):
             (len(close_matches) > 0)
             & (len(exact_matches) == 1)
             & (ignore_nearby_redshifts is False)
+            & (overwrite is False)
         ):
 
             entry = close_matches[0]

--- a/halotools/sim_manager/tests/test_download_manager.py
+++ b/halotools/sim_manager/tests/test_download_manager.py
@@ -437,10 +437,10 @@ class TestDownloadManager(TestCase):
                 version_name="halotools_v0p4",
                 redshift=11.7,
                 dz_tol=200,
-                overwrite=True,
+                overwrite=False,
                 download_dirname="std_cache_loc",
             )
-        substr = "the ``ignore_nearby_redshifts`` to True, or decrease ``dz_tol``"
+        substr = "you must set the ``overwrite`` keyword argument to True."
         assert substr in err.value.args[0]
 
     @pytest.mark.skipif("not APH_MACHINE")


### PR DESCRIPTION
This PR resolves a bug in the download manager. Previously, if a user passed the `-overwrite` flag when using the download script, they would have to pass an _additional_ flag in order to actually overwrite an existing halo catalog. This PR modifies the control flow within the DownloadManager so that this is no longer necessary.