### PR TITLE
Add support for numpy 2

### DIFF
--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -18,16 +18,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Ubuntu - Python 3.10 with all optional dependencies
-            os: ubuntu-latest
-            python: "3.10"
-            toxenv: 'py10-test-alldeps'
-
-          - name: MacOs - Python 3.10 with all optional dependencies
-            os: macos-latest
-            python: "3.10"
-            toxenv: 'py10-test-alldeps'
-
           - name: Ubuntu - Python 3.11 with all optional dependencies
             os: ubuntu-latest
             python: "3.11"

--- a/.github/workflows/cron_tests.yaml
+++ b/.github/workflows/cron_tests.yaml
@@ -15,16 +15,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Ubuntu - Python 3.10 with all optional dependencies
-            os: ubuntu-latest
-            python: "3.10"
-            toxenv: 'py10-test-alldeps'
-
-          - name: MacOs - Python 3.10 with all optional dependencies
-            os: macos-latest
-            python: "3.10"
-            toxenv: 'py10-test-alldeps'
-
           - name: Ubuntu - Python 3.11 with all optional dependencies
             os: ubuntu-latest
             python: "3.11"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ build:
   apt_packages:
     - graphviz
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/installing_halotools_with_virtualenv.rst
+++ b/docs/installing_halotools_with_virtualenv.rst
@@ -12,7 +12,7 @@ create a virtual environment that will automatically have compatible versions of
 By installing into a virtual environment, you will not change any of the
 packages that are already installed system-wide on your machine. In the example below, we will use conda to create a virtual environment with all the dependencies handled automatically::
 
-    conda create -n htenv python=3.9 halotools=0.8 h5py ipython jupyter matplotlib
+    conda create -n htenv python=3.11 halotools=0.9 h5py ipython jupyter matplotlib
 
 In order to activate this environment::
 

--- a/halotools/empirical_models/occupation_models/tinker13_components.py
+++ b/halotools/empirical_models/occupation_models/tinker13_components.py
@@ -237,7 +237,7 @@ class Tinker13Cens(OccupationComponent):
                     "you must pass both ``prim_haloprop`` and ``sfr_designation`` keyword arguments"
                 )
                 raise HalotoolsError(msg)
