### PR TITLE
Fix crashes due to rounding errors in mean_occupation functions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up python ${{ matrix.python }} on ${{ matrix.os }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Set up python ${{ matrix.python }} on ${{ matrix.os }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Install base dependencies

--- a/halotools/empirical_models/occupation_models/occupation_model_template.py
+++ b/halotools/empirical_models/occupation_models/occupation_model_template.py
@@ -135,6 +135,18 @@ class OccupationComponent(object):
             Integer array giving the number of galaxies in each of the input table.
         """
         first_occupation_moment = self.mean_occupation(**kwargs)
+
+        if np.any(first_occupation_moment < 0):
+            if np.all(first_occupation_moment >= -1e-6):
+                first_occupation_moment = np.maximum(
+                    first_occupation_moment, 0)
+            else:
+                msg = (
+                    "\nThe mean occupation for at least one halo was negative. \n"
+                    "Ensure that the mean occupation is always non-negative. \n"
+                )
+                raise HalotoolsError(msg)
+
         if self._upper_occupation_bound == 1:
             return self._nearest_integer_distribution(
                 first_occupation_moment, seed=seed, **kwargs

--- a/halotools/empirical_models/occupation_models/tests/test_cacciato09_clf.py
+++ b/halotools/empirical_models/occupation_models/tests/test_cacciato09_clf.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy.stats import kstest
 from scipy.interpolate import interp1d
 import pytest
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 from .. import Cacciato09Cens, Cacciato09Sats
 from ....custom_exceptions import HalotoolsError
@@ -486,7 +486,7 @@ def test_Cacciato09_gap():
             0.015821,
         ]
     )
-    cdf_more = np.concatenate([[0], cumtrapz(pdf_more, x=gap_more)])
+    cdf_more = np.concatenate([[0], cumulative_trapezoid(pdf_more, x=gap_more)])
     cdf_more = cdf_more / cdf_more[-1]
     cdf_more = interp1d(gap_more, cdf_more)
 

--- a/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
+++ b/halotools/empirical_models/occupation_models/tests/test_occupation_component.py
@@ -96,7 +96,7 @@ def test_nonstandard_upper_occupation_bound1():
             OccupationComponent.__init__(self, **constructor_kwargs)
 
         def mean_occupation(self, **kwargs):
-            return None
+            return 0.5
 
     model = MyOccupationComponent()
     with pytest.raises(HalotoolsError) as err:


### PR DESCRIPTION
This PR adds a check that the mean occupation for all halos is non-negative. If it's negative but reasonably close to 0 such that this may be caused by rounding errors, the mean occupation will be 0 exactly. If it's clearly negative, `halotools` will raise an error to alert the user that the model is unphysical. This should fix #1081.

@aphearin This PR also adds the above check for centrals and satellites. Let me know if this PR could produce any unwanted exceptions.