### PR TITLE
BLD: pin extension-helpers to 1.* following upstream recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,6 @@ requires = ["setuptools>=42.0.0",
             "wheel",
             "oldest-supported-numpy",
             "cython==3.0.2",
-            "extension-helpers"]
+            "extension-helpers==1.*"]
 
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
Following https://github.com/astropy/extension-helpers/pull/72