### PR TITLE
MNT: upgrade upload/download-artifact GitHub actions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,7 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9"
           CIBW_SKIP: pp*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
Hi, version 4 of upload-artifact and download-artifact were recently released.
Staying on old version is not viable long term because GitHub will sooner or later drop support for the old versions of node that these depend on.
Since migration to v4 is not as straightfoward as bumping the version number, I'm helping all astropy-related packages byt manually performing the necessary changes.
