### PR TITLE
Check build wheels for upcoming release of 0.8.3

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,10 +1,6 @@
 name: Build wheels
 
-on:
-  workflow_dispatch:
-  release:
-    types:
-      - published
+on: [push, pull_request]
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Temporarily build wheels with each PR to check build success before next release