### PR TITLE
Implement fix for inconsistent treatment of littleh in Leauthaud+11 model

### DIFF
--- a/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
+++ b/halotools/empirical_models/occupation_models/tests/test_leauthaud11_hod.py
@@ -4,14 +4,14 @@
 import numpy as np
 import pytest
 
-from .. import Leauthaud11Cens, Leauthaud11Sats
+from ..leauthaud11_components import Leauthaud11Cens, Leauthaud11Sats
 
-__all__ = ('test_Leauthaud11Cens', 'test_Leauthaud11Sats')
+__all__ = ("test_Leauthaud11Cens", "test_Leauthaud11Sats")
 
 
 @pytest.mark.installation_test
 def test_Leauthaud11Cens():
-    """ Function to test
+    """Function to test
     `~halotools.empirical_models.Leauthaud11Cens`.
     """
 
@@ -19,20 +19,20 @@ def test_Leauthaud11Cens():
     # for halos of mass 1e12
     model = Leauthaud11Cens()
     ncen1 = model.mean_occupation(prim_haloprop=5e11)
-    mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4))*5e11, seed=43)
+    mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4)) * 5e11, seed=43)
 
     # Check that the model behavior is altered in the expected way by changing param_dict values
 
     # Increasing scatter picks up more galaxies in low-mass halos
-    model.param_dict['scatter_model_param1'] *= 1.5
+    model.param_dict["scatter_model_param1"] *= 1.5
     ncen2 = model.mean_occupation(prim_haloprop=5e11)
     assert ncen2 > ncen1
-#
-    model.param_dict['smhm_m1_0'] *= 1.1
+    #
+    model.param_dict["smhm_m1_0"] *= 1.1
     ncen3 = model.mean_occupation(prim_haloprop=5e11)
     assert ncen3 < ncen2
-#
-    model.param_dict['smhm_m1_a'] *= 1.1
+    #
+    model.param_dict["smhm_m1_a"] *= 1.1
     ncen4 = model.mean_occupation(prim_haloprop=5e11)
     assert ncen4 == ncen3
 
@@ -48,25 +48,25 @@ def test_Leauthaud11Cens():
 
 @pytest.mark.installation_test
 def test_Leauthaud11Sats():
-    """ Function to test
+    """Function to test
     `~halotools.empirical_models.Leauthaud11Cens`.
     """
 
     # Verify that the mean and Monte Carlo occupations are both reasonable and in agreement
     # for halos of mass 1e12
     model = Leauthaud11Sats()
-    nsat1 = model.mean_occupation(prim_haloprop=5.e12)
-    mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4))*5e12, seed=43)
+    nsat1 = model.mean_occupation(prim_haloprop=5.0e12)
+    mcocc = model.mc_occupation(prim_haloprop=np.ones(int(1e4)) * 5e12, seed=43)
 
     # Check that the model behavior is altered in the expected way by changing param_dict values
-    model.param_dict['alphasat'] *= 1.1
-    nsat2 = model.mean_occupation(prim_haloprop=5.e12)
+    model.param_dict["alphasat"] *= 1.1
+    nsat2 = model.mean_occupation(prim_haloprop=5.0e12)
     assert nsat2 < nsat1
 
     # Msat := Bsat(mhalo_thresh/1e12)**betasat
     # since mhalo_thresh(logM*=10.5) > 1e12, increasing betasat should increase Msat
     msat1 = np.copy(model._msat)
-    model.param_dict['betasat'] *= 1.1
+    model.param_dict["betasat"] *= 1.1
     model._update_satellite_params()
     msat2 = np.copy(model._msat)
     assert msat2 > msat1
@@ -75,38 +75,38 @@ def test_Leauthaud11Sats():
     # Increasing Bsat should increase Msat regardless of mass
     model._update_satellite_params()
     msat1 = np.copy(model._msat)
-    model.param_dict['bsat'] *= 1.1
+    model.param_dict["bsat"] *= 1.1
     model._update_satellite_params()
     msat2 = np.copy(model._msat)
     assert msat2 > msat1
-#
+    #
     # Mcut := Bcut(mhalo_thresh/1e12)**betacut
     # Default value of betacut is -0.13 for default threshold of 10.5
     # since mhalo_thresh(logM*=10.5) > 1e12, increasing betacut should increase Mcut
-    model.param_dict['betacut'] = -0.13
+    model.param_dict["betacut"] = -0.13
     model._update_satellite_params()
     mcut1 = np.copy(model._mcut)
-    model.param_dict['betacut'] = -0.1
+    model.param_dict["betacut"] = -0.1
     model._update_satellite_params()
     mcut2 = np.copy(model._mcut)
     assert mcut2 > mcut1
-# #
+    # #
     # Mcut := Bcut(mhalo_thresh/1e12)**betacut
     # Increasing Bcut should increase Mcut regardless of mass
     model._update_satellite_params()
     mcut1 = np.copy(model._mcut)
-    model.param_dict['bcut'] *= 1.1
+    model.param_dict["bcut"] *= 1.1
     model._update_satellite_params()
     mcut2 = np.copy(model._mcut)
     assert mcut2 > mcut1
-# #
-#
+    # #
+    #
     # Check that modulate_with_cenocc strictly decreases the mean occupations
     model2a = Leauthaud11Sats(modulate_with_cenocc=False)
     model2b = Leauthaud11Sats(modulate_with_cenocc=True)
-    nsat2a = model2a.mean_occupation(prim_haloprop=5.e12)
-    nsat2b = model2b.mean_occupation(prim_haloprop=5.e12)
-    assert model2b.central_occupation_model.mean_occupation(prim_haloprop=5.e12) < 1
+    nsat2a = model2a.mean_occupation(prim_haloprop=5.0e12)
+    nsat2b = model2b.mean_occupation(prim_haloprop=5.0e12)
+    assert model2b.central_occupation_model.mean_occupation(prim_haloprop=5.0e12) < 1
     assert nsat2b < nsat2a
 
     # Check that increasing stellar mass thresholds decreases the mean occupation


### PR DESCRIPTION
This PR resolves #1061 as follows:

- The new Leauthaud11 has parameter values that assume h=0.72, so that the numerical values in the parameter dictionary can be directly compared to Leauthaud+11.
- The input stellar mass threshold is quoted in h=1, so that the user needs to rescale the stellar mass of their sample before directly comparing parameter values.
- All user-facing functions such as `mean_stellar_mass` and `mean_log_halo_mass` accept and return values of mass in h=1 units, for consistency with the rest of the package.
- There is no longer any dependence upon Behroozi10SmHm. Instead, there is a new Leauthaud11SmHm class defined within the same module. This simplifies the complication that Behroozi+10 assumed h=0.7, whereas Leauthaud+11 assumed h=0.72.

Throughout the docstrings, I have made an effort to write copious, very explicit notes about how to convert back and forth between halo and stellar mass.

Thanks to @zaidikumail for the patience. Comments from @zaidikumail in particular would be most welcome. 