-            if type(sfr_designation[0]) in (str, unicode, np.string_, np.unicode_):
+            if type(sfr_designation[0]) in (str, unicode, np.bytes_, np.str_):
                 if sfr_designation[0] not in ["active", "quiescent"]:
                     msg = (
                         "The only acceptable values of "

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_3d_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_3d_engine.pyx
@@ -70,8 +70,8 @@ def pairwise_distance_3d_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2in,
     cdef cnp.float64_t[:] y2 = np.ascontiguousarray(y2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] z2 = np.ascontiguousarray(z2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
 
-    cdef vector[cnp.int_t] i_ind
-    cdef vector[cnp.int_t] j_ind
+    cdef vector[cnp.int64_t] i_ind
+    cdef vector[cnp.int64_t] j_ind
     cdef vector[cnp.float64_t] distances
 
     cdef cnp.int64_t icell1, icell2

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_xy_z_engine.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distance_xy_z_engine.pyx
@@ -78,8 +78,8 @@ def pairwise_distance_xy_z_engine(double_mesh, x1in, y1in, z1in, x2in, y2in, z2i
     cdef cnp.float64_t[:] y2 = np.ascontiguousarray(y2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
     cdef cnp.float64_t[:] z2 = np.ascontiguousarray(z2in[double_mesh.mesh2.idx_sorted], dtype=np.float64)
 
-    cdef vector[cnp.int_t] i_ind
-    cdef vector[cnp.int_t] j_ind
+    cdef vector[cnp.int64_t] i_ind
+    cdef vector[cnp.int64_t] j_ind
     cdef vector[cnp.float64_t] rp_distances
     cdef vector[cnp.float64_t] pi_distances
 

--- a/halotools/mock_observables/pair_counters/cpairs/pairwise_distances.pyx
+++ b/halotools/mock_observables/pair_counters/cpairs/pairwise_distances.pyx
@@ -87,11 +87,11 @@ def pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
     """
 
     #c definitions
-    cdef vector[np.int_t] i_ind
-    cdef vector[np.int_t] j_ind
+    cdef vector[np.int64_t] i_ind
+    cdef vector[np.int64_t] j_ind
     cdef vector[np.float64_t] distances
     cdef double d
-    cdef np.int_t i, j, n
+    cdef np.int64_t i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
 
@@ -195,8 +195,8 @@ def pairwise_distance_pbc(np.ndarray[np.float64_t, ndim=1] x_icell1,
     """
 
     #c definitions
-    cdef vector[np.int_t] i_ind
-    cdef vector[np.int_t] j_ind
+    cdef vector[np.int64_t] i_ind
+    cdef vector[np.int64_t] j_ind
     cdef vector[np.float64_t] distances
     cdef double d
     cdef int i, j, n
@@ -307,8 +307,8 @@ def pairwise_xy_z_distance_no_pbc(
 
 
     #c definitions
-    cdef vector[np.int_t] i_ind
-    cdef vector[np.int_t] j_ind
+    cdef vector[np.int64_t] i_ind
+    cdef vector[np.int64_t] j_ind
     cdef vector[np.float64_t] para_distances
     cdef vector[np.float64_t] perp_distances
     cdef double d_perp, d_para
@@ -429,8 +429,8 @@ def pairwise_xy_z_distance_pbc(
     """
 
     #c definitions
-    cdef vector[np.int_t] i_ind
-    cdef vector[np.int_t] j_ind
+    cdef vector[np.int64_t] i_ind
+    cdef vector[np.int64_t] j_ind
     cdef vector[np.float64_t] para_distances
     cdef vector[np.float64_t] perp_distances
     cdef double d_perp, d_para

--- a/halotools/mock_observables/pair_counters/marked_cpairs/conditional_pairwise_distances.pyx
+++ b/halotools/mock_observables/pair_counters/marked_cpairs/conditional_pairwise_distances.pyx
@@ -30,7 +30,7 @@ def conditional_pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icel
                              np.float64_t max_r,
                              np.ndarray[np.float64_t, ndim=2] w_icell1,
                              np.ndarray[np.float64_t, ndim=2] w_icell2,
-                             np.int_t cond_func_id):
+                             np.int64_t cond_func_id):
 
     """
     Calculate the conditional limited pairwise distance matrix, :math:`d_{ij}`.
@@ -101,11 +101,11 @@ def conditional_pairwise_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x_icel
     """
 
     #c definitions
-    cdef vector[np.int_t] i_ind
-    cdef vector[np.int_t] j_ind
+    cdef vector[np.int64_t] i_ind
+    cdef vector[np.int64_t] j_ind
     cdef vector[np.float64_t] distances
     cdef double d
-    cdef np.int_t i, j, n
+    cdef np.int64_t i, j, n
     cdef int Ni = len(x_icell1)
     cdef int Nj = len(x_icell2)
 
@@ -149,7 +149,7 @@ def conditional_pairwise_xy_z_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x
                                   np.float64_t max_rp, np.float64_t max_pi,
                                   np.ndarray[np.float64_t, ndim=2] w_icell1,
                                   np.ndarray[np.float64_t, ndim=2] w_icell2,
-                                  np.int_t cond_func_id):
+                                  np.int64_t cond_func_id):
     """
     Calculate the conditional limited pairwise distance matrices, :math:`d_{{\perp}ij}` and :math:`d_{{\parallel}ij}`.
 
@@ -228,8 +228,8 @@ def conditional_pairwise_xy_z_distance_no_pbc(np.ndarray[np.float64_t, ndim=1] x
 
 
     #c definitions
-    cdef vector[np.int_t] i_ind
-    cdef vector[np.int_t] j_ind
+    cdef vector[np.int64_t] i_ind
+    cdef vector[np.int64_t] j_ind
     cdef vector[np.float64_t] para_distances
     cdef vector[np.float64_t] perp_distances
     cdef double d_perp, d_para

--- a/halotools/sim_manager/cached_halo_catalog.py
+++ b/halotools/sim_manager/cached_halo_catalog.py
@@ -395,11 +395,11 @@ class CachedHaloCatalog(object):
         else:
             msg += "redshift = ``" + str(self.redshift) + "``\n"
 
-        msg += ("\nThere is no matching catalog in cache "
-            "within dz_tol = "+str(self._dz_tol)+" of these inputs.\n"
-                )
-
         if len(matching_entries) == 0:
+            msg += (
+                "\nThere is no matching catalog in cache "
+                "within dz_tol = " + str(self._dz_tol) + " of these inputs.\n"
+            )
             suggestion_preamble = ("\nThe following entries in the cache log "
                 "most closely match your inputs:\n\n")
             alt_list1 = list(gen1)  # discard the redshift requirement

--- a/halotools/sim_manager/rockstar_hlist_reader.py
+++ b/halotools/sim_manager/rockstar_hlist_reader.py
@@ -708,22 +708,22 @@ class RockstarHlistReader(TabularAsciiReader):
 
         # Now add the metadata
         f = h5py.File(self.output_fname, 'a')
-        f.attrs.create('simname', np.string_(self.simname))
-        f.attrs.create('halo_finder', np.string_(self.halo_finder))
-        redshift_string = np.string_(get_redshift_string(self.redshift))
+        f.attrs.create('simname', np.bytes_(self.simname))
+        f.attrs.create('halo_finder', np.bytes_(self.halo_finder))
+        redshift_string = np.bytes_(get_redshift_string(self.redshift))
         f.attrs.create('redshift', redshift_string)
-        f.attrs.create('version_name', np.string_(self.version_name))
-        f.attrs.create('fname', np.string_(self.output_fname))
+        f.attrs.create('version_name', np.bytes_(self.version_name))
+        f.attrs.create('fname', np.bytes_(self.output_fname))
 
         f.attrs.create('Lbox', self.Lbox)
         f.attrs.create('particle_mass', self.particle_mass)
-        f.attrs.create('orig_ascii_fname', np.string_(self.input_fname))
+        f.attrs.create('orig_ascii_fname', np.bytes_(self.input_fname))
 
-        time_right_now = np.string_(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        time_right_now = np.bytes_(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
         f.attrs.create('time_of_catalog_production', time_right_now)
 
         if self.processing_notes is not None:
-            f.attrs.create('processing_notes', np.string_(self.processing_notes))
+            f.attrs.create('processing_notes', np.bytes_(self.processing_notes))
 
         # Store all the choices for row cuts as metadata
         for haloprop_key, cut_value in self.row_cut_min_dict.items():

--- a/halotools/sim_manager/user_supplied_halo_catalog.py
+++ b/halotools/sim_manager/user_supplied_halo_catalog.py
@@ -415,11 +415,11 @@ class UserSuppliedHaloCatalog(object):
 
         redshift_string = get_redshift_string(self.redshift)
 
-        f.attrs.create('simname', np.string_(simname))
-        f.attrs.create('halo_finder', np.string_(halo_finder))
-        f.attrs.create('version_name', np.string_(version_name))
-        f.attrs.create('redshift', np.string_(redshift_string))
-        f.attrs.create('fname', np.string_(fname))
+        f.attrs.create('simname', np.bytes_(simname))
+        f.attrs.create('halo_finder', np.bytes_(halo_finder))
+        f.attrs.create('version_name', np.bytes_(version_name))
+        f.attrs.create('redshift', np.bytes_(redshift_string))
+        f.attrs.create('fname', np.bytes_(fname))
 
         f.attrs.create('Lbox', self.Lbox)
         f.attrs.create('particle_mass', self.particle_mass)
@@ -427,12 +427,12 @@ class UserSuppliedHaloCatalog(object):
         time_right_now = datetime.datetime.now().strftime(
             '%Y-%m-%d %H:%M:%S')
 
-        f.attrs.create('time_catalog_was_originally_cached', np.string_(time_right_now))
+        f.attrs.create('time_catalog_was_originally_cached', np.bytes_(time_right_now))
 
-        f.attrs.create('processing_notes', np.string_(processing_notes))
+        f.attrs.create('processing_notes', np.bytes_(processing_notes))
 
         for key, value in additional_metadata.items():
-            f.attrs.create(key, np.string_(value))
+            f.attrs.create(key, np.bytes_(value))
 
         f.close()
         ############################################################

--- a/halotools/sim_manager/user_supplied_ptcl_catalog.py
+++ b/halotools/sim_manager/user_supplied_ptcl_catalog.py
@@ -300,19 +300,19 @@ class UserSuppliedPtclCatalog(object):
 
         redshift_string = get_redshift_string(self.redshift)
 
-        f.attrs.create('simname', np.string_(simname))
-        f.attrs.create('version_name', np.string_(version_name))
-        f.attrs.create('redshift', np.string_(redshift_string))
-        f.attrs.create('fname', np.string_(fname))
+        f.attrs.create('simname', np.bytes_(simname))
+        f.attrs.create('version_name', np.bytes_(version_name))
+        f.attrs.create('redshift', np.bytes_(redshift_string))
+        f.attrs.create('fname', np.bytes_(fname))
 
         f.attrs.create('Lbox', self.Lbox)
         f.attrs.create('particle_mass', self.particle_mass)
 
         time_right_now = datetime.datetime.now().strftime(
             '%Y-%m-%d %H:%M:%S')
-        f.attrs.create('time_catalog_was_originally_cached', np.string_(time_right_now))
+        f.attrs.create('time_catalog_was_originally_cached', np.bytes_(time_right_now))
 
-        f.attrs.create('processing_notes', np.string_(processing_notes))
+        f.attrs.create('processing_notes', np.bytes_(processing_notes))
 
         f.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,8 @@ markers = ["slow", "installation_test"]
 requires = ["setuptools>=42.0.0",
             "setuptools_scm",
             "wheel",
-            "oldest-supported-numpy",
-            "cython==3.0.2",
+            "numpy>=2.0",
+            "cython>=3.0.2",
             "extension-helpers==1.*"]
 build-backend = 'setuptools.build_meta'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 astropy
-numpy<2
+numpy
 scipy
 requests
 beautifulsoup4


### PR DESCRIPTION
This pull request brings halotools up to date with numpy 2 to bring #1084 to a close. Build system now requires numpy>=2, which compiles code compatible with both numpy 1 and 2.

Edit: Might still need to replace `oldest-supported-numpy` with `numpy>=2` [here](https://github.com/astropy/halotools/blob/master/.github/workflows/wheels.yaml#L30)? 