### PR TITLE
Count cic indexes with int64 to prevent overflow

### DIFF
--- a/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
+++ b/halotools/mock_observables/counts_in_cells/engines/counts_in_cylinders_engine.pyx
@@ -146,8 +146,8 @@ def counts_in_cylinders_engine(
 
     cdef bint c_return_indexes = return_indexes
     cdef cnp.int64_t[:] counts = np.zeros(len(x1_sorted), dtype=np.int64)
-    cdef int current_indexes_cnt = 0
-    cdef int current_indexes_len = len(x1_sorted) if c_return_indexes else 0
+    cdef cnp.int64_t current_indexes_cnt = 0
+    cdef cnp.int64_t current_indexes_len = len(x1_sorted) if c_return_indexes else 0
     cdef cnp.uint32_t[:,:] indexes = np.ascontiguousarray(
             np.zeros((current_indexes_len, 2), dtype=np.uint32))
 


### PR DESCRIPTION
This PR will provide a solution to the ValueError in galtab [issue 6](https://github.com/AlanPearl/galtab/issues/6) and does not degrade performance. I'll leave the example test script here, since it is too expensive to include as a unit test:

```
# NOTE Memory requirement: ~46 GB
import numpy as np
import halotools.mock_observables as htmo

sample = np.zeros((40_000, 3))
htmo.counts_in_cylinders(sample, sample, 1, 1, return_indexes=True, period=100)
```